### PR TITLE
Merge develop to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Set Solana & Starknet RPC URL to use
 
 ```typescript
 const solanaRpc = "https://api.mainnet-beta.solana.com";
-const starknetRpc = "https://starknet-mainnet.public.blastapi.io/rpc/v0_8";
-const citreaRpc = "https://rpc.testnet.citrea.xyz";
+const starknetRpc = "https://rpc.starknet.lava.build/"; //Alternatively: https://starknet.api.onfinality.io/public or https://api.zan.top/public/starknet-mainnet
+const citreaRpc = "https://rpc.mainnet.citrea.xyz";
 ```
 
 Create swapper factory, here we can pick and choose which chains we want to have supported in the SDK, ensure the "as const" keyword is used such that the typescript compiler can properly infer the types.
@@ -87,10 +87,10 @@ const swapper: TypedSwapper<SupportedChains> = Factory.newSwapper({
       rpcUrl: starknetRpc //You can also pass Provider object here           
     },
     CITREA: {
-      rpcUrl: citreaRpc, //You can also pass JsonApiProvider object here
+      rpcUrl: citreaRpc, //You can also pass JsonRpcApiProvider object here
     }
   },
-  bitcoinNetwork: BitcoinNetwork.TESTNET //or BitcoinNetwork.MAINNET, BitcoinNetwork.TESTNET4 - this also sets the network to use for Solana (solana devnet for bitcoin testnet) & Starknet (sepolia for bitcoin testnet)
+  bitcoinNetwork: BitcoinNetwork.MAINNET //or BitcoinNetwork.TESTNET3, BitcoinNetwork.TESTNET4 - this also sets the network to use for Solana (solana devnet for bitcoin testnet) & Starknet (sepolia for bitcoin testnet)
 });
 ```
 
@@ -122,7 +122,7 @@ const swapper: TypedSwapper<SupportedChains> = Factory.newSwapper({
             rpcUrl: citreaRpc, //You can also pass JsonApiProvider object here
         }
     },
-    bitcoinNetwork: BitcoinNetwork.TESTNET, //or BitcoinNetwork.MAINNET - this also sets the network to use for Solana (solana devnet for bitcoin testnet) & Starknet (sepolia for bitcoin testnet)
+    bitcoinNetwork: BitcoinNetwork.MAINNET //or BitcoinNetwork.TESTNET3, BitcoinNetwork.TESTNET4 - this also sets the network to use for Solana (solana devnet for bitcoin testnet) & Starknet (sepolia for bitcoin testnet)
     //The following lines are important for running on backend node.js,
     // because the SDK by default uses browser's Indexed DB
     swapStorage: chainId => new SqliteUnifiedStorage("CHAIN_"+chainId+".sqlite3"),
@@ -143,7 +143,7 @@ const wallet = new SolanaSigner(anchorWallet);
 
 ```typescript
 import {WalletAccount} from "starknet";
-import {StarknetSigner} from "@atomiqlabs/chain-starknet";
+import {StarknetBrowserSigner} from "@atomiqlabs/chain-starknet";
 //Browser, using get-starknet
 const swo = await connect();
 const wallet = new StarknetBrowserSigner(new WalletAccount(starknetRpc, swo.wallet));
@@ -1609,13 +1609,13 @@ Returns swaps that are ready to be claimed by the client, this can happen if cli
 
 ```typescript
 //Get the swaps
-const claimableSolanaSwaps = await solanaSwapper.getClaimableSwaps("SOLANA", solanaSigner.getAddress());
+const claimableSolanaSwaps = await swapper.getClaimableSwaps("SOLANA", solanaSigner.getAddress());
 //Claim all the claimable swaps
 for(let swap of claimableSolanaSwaps) {
     await swap.claim(solanaSigner);
 }
 //Get the swaps
-const claimableStarknetSwaps = await solanaSwapper.getClaimableSwaps("STARKNET", starknetSigner.getAddress());
+const claimableStarknetSwaps = await swapper.getClaimableSwaps("STARKNET", starknetSigner.getAddress());
 //Claim all the claimable swaps
 for(let swap of claimableStarknetSwaps) {
   await swap.claim(starknetSigner);

--- a/dist/enums/SwapSide.d.ts
+++ b/dist/enums/SwapSide.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Enum representing the side of the swap for querying available input/output tokens
+ *
+ * @category Core
+ */
+export declare enum SwapSide {
+    /**
+     * Represents input / source side of the swap
+     */
+    INPUT = 1,
+    /**
+     * Represents output / destination side of the swap
+     */
+    OUTPUT = 0
+}

--- a/dist/enums/SwapSide.js
+++ b/dist/enums/SwapSide.js
@@ -1,0 +1,19 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.SwapSide = void 0;
+/**
+ * Enum representing the side of the swap for querying available input/output tokens
+ *
+ * @category Core
+ */
+var SwapSide;
+(function (SwapSide) {
+    /**
+     * Represents input / source side of the swap
+     */
+    SwapSide[SwapSide["INPUT"] = 1] = "INPUT";
+    /**
+     * Represents output / destination side of the swap
+     */
+    SwapSide[SwapSide["OUTPUT"] = 0] = "OUTPUT";
+})(SwapSide = exports.SwapSide || (exports.SwapSide = {}));

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -8,6 +8,7 @@ export { CoinselectAddressTypes } from "./bitcoin/coinselect2";
 export * from "./enums/FeeType";
 export * from "./enums/SwapAmountType";
 export * from "./enums/SwapDirection";
+export * from "./enums/SwapSide";
 export * from "./enums/SwapType";
 export * from "./errors/IntermediaryError";
 export * from "./errors/RequestError";

--- a/dist/index.js
+++ b/dist/index.js
@@ -37,6 +37,7 @@ __exportStar(require("./bitcoin/wallet/SingleAddressBitcoinWallet"), exports);
 __exportStar(require("./enums/FeeType"), exports);
 __exportStar(require("./enums/SwapAmountType"), exports);
 __exportStar(require("./enums/SwapDirection"), exports);
+__exportStar(require("./enums/SwapSide"), exports);
 __exportStar(require("./enums/SwapType"), exports);
 __exportStar(require("./errors/IntermediaryError"), exports);
 __exportStar(require("./errors/RequestError"), exports);

--- a/dist/intermediaries/apis/IntermediaryAPI.d.ts
+++ b/dist/intermediaries/apis/IntermediaryAPI.d.ts
@@ -169,9 +169,9 @@ export type FromBTCInit = BaseFromBTCSwapInit & {
     sequence: bigint;
     claimerBounty: Promise<{
         feePerBlock: bigint;
-        safetyFactor: number;
+        safetyFactor: bigint;
         startTimestamp: bigint;
-        addBlock: number;
+        addBlock: bigint;
         addFee: bigint;
     }>;
 };

--- a/dist/intermediaries/apis/IntermediaryAPI.js
+++ b/dist/intermediaries/apis/IntermediaryAPI.js
@@ -271,9 +271,9 @@ class IntermediaryAPI {
             claimerBounty: init.claimerBounty.then(claimerBounty => {
                 return {
                     feePerBlock: claimerBounty.feePerBlock.toString(10),
-                    safetyFactor: claimerBounty.safetyFactor,
+                    safetyFactor: claimerBounty.safetyFactor.toString(10),
                     startTimestamp: claimerBounty.startTimestamp.toString(10),
-                    addBlock: claimerBounty.addBlock,
+                    addBlock: claimerBounty.addBlock.toString(10),
                     addFee: claimerBounty.addFee.toString(10)
                 };
             }),

--- a/dist/storage/UnifiedSwapStorage.d.ts
+++ b/dist/storage/UnifiedSwapStorage.d.ts
@@ -36,6 +36,7 @@ declare const indexes: readonly [{
  * Simple index types for SDK swap storage
  *
  * @category Storage
+ * @useDeclaredType
  */
 export type UnifiedSwapStorageIndexes = typeof indexes;
 declare const compositeIndexes: readonly [{
@@ -55,6 +56,7 @@ declare const compositeIndexes: readonly [{
  * Composite index types for SDK swap storage
  *
  * @category Storage
+ * @useDeclaredType
  */
 export type UnifiedSwapStorageCompositeIndexes = typeof compositeIndexes;
 /**

--- a/dist/storage/UnifiedSwapStorage.js
+++ b/dist/storage/UnifiedSwapStorage.js
@@ -64,6 +64,7 @@ class UnifiedSwapStorage {
             const value = reviver(rawObj);
             if (value == null)
                 return;
+            value._persisted = true;
             if (!this.noWeakRefMap)
                 this.weakRefCache.set(rawObj.id, new WeakRef(value));
             result.push(value);
@@ -75,37 +76,41 @@ class UnifiedSwapStorage {
      *
      * @param value Swap to save
      */
-    save(value) {
+    async save(value) {
         if (!this.noWeakRefMap)
             this.weakRefCache.set(value.getId(), new WeakRef(value));
-        return this.storage.save(value.serialize());
+        await this.storage.save(value.serialize());
+        value._persisted = true;
     }
     /**
      * Saves multiple swaps to storage in a batch operation
      * @param values Array of swaps to save
      */
-    saveAll(values) {
+    async saveAll(values) {
         if (!this.noWeakRefMap)
             values.forEach(value => this.weakRefCache.set(value.getId(), new WeakRef(value)));
-        return this.storage.saveAll(values.map(obj => obj.serialize()));
+        await this.storage.saveAll(values.map(obj => obj.serialize()));
+        values.forEach(value => value._persisted = true);
     }
     /**
      * Removes a swap from storage
      * @param value Swap to remove
      */
-    remove(value) {
+    async remove(value) {
         if (!this.noWeakRefMap)
             this.weakRefCache.delete(value.getId());
-        return this.storage.remove(value.serialize());
+        await this.storage.remove(value.serialize());
+        value._persisted = false;
     }
     /**
      * Removes multiple swaps from storage in a batch operation
      * @param values Array of swaps to remove
      */
-    removeAll(values) {
+    async removeAll(values) {
         if (!this.noWeakRefMap)
             values.forEach(value => this.weakRefCache.delete(value.getId()));
-        return this.storage.removeAll(values.map(obj => obj.serialize()));
+        await this.storage.removeAll(values.map(obj => obj.serialize()));
+        values.forEach(value => value._persisted = false);
     }
 }
 exports.UnifiedSwapStorage = UnifiedSwapStorage;

--- a/dist/swapper/Swapper.d.ts
+++ b/dist/swapper/Swapper.d.ts
@@ -470,25 +470,25 @@ export declare class Swapper<T extends MultiChain> extends EventEmitter<{
     /**
      * @internal
      */
-    swap<C extends ChainIds<T>>(srcToken: BtcToken<true>, dstToken: SCToken<C>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string | LNURLWithdraw, dstSmartchainWallet: string, options?: (SupportsSwapType<T[C], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoOptions : FromBTCLNOptions)): Promise<(SupportsSwapType<T[C], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoSwap<T[C]> : FromBTCLNSwap<T[C]>)>;
+    swap<C extends ChainIds<T>>(srcToken: BtcToken<true> | "BTCLN" | "BTC-LN" | "LIGHTNING-BTC", dstToken: SCToken<C> | string, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string | LNURLWithdraw, dstSmartchainWallet: string, options?: (SupportsSwapType<T[C], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoOptions : FromBTCLNOptions)): Promise<(SupportsSwapType<T[C], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoSwap<T[C]> : FromBTCLNSwap<T[C]>)>;
     /**
      * @internal
      */
-    swap<C extends ChainIds<T>>(srcToken: BtcToken<false>, dstToken: SCToken<C>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string, dstSmartchainWallet: string, options?: (SupportsSwapType<T[C], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCOptions : FromBTCOptions)): Promise<(SupportsSwapType<T[C], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCSwap<T[C]> : FromBTCSwap<T[C]>)>;
+    swap<C extends ChainIds<T>>(srcToken: BtcToken<false> | "BTC" | "BITCOIN-BTC", dstToken: SCToken<C> | string, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string, dstSmartchainWallet: string, options?: (SupportsSwapType<T[C], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCOptions : FromBTCOptions)): Promise<(SupportsSwapType<T[C], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCSwap<T[C]> : FromBTCSwap<T[C]>)>;
     /**
      * @internal
      */
-    swap<C extends ChainIds<T>>(srcToken: SCToken<C>, dstToken: BtcToken<false>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstAddress: string, options?: ToBTCOptions): Promise<ToBTCSwap<T[C]>>;
+    swap<C extends ChainIds<T>>(srcToken: SCToken<C> | string, dstToken: BtcToken<false> | "BTC" | "BITCOIN-BTC", amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstAddress: string, options?: ToBTCOptions): Promise<ToBTCSwap<T[C]>>;
     /**
      * @internal
      */
-    swap<C extends ChainIds<T>>(srcToken: SCToken<C>, dstToken: BtcToken<true>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstLnurlPayOrInvoiceCreateService: string | LNURLPay | LightningInvoiceCreateService, options?: ToBTCLNOptions & {
+    swap<C extends ChainIds<T>>(srcToken: SCToken<C> | string, dstToken: BtcToken<true> | "BTCLN" | "BTC-LN" | "LIGHTNING-BTC", amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstLnurlPayOrInvoiceCreateService: string | LNURLPay | LightningInvoiceCreateService, options?: ToBTCLNOptions & {
         comment?: string;
     }): Promise<ToBTCLNSwap<T[C]>>;
     /**
      * @internal
      */
-    swap<C extends ChainIds<T>>(srcToken: SCToken<C>, dstToken: BtcToken<true>, amount: undefined, exactIn: false | SwapAmountType.EXACT_OUT, src: string, dstLightningInvoice: string, options?: ToBTCLNOptions): Promise<ToBTCLNSwap<T[C]>>;
+    swap<C extends ChainIds<T>>(srcToken: SCToken<C> | string, dstToken: BtcToken<true> | "BTCLN" | "BTC-LN" | "LIGHTNING-BTC", amount: undefined, exactIn: false | SwapAmountType.EXACT_OUT, src: string, dstLightningInvoice: string, options?: ToBTCLNOptions): Promise<ToBTCLNSwap<T[C]>>;
     /**
      * Creates a swap from srcToken to dstToken, of a specific token amount, either specifying input amount (if `exactIn=true`)
      *  or output amount (if `exactIn=false`), NOTE: For regular Smart chain -> BTC-LN (lightning) swaps the passed amount is ignored and
@@ -587,14 +587,9 @@ export declare class Swapper<T extends MultiChain> extends EventEmitter<{
      *  initiated after this blockheight
      */
     recoverSwaps<C extends ChainIds<T>>(chainId: C, signer: string, startBlockheight?: number): Promise<ISwap<T[C]>[]>;
-    /**
-     * Returns the {@link Token} object for a given token
-     *
-     * @param tickerOrAddress Token to return the object for, can use multiple formats:
-     *  - a) token ticker, such as `"BTC"`, `"SOL"`, etc.
-     *  - b) token ticker prefixed with smart chain identifier, such as `"SOLANA-SOL"`, `"SOLANA-USDC"`, etc.
-     *  - c) token address
-     */
+    getToken(ticker: "BTC" | "BITCOIN-BTC"): BtcToken<false>;
+    getToken(ticker: "BTCLN" | "BTC-LN" | "LIGHTNING-BTC"): BtcToken<true>;
+    getToken<ChainIdentifier extends ChainIds<T>>(ticker: `${ChainIdentifier}-${string}`): SCToken<ChainIdentifier>;
     getToken(tickerOrAddress: string): Token<ChainIds<T>>;
     /**
      * Creates a child swapper instance with a given smart chain

--- a/dist/swapper/Swapper.d.ts
+++ b/dist/swapper/Swapper.d.ts
@@ -656,12 +656,12 @@ export declare class Swapper<T extends MultiChain> extends EventEmitter<{
      */
     getSwapLimits<C extends ChainIds<T>, A extends Token<C>, B extends Token<C>>(srcToken: A, dstToken: B): {
         input: {
-            min: TokenAmount<string, A>;
-            max?: TokenAmount<string, A>;
+            min: TokenAmount<A>;
+            max?: TokenAmount<A>;
         };
         output: {
-            min: TokenAmount<string, B>;
-            max?: TokenAmount<string, B>;
+            min: TokenAmount<B>;
+            max?: TokenAmount<B>;
         };
     };
     /**

--- a/dist/swapper/Swapper.d.ts
+++ b/dist/swapper/Swapper.d.ts
@@ -174,17 +174,6 @@ type MultiChainData<T extends MultiChain> = {
 type CtorMultiChainData<T extends MultiChain> = {
     [chainIdentifier in keyof T]: ChainData<T[chainIdentifier]>;
 };
-type SwapperCtorTokens<T extends MultiChain = MultiChain> = {
-    ticker: string;
-    name: string;
-    chains: {
-        [chainId in ChainIds<T>]?: {
-            address: string;
-            decimals: number;
-            displayDecimals?: number;
-        };
-    };
-}[];
 /**
  * Type extracting chain identifiers from a MultiChain type
  * @category Core
@@ -263,7 +252,7 @@ export declare class Swapper<T extends MultiChain> extends EventEmitter<{
     /**
      * @internal
      */
-    constructor(bitcoinRpc: BitcoinRpcWithAddressIndex<any>, lightningApi: LightningNetworkApi, bitcoinSynchronizer: (btcRelay: BtcRelay<any, any, any>) => RelaySynchronizer<any, any, any>, chainsData: CtorMultiChainData<T>, pricing: ISwapPrice<T>, tokens: SwapperCtorTokens<T>, messenger: Messenger, options?: SwapperOptions);
+    constructor(bitcoinRpc: BitcoinRpcWithAddressIndex<any>, lightningApi: LightningNetworkApi, bitcoinSynchronizer: (btcRelay: BtcRelay<any, any, any>) => RelaySynchronizer<any, any, any>, chainsData: CtorMultiChainData<T>, pricing: ISwapPrice<T>, tokens: SCToken[], messenger: Messenger, options?: SwapperOptions);
     private _init;
     private initPromise?;
     private initialized;

--- a/dist/swapper/Swapper.d.ts
+++ b/dist/swapper/Swapper.d.ts
@@ -39,6 +39,7 @@ import { LNURLWithdraw } from "../types/lnurl/LNURLWithdraw";
 import { LNURLPay } from "../types/lnurl/LNURLPay";
 import { NotNever } from "../utils/TypeUtils";
 import { LightningInvoiceCreateService } from "../types/wallets/LightningInvoiceCreateService";
+import { SwapSide } from "../enums/SwapSide";
 /**
  * Configuration options for the Swapper
  * @category Core
@@ -663,7 +664,7 @@ export declare class Swapper<T extends MultiChain> extends EventEmitter<{
      *
      * @param input Whether to return input tokens or output tokens
      */
-    getSupportedTokens(input: boolean): Token[];
+    getSupportedTokens(input: SwapSide | boolean): Token[];
     /**
      * Returns a set of supported tokens by all the intermediaries offering a specific swap service
      *
@@ -681,6 +682,6 @@ export declare class Swapper<T extends MultiChain> extends EventEmitter<{
      * Returns tokens that you can swap to (if input=true) from a given token,
      *  or tokens that you can swap from (if input=false) to a given token
      */
-    getSwapCounterTokens(token: Token, input: boolean): Token[];
+    getSwapCounterTokens(token: Token, input: SwapSide | boolean): Token[];
 }
 export {};

--- a/dist/swapper/Swapper.d.ts
+++ b/dist/swapper/Swapper.d.ts
@@ -123,9 +123,15 @@ export type SwapperOptions = {
      */
     dontFetchLPs?: boolean;
     /**
-     * By setting this flag the SDK persists all created swaps. By default, the SDK only saves and persists swaps that
-     *  are considered initiated, i.e. when `commit()`, `execute()` or `waitTillPayment` is called (or their respective
-     *  txs... prefixed variations).
+     * Defaults to `true`, this means every swap regardless of it being initiated (i.e. when `commit()`, `execute()` or
+     *  `waitTillPayment` is called) is saved to the persistent storage. This is a reasonable default for when you
+     *  want to only create a swap, and then later on retrieve it with the `swapper.getSwapById()` function.
+     *
+     * Setting this to `false` means the SDK only saves and persists swaps that are considered initiated, i.e. when
+     *  `commit()`, `execute()` or `waitTillPayment` is called (or their respective txs... prefixed variations). This
+     *  might save calls to the persistent storage for swaps that are never initiated. This is useful in e.g.
+     *  frontend implementations where the frontend holds the swap object reference until it is initiated anyway, not
+     *  necessitating the saving of the swap data to the persistent storage until it is actually initiated.
      */
     saveUninitializedSwaps?: boolean;
     /**

--- a/dist/swapper/Swapper.d.ts
+++ b/dist/swapper/Swapper.d.ts
@@ -16,7 +16,6 @@ import { LnForGasWrapper } from "../swaps/trusted/ln/LnForGasWrapper";
 import { LnForGasSwap } from "../swaps/trusted/ln/LnForGasSwap";
 import { EventEmitter } from "events";
 import { Intermediary } from "../intermediaries/Intermediary";
-import { WrapperCtorTokens } from "../swaps/ISwapWrapper";
 import { SwapperWithChain } from "./SwapperWithChain";
 import { OnchainForGasSwap } from "../swaps/trusted/onchain/OnchainForGasSwap";
 import { OnchainForGasWrapper } from "../swaps/trusted/onchain/OnchainForGasWrapper";
@@ -169,6 +168,17 @@ type MultiChainData<T extends MultiChain> = {
 type CtorMultiChainData<T extends MultiChain> = {
     [chainIdentifier in keyof T]: ChainData<T[chainIdentifier]>;
 };
+type SwapperCtorTokens<T extends MultiChain = MultiChain> = {
+    ticker: string;
+    name: string;
+    chains: {
+        [chainId in ChainIds<T>]?: {
+            address: string;
+            decimals: number;
+            displayDecimals?: number;
+        };
+    };
+}[];
 /**
  * Type extracting chain identifiers from a MultiChain type
  * @category Core
@@ -247,7 +257,7 @@ export declare class Swapper<T extends MultiChain> extends EventEmitter<{
     /**
      * @internal
      */
-    constructor(bitcoinRpc: BitcoinRpcWithAddressIndex<any>, lightningApi: LightningNetworkApi, bitcoinSynchronizer: (btcRelay: BtcRelay<any, any, any>) => RelaySynchronizer<any, any, any>, chainsData: CtorMultiChainData<T>, pricing: ISwapPrice<T>, tokens: WrapperCtorTokens<T>, messenger: Messenger, options?: SwapperOptions);
+    constructor(bitcoinRpc: BitcoinRpcWithAddressIndex<any>, lightningApi: LightningNetworkApi, bitcoinSynchronizer: (btcRelay: BtcRelay<any, any, any>) => RelaySynchronizer<any, any, any>, chainsData: CtorMultiChainData<T>, pricing: ISwapPrice<T>, tokens: SwapperCtorTokens<T>, messenger: Messenger, options?: SwapperOptions);
     private _init;
     private initPromise?;
     private initialized;

--- a/dist/swapper/Swapper.js
+++ b/dist/swapper/Swapper.js
@@ -480,9 +480,6 @@ class Swapper extends events_1.EventEmitter {
         if (!this._chains[chainIdentifier].chainInterface.isValidAddress(signer, true))
             throw new Error("Invalid " + chainIdentifier + " address");
         signer = this._chains[chainIdentifier].chainInterface.normalizeAddress(signer);
-        options ??= {};
-        options.confirmationTarget ??= 3;
-        options.confirmations ??= 2;
         const amountData = {
             amount,
             token: tokenAddress,
@@ -504,7 +501,6 @@ class Swapper extends events_1.EventEmitter {
     async createToBTCLNSwap(chainIdentifier, signer, tokenAddress, paymentRequest, additionalParams = this.options.defaultAdditionalParameters, options) {
         if (this._chains[chainIdentifier] == null)
             throw new Error("Invalid chain identifier! Unknown chain: " + chainIdentifier);
-        options ??= {};
         if (paymentRequest.startsWith("lightning:"))
             paymentRequest = paymentRequest.substring(10);
         if (!this.Utils.isValidLightningInvoice(paymentRequest))
@@ -520,7 +516,6 @@ class Swapper extends events_1.EventEmitter {
             token: tokenAddress,
             exactIn: false
         };
-        options.expirySeconds ??= 5 * 24 * 3600;
         return this.createSwap(chainIdentifier, (candidates, abortSignal, chain) => chain.wrappers[SwapType_1.SwapType.TO_BTCLN].create(signer, paymentRequest, amountData, candidates, options, additionalParams, abortSignal), amountData, SwapType_1.SwapType.TO_BTCLN);
     }
     /**
@@ -548,8 +543,6 @@ class Swapper extends events_1.EventEmitter {
             token: tokenAddress,
             exactIn
         };
-        options ??= {};
-        options.expirySeconds ??= 5 * 24 * 3600;
         return this.createSwap(chainIdentifier, (candidates, abortSignal, chain) => chain.wrappers[SwapType_1.SwapType.TO_BTCLN].createViaLNURL(signer, typeof (lnurlPay) === "string" ? (lnurlPay.startsWith("lightning:") ? lnurlPay.substring(10) : lnurlPay) : lnurlPay.params, amountData, candidates, options, additionalParams, abortSignal), amountData, SwapType_1.SwapType.TO_BTCLN);
     }
     /**
@@ -570,13 +563,11 @@ class Swapper extends events_1.EventEmitter {
         if (!this._chains[chainIdentifier].chainInterface.isValidAddress(signer, true))
             throw new Error("Invalid " + chainIdentifier + " address");
         signer = this._chains[chainIdentifier].chainInterface.normalizeAddress(signer);
-        options ??= {};
         const amountData = {
             amount,
             token: tokenAddress,
             exactIn
         };
-        options.expirySeconds ??= 5 * 24 * 3600;
         return this.createSwap(chainIdentifier, (candidates, abortSignal, chain) => chain.wrappers[SwapType_1.SwapType.TO_BTCLN].createViaInvoiceCreateService(signer, Promise.resolve(service), amountData, candidates, options, additionalParams, abortSignal), amountData, SwapType_1.SwapType.TO_BTCLN);
     }
     /**

--- a/dist/swapper/Swapper.js
+++ b/dist/swapper/Swapper.js
@@ -94,7 +94,7 @@ class Swapper extends events_1.EventEmitter {
                     displayDecimals: chainData.displayDecimals,
                     address: chainData.address,
                     equals: (other) => other.chainId === chainId && other.ticker === tokenData.ticker && other.address === chainData.address,
-                    toString: () => chainId + "-" + tokenData.ticker
+                    toString: () => `${chainId}-${tokenData.ticker}`
                 };
             }
         }

--- a/dist/swapper/Swapper.js
+++ b/dist/swapper/Swapper.js
@@ -720,7 +720,7 @@ class Swapper extends events_1.EventEmitter {
      * @param trustedIntermediaryOrUrl  URL or Intermediary object of the trusted intermediary to use, otherwise uses default
      * @throws {Error} If no trusted intermediary specified
      */
-    createTrustedLNForGasSwap(chainIdentifier, recipient, amount, trustedIntermediaryOrUrl) {
+    async createTrustedLNForGasSwap(chainIdentifier, recipient, amount, trustedIntermediaryOrUrl) {
         if (this._chains[chainIdentifier] == null)
             throw new Error("Invalid chain identifier! Unknown chain: " + chainIdentifier);
         if (!this._chains[chainIdentifier].chainInterface.isValidAddress(recipient, true))
@@ -729,7 +729,9 @@ class Swapper extends events_1.EventEmitter {
         const useUrl = trustedIntermediaryOrUrl ?? this.defaultTrustedIntermediary ?? this.options.defaultTrustedIntermediaryUrl;
         if (useUrl == null)
             throw new Error("No trusted intermediary specified!");
-        return this._chains[chainIdentifier].wrappers[SwapType_1.SwapType.TRUSTED_FROM_BTCLN].create(recipient, amount, useUrl);
+        const swap = await this._chains[chainIdentifier].wrappers[SwapType_1.SwapType.TRUSTED_FROM_BTCLN].create(recipient, amount, useUrl);
+        await swap._save();
+        return swap;
     }
     /**
      * Creates a trusted Bitcoin -> Smart chain ({@link SwapType.TRUSTED_FROM_BTC}) gas swap
@@ -741,7 +743,7 @@ class Swapper extends events_1.EventEmitter {
      * @param trustedIntermediaryOrUrl URL or Intermediary object of the trusted intermediary to use, otherwise uses default
      * @throws {Error} If no trusted intermediary specified
      */
-    createTrustedOnchainForGasSwap(chainIdentifier, recipient, amount, refundAddress, trustedIntermediaryOrUrl) {
+    async createTrustedOnchainForGasSwap(chainIdentifier, recipient, amount, refundAddress, trustedIntermediaryOrUrl) {
         if (this._chains[chainIdentifier] == null)
             throw new Error("Invalid chain identifier! Unknown chain: " + chainIdentifier);
         if (!this._chains[chainIdentifier].chainInterface.isValidAddress(recipient, true))
@@ -750,7 +752,9 @@ class Swapper extends events_1.EventEmitter {
         const useUrl = trustedIntermediaryOrUrl ?? this.defaultTrustedIntermediary ?? this.options.defaultTrustedIntermediaryUrl;
         if (useUrl == null)
             throw new Error("No trusted intermediary specified!");
-        return this._chains[chainIdentifier].wrappers[SwapType_1.SwapType.TRUSTED_FROM_BTC].create(recipient, amount, useUrl, refundAddress);
+        const swap = await this._chains[chainIdentifier].wrappers[SwapType_1.SwapType.TRUSTED_FROM_BTC].create(recipient, amount, useUrl, refundAddress);
+        await swap._save();
+        return swap;
     }
     /**
      * Creates a swap from srcToken to dstToken, of a specific token amount, either specifying input amount (exactIn=true)

--- a/dist/swapper/Swapper.js
+++ b/dist/swapper/Swapper.js
@@ -63,6 +63,7 @@ class Swapper extends events_1.EventEmitter {
         this.SwapTypeInfo = SwapUtils_1.SwapProtocolInfo;
         const storagePrefix = options?.storagePrefix ?? "atomiq-";
         options ??= {};
+        options.saveUninitializedSwaps ??= true;
         options.bitcoinNetwork = options.bitcoinNetwork == null ? base_1.BitcoinNetwork.TESTNET : options.bitcoinNetwork;
         const swapStorage = options.swapStorage ??= (name) => new IndexedDBUnifiedStorage_1.IndexedDBUnifiedStorage(name);
         this.options = options;

--- a/dist/swapper/Swapper.js
+++ b/dist/swapper/Swapper.js
@@ -100,35 +100,42 @@ class Swapper extends events_1.EventEmitter {
             wrappers[SwapType_1.SwapType.TO_BTCLN] = new ToBTCLNWrapper_1.ToBTCLNWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
+                saveUninitializedSwaps: this.options.saveUninitializedSwaps,
             });
             wrappers[SwapType_1.SwapType.TO_BTC] = new ToBTCWrapper_1.ToBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, this._bitcoinRpc, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
+                saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                 bitcoinNetwork: this._btcNetwork
             });
             wrappers[SwapType_1.SwapType.FROM_BTCLN] = new FromBTCLNWrapper_1.FromBTCLNWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, lightningApi, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
+                saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                 unsafeSkipLnNodeCheck: this.bitcoinNetwork === base_1.BitcoinNetwork.TESTNET4 || this.bitcoinNetwork === base_1.BitcoinNetwork.REGTEST
             });
             wrappers[SwapType_1.SwapType.FROM_BTC] = new FromBTCWrapper_1.FromBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, btcRelay, synchronizer, this._bitcoinRpc, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
+                saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                 bitcoinNetwork: this._btcNetwork
             });
             wrappers[SwapType_1.SwapType.TRUSTED_FROM_BTCLN] = new LnForGasWrapper_1.LnForGasWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, pricing, this._tokens[chainId], {
                 getRequestTimeout: this.options.getRequestTimeout,
-                postRequestTimeout: this.options.postRequestTimeout
+                postRequestTimeout: this.options.postRequestTimeout,
+                saveUninitializedSwaps: this.options.saveUninitializedSwaps,
             });
             wrappers[SwapType_1.SwapType.TRUSTED_FROM_BTC] = new OnchainForGasWrapper_1.OnchainForGasWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, pricing, this._tokens[chainId], bitcoinRpc, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
+                saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                 bitcoinNetwork: this._btcNetwork
             });
             if (spvVaultContract != null) {
                 wrappers[SwapType_1.SwapType.SPV_VAULT_FROM_BTC] = new SpvFromBTCWrapper_1.SpvFromBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, spvVaultContract, pricing, this._tokens[chainId], spvVaultWithdrawalDataConstructor, btcRelay, synchronizer, bitcoinRpc, {
                     getRequestTimeout: this.options.getRequestTimeout,
                     postRequestTimeout: this.options.postRequestTimeout,
+                    saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                     bitcoinNetwork: this._btcNetwork
                 });
             }
@@ -136,6 +143,7 @@ class Swapper extends events_1.EventEmitter {
                 wrappers[SwapType_1.SwapType.FROM_BTCLN_AUTO] = new FromBTCLNAutoWrapper_1.FromBTCLNAutoWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, lightningApi, this.messenger, {
                     getRequestTimeout: this.options.getRequestTimeout,
                     postRequestTimeout: this.options.postRequestTimeout,
+                    saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                     unsafeSkipLnNodeCheck: this.bitcoinNetwork === base_1.BitcoinNetwork.TESTNET4 || this.bitcoinNetwork === base_1.BitcoinNetwork.REGTEST
                 });
             }
@@ -434,10 +442,7 @@ class Swapper extends events_1.EventEmitter {
             if (swapLimitsChanged)
                 this.emit("swapLimitsChanged");
             const quote = quotes[0].quote;
-            if (this.options.saveUninitializedSwaps) {
-                quote._setInitiated();
-                await quote._save();
-            }
+            await quote._save();
             return quote;
         }
         catch (e) {

--- a/dist/swapper/Swapper.js
+++ b/dist/swapper/Swapper.js
@@ -82,22 +82,10 @@ class Swapper extends events_1.EventEmitter {
         this._tokens = {};
         this._tokensByTicker = {};
         for (let tokenData of tokens) {
-            for (let chainId in tokenData.chains) {
-                const chainData = tokenData.chains[chainId];
-                this._tokens[chainId] ??= {};
-                this._tokensByTicker[chainId] ??= {};
-                this._tokens[chainId][chainData.address] = this._tokensByTicker[chainId][tokenData.ticker] = {
-                    chain: "SC",
-                    chainId,
-                    ticker: tokenData.ticker,
-                    name: tokenData.name,
-                    decimals: chainData.decimals,
-                    displayDecimals: chainData.displayDecimals,
-                    address: chainData.address,
-                    equals: (other) => other.chainId === chainId && other.ticker === tokenData.ticker && other.address === chainData.address,
-                    toString: () => `${chainId}-${tokenData.ticker}`
-                };
-            }
+            const chainId = tokenData.chainId;
+            this._tokens[chainId] ??= {};
+            this._tokensByTicker[chainId] ??= {};
+            this._tokens[chainId][tokenData.address] = this._tokensByTicker[chainId][tokenData.ticker] = tokenData;
         }
         this.swapStateListener = (swap) => {
             this.emit("swapState", swap);

--- a/dist/swapper/Swapper.js
+++ b/dist/swapper/Swapper.js
@@ -92,7 +92,9 @@ class Swapper extends events_1.EventEmitter {
                     name: tokenData.name,
                     decimals: chainData.decimals,
                     displayDecimals: chainData.displayDecimals,
-                    address: chainData.address
+                    address: chainData.address,
+                    equals: (other) => other.chainId === chainId && other.ticker === tokenData.ticker && other.address === chainData.address,
+                    toString: () => chainId + "-" + tokenData.ticker
                 };
             }
         }
@@ -100,49 +102,49 @@ class Swapper extends events_1.EventEmitter {
             this.emit("swapState", swap);
         };
         this._chains = (0, Utils_1.objectMap)(chainsData, (chainData, key) => {
-            const { swapContract, chainEvents, btcRelay, chainInterface, spvVaultContract, spvVaultWithdrawalDataConstructor } = chainData;
+            const { swapContract, chainEvents, btcRelay, chainInterface, spvVaultContract, spvVaultWithdrawalDataConstructor, chainId } = chainData;
             const synchronizer = bitcoinSynchronizer(btcRelay);
-            const storageHandler = swapStorage(storagePrefix + chainData.chainId);
+            const storageHandler = swapStorage(storagePrefix + chainId);
             const unifiedSwapStorage = new UnifiedSwapStorage_1.UnifiedSwapStorage(storageHandler, this.options.noSwapCache);
             const unifiedChainEvents = new UnifiedSwapEventListener_1.UnifiedSwapEventListener(unifiedSwapStorage, chainEvents);
             const wrappers = {};
-            wrappers[SwapType_1.SwapType.TO_BTCLN] = new ToBTCLNWrapper_1.ToBTCLNWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, tokens, chainData.swapDataConstructor, {
+            wrappers[SwapType_1.SwapType.TO_BTCLN] = new ToBTCLNWrapper_1.ToBTCLNWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
             });
-            wrappers[SwapType_1.SwapType.TO_BTC] = new ToBTCWrapper_1.ToBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, tokens, chainData.swapDataConstructor, this._bitcoinRpc, {
+            wrappers[SwapType_1.SwapType.TO_BTC] = new ToBTCWrapper_1.ToBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, this._bitcoinRpc, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
                 bitcoinNetwork: this._btcNetwork
             });
-            wrappers[SwapType_1.SwapType.FROM_BTCLN] = new FromBTCLNWrapper_1.FromBTCLNWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, tokens, chainData.swapDataConstructor, lightningApi, {
+            wrappers[SwapType_1.SwapType.FROM_BTCLN] = new FromBTCLNWrapper_1.FromBTCLNWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, lightningApi, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
                 unsafeSkipLnNodeCheck: this.bitcoinNetwork === base_1.BitcoinNetwork.TESTNET4 || this.bitcoinNetwork === base_1.BitcoinNetwork.REGTEST
             });
-            wrappers[SwapType_1.SwapType.FROM_BTC] = new FromBTCWrapper_1.FromBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, tokens, chainData.swapDataConstructor, btcRelay, synchronizer, this._bitcoinRpc, {
+            wrappers[SwapType_1.SwapType.FROM_BTC] = new FromBTCWrapper_1.FromBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, btcRelay, synchronizer, this._bitcoinRpc, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
                 bitcoinNetwork: this._btcNetwork
             });
-            wrappers[SwapType_1.SwapType.TRUSTED_FROM_BTCLN] = new LnForGasWrapper_1.LnForGasWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, pricing, tokens, {
+            wrappers[SwapType_1.SwapType.TRUSTED_FROM_BTCLN] = new LnForGasWrapper_1.LnForGasWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, pricing, this._tokens[chainId], {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout
             });
-            wrappers[SwapType_1.SwapType.TRUSTED_FROM_BTC] = new OnchainForGasWrapper_1.OnchainForGasWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, pricing, tokens, bitcoinRpc, {
+            wrappers[SwapType_1.SwapType.TRUSTED_FROM_BTC] = new OnchainForGasWrapper_1.OnchainForGasWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, pricing, this._tokens[chainId], bitcoinRpc, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
                 bitcoinNetwork: this._btcNetwork
             });
             if (spvVaultContract != null) {
-                wrappers[SwapType_1.SwapType.SPV_VAULT_FROM_BTC] = new SpvFromBTCWrapper_1.SpvFromBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, spvVaultContract, pricing, tokens, spvVaultWithdrawalDataConstructor, btcRelay, synchronizer, bitcoinRpc, {
+                wrappers[SwapType_1.SwapType.SPV_VAULT_FROM_BTC] = new SpvFromBTCWrapper_1.SpvFromBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, spvVaultContract, pricing, this._tokens[chainId], spvVaultWithdrawalDataConstructor, btcRelay, synchronizer, bitcoinRpc, {
                     getRequestTimeout: this.options.getRequestTimeout,
                     postRequestTimeout: this.options.postRequestTimeout,
                     bitcoinNetwork: this._btcNetwork
                 });
             }
             if (swapContract.supportsInitWithoutClaimer) {
-                wrappers[SwapType_1.SwapType.FROM_BTCLN_AUTO] = new FromBTCLNAutoWrapper_1.FromBTCLNAutoWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, tokens, chainData.swapDataConstructor, lightningApi, this.messenger, {
+                wrappers[SwapType_1.SwapType.FROM_BTCLN_AUTO] = new FromBTCLNAutoWrapper_1.FromBTCLNAutoWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, lightningApi, this.messenger, {
                     getRequestTimeout: this.options.getRequestTimeout,
                     postRequestTimeout: this.options.postRequestTimeout,
                     unsafeSkipLnNodeCheck: this.bitcoinNetwork === base_1.BitcoinNetwork.TESTNET4 || this.bitcoinNetwork === base_1.BitcoinNetwork.REGTEST
@@ -809,8 +811,8 @@ class Swapper extends events_1.EventEmitter {
         const srcToken = typeof (_srcToken) === "string" ? this.getToken(_srcToken) : _srcToken;
         const dstToken = typeof (_dstToken) === "string" ? this.getToken(_dstToken) : _dstToken;
         const amount = _amount == null ? null : (typeof (_amount) === "bigint" ? _amount : (0, Utils_1.fromDecimal)(_amount, exactIn ? srcToken.decimals : dstToken.decimals));
-        if (srcToken.chain === "BTC") {
-            if (dstToken.chain === "SC") {
+        if ((0, Token_1.isBtcToken)(srcToken)) {
+            if ((0, Token_1.isSCToken)(dstToken)) {
                 if (typeof (dst) !== "string")
                     throw new Error("Destination for BTC/BTC-LN -> smart chain swaps must be a smart chain address!");
                 if (amount == null)
@@ -841,8 +843,8 @@ class Swapper extends events_1.EventEmitter {
                 }
             }
         }
-        else {
-            if (dstToken.chain === "BTC") {
+        else if ((0, Token_1.isSCToken)(srcToken)) {
+            if ((0, Token_1.isBtcToken)(dstToken)) {
                 if (typeof (src) !== "string")
                     throw new Error("Source address for BTC/BTC-LN -> smart chain swaps must be a smart chain address!");
                 if (dstToken.lightning) {
@@ -1305,9 +1307,9 @@ class Swapper extends events_1.EventEmitter {
      */
     getToken(tickerOrAddress) {
         //Btc tokens - BTC, BTCLN, BTC-LN
-        if (tickerOrAddress === "BTC")
+        if (tickerOrAddress === "BTC" || tickerOrAddress === "BITCOIN-BTC")
             return Token_1.BitcoinTokens.BTC;
-        if (tickerOrAddress === "BTCLN" || tickerOrAddress === "BTC-LN")
+        if (tickerOrAddress === "BTCLN" || tickerOrAddress === "BTC-LN" || tickerOrAddress === "LIGHTNING-BTC")
             return Token_1.BitcoinTokens.BTCLN;
         //Check if the ticker is in format <chainId>-<ticker>, i.e. SOLANA-USDC, STARKNET-WBTC
         if (tickerOrAddress.includes("-")) {

--- a/dist/swapper/SwapperFactory.d.ts
+++ b/dist/swapper/SwapperFactory.d.ts
@@ -113,6 +113,7 @@ export declare class SwapperFactory<T extends readonly ChainInitializer<any, Cha
      * Token resolvers for various smart chains supported by the SDK, allow fetching tokens based on their addresses
      */
     TokenResolver: TypedTokenResolvers<T>;
+    private smartChainTokens;
     constructor(initializers: T);
     /**
      * Returns a new swapper instance with the passed options.

--- a/dist/swapper/SwapperFactory.js
+++ b/dist/swapper/SwapperFactory.js
@@ -64,21 +64,26 @@ class SwapperFactory {
          * Token resolvers for various smart chains supported by the SDK, allow fetching tokens based on their addresses
          */
         this.TokenResolver = {};
+        this.smartChainTokens = [];
         this.initializers = initializers;
         initializers.forEach(initializer => {
             const addressMap = {};
             const tokens = (this.Tokens[initializer.chainId] = {});
             for (let ticker in initializer.tokens) {
                 const assetData = initializer.tokens[ticker];
-                tokens[ticker] = addressMap[assetData.address] = {
+                const token = {
                     chain: "SC",
                     chainId: initializer.chainId,
-                    address: assetData.address,
+                    ticker,
                     name: SmartChainAssets_1.SmartChainAssets[ticker]?.name ?? ticker,
                     decimals: assetData.decimals,
                     displayDecimals: assetData.displayDecimals,
-                    ticker
+                    address: assetData.address,
+                    equals: (other) => other.chainId === initializer.chainId && other.ticker === ticker && other.address === assetData.address,
+                    toString: () => `${initializer.chainId}-${ticker}`
                 };
+                this.smartChainTokens.push(token);
+                tokens[ticker] = addressMap[assetData.address] = token;
             }
             this.TokenResolver[initializer.chainId] = {
                 getToken: (address) => addressMap[address]
@@ -140,7 +145,7 @@ class SwapperFactory {
                 };
             }), options.getPriceFn)) :
             RedundantSwapPrice_1.RedundantSwapPrice.createFromTokenMap(options.pricingFeeDifferencePPM ?? 10000n, pricingAssets);
-        return new Swapper_1.Swapper(bitcoinRpc, bitcoinRpc, (btcRelay) => new btc_mempool_1.MempoolBtcRelaySynchronizer(btcRelay, bitcoinRpc), chains, swapPricing, pricingAssets, options.messenger, options);
+        return new Swapper_1.Swapper(bitcoinRpc, bitcoinRpc, (btcRelay) => new btc_mempool_1.MempoolBtcRelaySynchronizer(btcRelay, bitcoinRpc), chains, swapPricing, this.smartChainTokens, options.messenger, options);
     }
     /**
      * Returns a new and already initialized swapper instance with the passed options. There is no need

--- a/dist/swapper/SwapperWithChain.d.ts
+++ b/dist/swapper/SwapperWithChain.d.ts
@@ -29,6 +29,7 @@ import { LNURLPay } from "../types/lnurl/LNURLPay";
 import { LightningInvoiceCreateService } from "../types/wallets/LightningInvoiceCreateService";
 import { Intermediary } from "../intermediaries/Intermediary";
 import { SwapTypeMapping } from "../utils/SwapUtils";
+import { SwapSide } from "../enums/SwapSide";
 /**
  * Chain-specific wrapper around Swapper for a particular blockchain
  *
@@ -398,7 +399,7 @@ export declare class SwapperWithChain<T extends MultiChain, ChainIdentifier exte
      * Returns tokens that you can swap to (if input=true) from a given token,
      *  or tokens that you can swap from (if input=false) to a given token
      */
-    getSwapCounterTokens(token: Token, input: boolean): Token<ChainIdentifier>[];
+    getSwapCounterTokens(token: Token, input: SwapSide | boolean): Token<ChainIdentifier>[];
     /**
      * Creates a child swapper instance with a signer
      *

--- a/dist/swapper/SwapperWithChain.d.ts
+++ b/dist/swapper/SwapperWithChain.d.ts
@@ -245,25 +245,25 @@ export declare class SwapperWithChain<T extends MultiChain, ChainIdentifier exte
     /**
      * @internal
      */
-    swap(srcToken: BtcToken<true>, dstToken: SCToken<ChainIdentifier>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string | LNURLWithdraw, dstSmartchainWallet: string, options?: (SupportsSwapType<T[ChainIdentifier], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoOptions : FromBTCLNOptions)): Promise<SupportsSwapType<T[ChainIdentifier], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoSwap<T[ChainIdentifier]> : FromBTCLNSwap<T[ChainIdentifier]>>;
+    swap(srcToken: BtcToken<true> | "BTCLN" | "BTC-LN" | "LIGHTNING-BTC", dstToken: SCToken<ChainIdentifier>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string | LNURLWithdraw, dstSmartchainWallet: string, options?: (SupportsSwapType<T[ChainIdentifier], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoOptions : FromBTCLNOptions)): Promise<SupportsSwapType<T[ChainIdentifier], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoSwap<T[ChainIdentifier]> : FromBTCLNSwap<T[ChainIdentifier]>>;
     /**
      * @internal
      */
-    swap(srcToken: BtcToken<false>, dstToken: SCToken<ChainIdentifier>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string, dstSmartchainWallet: string, options?: (SupportsSwapType<T[ChainIdentifier], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCOptions : FromBTCOptions)): Promise<(SupportsSwapType<T[ChainIdentifier], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCSwap<T[ChainIdentifier]> : FromBTCSwap<T[ChainIdentifier]>)>;
+    swap(srcToken: BtcToken<false> | "BTC" | "BITCOIN-BTC", dstToken: SCToken<ChainIdentifier>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string, dstSmartchainWallet: string, options?: (SupportsSwapType<T[ChainIdentifier], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCOptions : FromBTCOptions)): Promise<(SupportsSwapType<T[ChainIdentifier], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCSwap<T[ChainIdentifier]> : FromBTCSwap<T[ChainIdentifier]>)>;
     /**
      * @internal
      */
-    swap(srcToken: SCToken<ChainIdentifier>, dstToken: BtcToken<false>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstAddress: string, options?: ToBTCOptions): Promise<ToBTCSwap<T[ChainIdentifier]>>;
+    swap(srcToken: SCToken<ChainIdentifier>, dstToken: BtcToken<false> | "BTC" | "BITCOIN-BTC", amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstAddress: string, options?: ToBTCOptions): Promise<ToBTCSwap<T[ChainIdentifier]>>;
     /**
      * @internal
      */
-    swap(srcToken: SCToken<ChainIdentifier>, dstToken: BtcToken<true>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstLnurlPayOrInvoiceCreateService: string | LNURLPay | LightningInvoiceCreateService, options?: ToBTCLNOptions & {
+    swap(srcToken: SCToken<ChainIdentifier>, dstToken: BtcToken<true> | "BTCLN" | "BTC-LN" | "LIGHTNING-BTC", amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstLnurlPayOrInvoiceCreateService: string | LNURLPay | LightningInvoiceCreateService, options?: ToBTCLNOptions & {
         comment?: string;
     }): Promise<ToBTCLNSwap<T[ChainIdentifier]>>;
     /**
      * @internal
      */
-    swap(srcToken: SCToken<ChainIdentifier>, dstToken: BtcToken<true>, amount: undefined, exactIn: false | SwapAmountType.EXACT_OUT, src: string, dstLightningInvoice: string, options?: ToBTCLNOptions): Promise<ToBTCLNSwap<T[ChainIdentifier]>>;
+    swap(srcToken: SCToken<ChainIdentifier>, dstToken: BtcToken<true> | "BTCLN" | "BTC-LN" | "LIGHTNING-BTC", amount: undefined, exactIn: false | SwapAmountType.EXACT_OUT, src: string, dstLightningInvoice: string, options?: ToBTCLNOptions): Promise<ToBTCLNSwap<T[ChainIdentifier]>>;
     /**
      * Creates a swap from srcToken to dstToken, of a specific token amount, either specifying input amount (exactIn=true)
      *  or output amount (exactIn=false), NOTE: For regular SmartChain -> BTC-LN (lightning) swaps the passed amount is ignored and
@@ -329,14 +329,9 @@ export declare class SwapperWithChain<T extends MultiChain, ChainIdentifier exte
      *  initiated after this blockheight
      */
     recoverSwaps(signer: string, startBlockheight?: number): Promise<ISwap<T[ChainIdentifier]>[]>;
-    /**
-     * Returns the {@link Token} object for a given token
-     *
-     * @param tickerOrAddress Token to return the object for, can use multiple formats:
-     *  - a) token ticker, such as `"BTC"`, `"SOL"`, etc.
-     *  - b) token ticker prefixed with smart chain identifier, such as `"SOLANA-SOL"`, `"SOLANA-USDC"`, etc.
-     *  - c) token address
-     */
+    getToken(ticker: "BTC" | "BITCOIN-BTC"): BtcToken<false>;
+    getToken(ticker: "BTCLN" | "BTC-LN" | "LIGHTNING-BTC"): BtcToken<true>;
+    getToken(ticker: `${ChainIdentifier}-${string}`): SCToken<ChainIdentifier>;
     getToken(tickerOrAddress: string): Token<ChainIdentifier>;
     /**
      * Returns whether the SDK supports a given swap type on this chain based on currently known LPs

--- a/dist/swapper/SwapperWithChain.d.ts
+++ b/dist/swapper/SwapperWithChain.d.ts
@@ -370,12 +370,12 @@ export declare class SwapperWithChain<T extends MultiChain, ChainIdentifier exte
      */
     getSwapLimits<A extends Token<ChainIdentifier>, B extends Token<ChainIdentifier>>(srcToken: A, dstToken: B): {
         input: {
-            min: TokenAmount<string, A>;
-            max?: TokenAmount<string, A>;
+            min: TokenAmount<A>;
+            max?: TokenAmount<A>;
         };
         output: {
-            min: TokenAmount<string, B>;
-            max?: TokenAmount<string, B>;
+            min: TokenAmount<B>;
+            max?: TokenAmount<B>;
         };
     };
     /**

--- a/dist/swapper/SwapperWithChain.js
+++ b/dist/swapper/SwapperWithChain.js
@@ -315,9 +315,9 @@ class SwapperWithChain {
      */
     getToken(tickerOrAddress) {
         //Btc tokens - BTC, BTCLN, BTC-LN
-        if (tickerOrAddress === "BTC")
+        if (tickerOrAddress === "BTC" || tickerOrAddress === "BITCOIN-BTC")
             return Token_1.BitcoinTokens.BTC;
-        if (tickerOrAddress === "BTCLN" || tickerOrAddress === "BTC-LN")
+        if (tickerOrAddress === "BTCLN" || tickerOrAddress === "BTC-LN" || tickerOrAddress === "LIGHTNING-BTC")
             return Token_1.BitcoinTokens.BTCLN;
         //Check if the ticker is in format <chainId>-<ticker>, i.e. SOLANA-USDC, STARKNET-WBTC
         if (tickerOrAddress.includes("-")) {

--- a/dist/swapper/SwapperWithSigner.d.ts
+++ b/dist/swapper/SwapperWithSigner.d.ts
@@ -306,12 +306,12 @@ export declare class SwapperWithSigner<T extends MultiChain, ChainIdentifier ext
      */
     getSwapLimits<A extends Token<ChainIdentifier>, B extends Token<ChainIdentifier>>(srcToken: A, dstToken: B): {
         input: {
-            min: TokenAmount<string, A>;
-            max?: TokenAmount<string, A>;
+            min: TokenAmount<A>;
+            max?: TokenAmount<A>;
         };
         output: {
-            min: TokenAmount<string, B>;
-            max?: TokenAmount<string, B>;
+            min: TokenAmount<B>;
+            max?: TokenAmount<B>;
         };
     };
     /**

--- a/dist/swapper/SwapperWithSigner.d.ts
+++ b/dist/swapper/SwapperWithSigner.d.ts
@@ -28,6 +28,7 @@ import { LightningInvoiceCreateService } from "../types/wallets/LightningInvoice
 import { Intermediary } from "../intermediaries/Intermediary";
 import { SpvFromBTCOptions } from "../swaps/spv_swaps/SpvFromBTCWrapper";
 import { SwapTypeMapping } from "../utils/SwapUtils";
+import { SwapSide } from "../enums/SwapSide";
 /**
  * Chain and signer-specific wrapper for automatic signer injection into swap methods
  * @category Core
@@ -322,5 +323,5 @@ export declare class SwapperWithSigner<T extends MultiChain, ChainIdentifier ext
      * Returns tokens that you can swap to (if input=true) from a given token,
      *  or tokens that you can swap from (if input=false) to a given token
      */
-    getSwapCounterTokens(token: Token, input: boolean): Token<ChainIdentifier>[];
+    getSwapCounterTokens(token: Token, input: SwapSide | boolean): Token<ChainIdentifier>[];
 }

--- a/dist/swapper/SwapperWithSigner.d.ts
+++ b/dist/swapper/SwapperWithSigner.d.ts
@@ -265,14 +265,9 @@ export declare class SwapperWithSigner<T extends MultiChain, ChainIdentifier ext
      *  initiated after this blockheight
      */
     recoverSwaps(startBlockheight?: number): Promise<ISwap<T[ChainIdentifier]>[]>;
-    /**
-     * Returns the {@link Token} object for a given token
-     *
-     * @param tickerOrAddress Token to return the object for, can use multiple formats:
-     *  - a) token ticker, such as `"BTC"`, `"SOL"`, etc.
-     *  - b) token ticker prefixed with smart chain identifier, such as `"SOLANA-SOL"`, `"SOLANA-USDC"`, etc.
-     *  - c) token address
-     */
+    getToken(ticker: "BTC" | "BITCOIN-BTC"): BtcToken<false>;
+    getToken(ticker: "BTCLN" | "BTC-LN" | "LIGHTNING-BTC"): BtcToken<true>;
+    getToken(ticker: `${ChainIdentifier}-${string}`): SCToken<ChainIdentifier>;
     getToken(tickerOrAddress: string): Token<ChainIdentifier>;
     /**
      * Returns whether the SDK supports a given swap type on this chain based on currently known LPs

--- a/dist/swaps/IBTCWalletSwap.d.ts
+++ b/dist/swaps/IBTCWalletSwap.d.ts
@@ -48,7 +48,7 @@ export interface IBTCWalletSwap {
      * @param wallet Sender's bitcoin wallet
      * @param feeRate Optional fee rate in sats/vB for the transaction
      */
-    estimateBitcoinFee(wallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<any, BtcToken<false>> | null>;
+    estimateBitcoinFee(wallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<BtcToken<false>> | null>;
     /**
      * Sends a swap bitcoin transaction via the passed bitcoin wallet
      *

--- a/dist/swaps/ISwap.d.ts
+++ b/dist/swaps/ISwap.d.ts
@@ -112,6 +112,14 @@ export declare abstract class ISwap<T extends ChainType = ChainType, D extends S
      */
     _randomNonce: string;
     /**
+     * Whether the swap is saved in the persistent storage or not.
+     *
+     * @remarks This field itself is not persisted but is instead derived during runtime
+     *
+     * @internal
+     */
+    _persisted: boolean;
+    /**
      * Event emitter emitting `"swapState"` event when swap's state changes
      */
     readonly events: EventEmitter<{

--- a/dist/swaps/ISwap.js
+++ b/dist/swaps/ISwap.js
@@ -109,8 +109,8 @@ class ISwap {
         // swap exists, it will just never resolve!
         return new Promise((resolve, reject) => {
             let listener;
-            listener = (swap) => {
-                if (type === "eq" ? swap._state === targetState : type === "gte" ? swap._state >= targetState : swap._state != targetState) {
+            listener = () => {
+                if (type === "eq" ? this._state === targetState : type === "gte" ? this._state >= targetState : this._state != targetState) {
                     resolve();
                     this.events.removeListener("swapState", listener);
                 }

--- a/dist/swaps/ISwap.js
+++ b/dist/swaps/ISwap.js
@@ -50,6 +50,14 @@ class ISwap {
          */
         this._state = 0;
         /**
+         * Whether the swap is saved in the persistent storage or not.
+         *
+         * @remarks This field itself is not persisted but is instead derived during runtime
+         *
+         * @internal
+         */
+        this._persisted = false;
+        /**
          * Event emitter emitting `"swapState"` event when swap's state changes
          */
         this.events = new events_1.EventEmitter();

--- a/dist/swaps/ISwap.js
+++ b/dist/swaps/ISwap.js
@@ -105,6 +105,8 @@ class ISwap {
      * @internal
      */
     waitTillState(targetState, type = "eq", abortSignal) {
+        //TODO: This doesn't hold strong reference to the swap, hence if no other strong reference to the
+        // swap exists, it will just never resolve!
         return new Promise((resolve, reject) => {
             let listener;
             listener = (swap) => {

--- a/dist/swaps/ISwapWithGasDrop.d.ts
+++ b/dist/swaps/ISwapWithGasDrop.d.ts
@@ -17,5 +17,5 @@ export interface ISwapWithGasDrop<T extends ChainType> {
      * Returns the output of the "gas drop", additional native token received by the user on
      *  the destination chain
      */
-    getGasDropOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>>;
+    getGasDropOutput(): TokenAmount<SCToken<T["ChainId"]>>;
 }

--- a/dist/swaps/ISwapWrapper.d.ts
+++ b/dist/swaps/ISwapWrapper.d.ts
@@ -127,6 +127,15 @@ export declare abstract class ISwapWrapper<T extends ChainType, D extends SwapTy
         swapState: [ISwap];
     }>);
     /**
+     * Parses the provided gas amount from its `string` or `bigint` representation to `bigint` base units.
+     *
+     * Defaults to `0n` if no gasAmount is provided
+     *
+     * @param gasAmount
+     * @internal
+     */
+    protected parseGasAmount(gasAmount?: string | bigint): bigint;
+    /**
      * Pre-fetches swap price for a given swap
      *
      * @param amountData Amount data

--- a/dist/swaps/ISwapWrapper.d.ts
+++ b/dist/swaps/ISwapWrapper.d.ts
@@ -27,6 +27,10 @@ export type ISwapWrapperOptions = {
      * How many swaps to call `_sync()` for in parallel
      */
     maxParallelSwapSyncs?: number;
+    /**
+     * Whether to save swaps that are not initialized into the persistent storage
+     */
+    saveUninitializedSwaps?: boolean;
 };
 /**
  * Token configuration for wrapper constructors

--- a/dist/swaps/ISwapWrapper.d.ts
+++ b/dist/swaps/ISwapWrapper.d.ts
@@ -9,6 +9,8 @@ import { SwapType } from "../enums/SwapType";
 import { UnifiedSwapStorage } from "../storage/UnifiedSwapStorage";
 import { SCToken } from "../types/Token";
 import { PriceInfoType } from "../types/PriceInfoType";
+export declare const DEFAULT_MAX_PARALLEL_SWAP_TICKS = 50;
+export declare const DEFAULT_MAX_PARALLEL_SWAP_SYNCS = 50;
 /**
  * Options for swap wrapper configuration
  *
@@ -17,6 +19,14 @@ import { PriceInfoType } from "../types/PriceInfoType";
 export type ISwapWrapperOptions = {
     getRequestTimeout?: number;
     postRequestTimeout?: number;
+    /**
+     * How many swaps to call `_tick()` for in parallel
+     */
+    maxParallelSwapTicks?: number;
+    /**
+     * How many swaps to call `_sync()` for in parallel
+     */
+    maxParallelSwapSyncs?: number;
 };
 /**
  * Token configuration for wrapper constructors
@@ -86,6 +96,11 @@ export declare abstract class ISwapWrapper<T extends ChainType, D extends SwapTy
      * @internal
      */
     protected tickInterval?: NodeJS.Timeout;
+    /**
+     * An internal abort controller for the running tick handler
+     * @internal
+     */
+    protected tickAbortController?: AbortController;
     /**
      * States of the swaps in pending (non-final state), these are checked automatically on initial swap synchronization
      * @internal
@@ -228,8 +243,9 @@ export declare abstract class ISwapWrapper<T extends ChainType, D extends SwapTy
      *
      * @param swaps Optional array of swaps to invoke `_tick()` on, otherwise all relevant swaps will be fetched
      *  from the persistent storage
+     * @param abortSignal Abort signal
      */
-    tick(swaps?: D["Swap"][]): Promise<void>;
+    tick(swaps?: D["Swap"][], abortSignal?: AbortSignal): Promise<void>;
     /**
      * Returns the smart chain's native token used to pay for fees
      * @internal

--- a/dist/swaps/ISwapWrapper.d.ts
+++ b/dist/swaps/ISwapWrapper.d.ts
@@ -4,7 +4,6 @@ import { ChainEvent, ChainType } from "@atomiqlabs/base";
 import { EventEmitter } from "events";
 import { ISwap } from "./ISwap";
 import { ISwapPrice } from "../prices/abstract/ISwapPrice";
-import { ChainIds, MultiChain } from "../swapper/Swapper";
 import { UnifiedSwapEventListener } from "../events/UnifiedSwapEventListener";
 import { SwapType } from "../enums/SwapType";
 import { UnifiedSwapStorage } from "../storage/UnifiedSwapStorage";
@@ -24,17 +23,9 @@ export type ISwapWrapperOptions = {
  *
  * @category Swaps/Base
  */
-export type WrapperCtorTokens<T extends MultiChain = MultiChain> = {
-    ticker: string;
-    name: string;
-    chains: {
-        [chainId in ChainIds<T>]?: {
-            address: string;
-            decimals: number;
-            displayDecimals?: number;
-        };
-    };
-}[];
+export type WrapperCtorTokens<T extends ChainType = ChainType> = {
+    [tokenAddress: string]: SCToken<T["ChainId"]>;
+};
 /**
  * Type definition linking wrapper and swap types
  *

--- a/dist/swaps/ISwapWrapper.d.ts
+++ b/dist/swaps/ISwapWrapper.d.ts
@@ -230,6 +230,8 @@ export declare abstract class ISwapWrapper<T extends ChainType, D extends SwapTy
     /**
      * Runs checks on all the known pending swaps, syncing their state from on-chain data
      *
+     * @remarks Doesn't work properly if you pass non-persisted swaps
+     *
      * @param pastSwaps Optional array of past swaps to check, otherwise all relevant swaps will be fetched
      *  from the persistent storage
      * @param noSave Whether to skip saving the swap changes in the persistent storage

--- a/dist/swaps/ISwapWrapper.js
+++ b/dist/swaps/ISwapWrapper.js
@@ -4,6 +4,8 @@ exports.ISwapWrapper = void 0;
 const events_1 = require("events");
 const IntermediaryError_1 = require("../errors/IntermediaryError");
 const Logger_1 = require("../utils/Logger");
+const TokenUtils_1 = require("../utils/TokenUtils");
+const UserError_1 = require("../errors/UserError");
 /**
  * Base abstract class for swap handler implementations
  *
@@ -35,6 +37,26 @@ class ISwapWrapper {
         this.events = events || new events_1.EventEmitter();
         this._options = options;
         this._tokens = tokens;
+    }
+    /**
+     * Parses the provided gas amount from its `string` or `bigint` representation to `bigint` base units.
+     *
+     * Defaults to `0n` if no gasAmount is provided
+     *
+     * @param gasAmount
+     * @internal
+     */
+    parseGasAmount(gasAmount) {
+        let result;
+        if (typeof (gasAmount) === "string") {
+            result = (0, TokenUtils_1.fromHumanReadableString)(gasAmount, this._getNativeToken());
+            if (result == null)
+                throw new UserError_1.UserError("Invalid `gasAmount` option provided, not a numerical string!");
+        }
+        else {
+            result = gasAmount;
+        }
+        return result ?? 0n;
     }
     /**
      * Pre-fetches swap price for a given swap

--- a/dist/swaps/ISwapWrapper.js
+++ b/dist/swaps/ISwapWrapper.js
@@ -314,13 +314,15 @@ class ISwapWrapper {
      * @internal
      */
     _saveSwapData(swap) {
-        if (!swap.isInitiated()) {
-            this.logger.debug("saveSwapData(): Swap " + swap.getId() + " not initiated, saving to pending swaps");
-            this.pendingSwaps.set(swap.getId(), new WeakRef(swap));
-            return Promise.resolve();
-        }
-        else {
-            this.pendingSwaps.delete(swap.getId());
+        if (!this._options.saveUninitializedSwaps) {
+            if (!swap.isInitiated()) {
+                this.logger.debug("saveSwapData(): Swap " + swap.getId() + " not initiated, saving to pending swaps");
+                this.pendingSwaps.set(swap.getId(), new WeakRef(swap));
+                return Promise.resolve();
+            }
+            else {
+                this.pendingSwaps.delete(swap.getId());
+            }
         }
         return this.unifiedStorage.save(swap);
     }

--- a/dist/swaps/ISwapWrapper.js
+++ b/dist/swaps/ISwapWrapper.js
@@ -34,21 +34,7 @@ class ISwapWrapper {
         this._prices = prices;
         this.events = events || new events_1.EventEmitter();
         this._options = options;
-        this._tokens = {};
-        for (let tokenData of tokens) {
-            const chainData = tokenData.chains[chainIdentifier];
-            if (chainData == null)
-                continue;
-            this._tokens[chainData.address] = {
-                chain: "SC",
-                chainId: this.chainIdentifier,
-                address: chainData.address,
-                decimals: chainData.decimals,
-                ticker: tokenData.ticker,
-                name: tokenData.name,
-                displayDecimals: chainData.displayDecimals
-            };
-        }
+        this._tokens = tokens;
     }
     /**
      * Pre-fetches swap price for a given swap

--- a/dist/swaps/ISwapWrapper.js
+++ b/dist/swaps/ISwapWrapper.js
@@ -232,6 +232,8 @@ class ISwapWrapper {
     /**
      * Runs checks on all the known pending swaps, syncing their state from on-chain data
      *
+     * @remarks Doesn't work properly if you pass non-persisted swaps
+     *
      * @param pastSwaps Optional array of past swaps to check, otherwise all relevant swaps will be fetched
      *  from the persistent storage
      * @param noSave Whether to skip saving the swap changes in the persistent storage
@@ -331,7 +333,7 @@ class ISwapWrapper {
      */
     _removeSwapData(swap) {
         this.pendingSwaps.delete(swap.getId());
-        if (!swap.isInitiated())
+        if (!swap._persisted)
             return Promise.resolve();
         return this.unifiedStorage.remove(swap);
     }

--- a/dist/swaps/ISwapWrapper.js
+++ b/dist/swaps/ISwapWrapper.js
@@ -1,11 +1,13 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.ISwapWrapper = void 0;
+exports.ISwapWrapper = exports.DEFAULT_MAX_PARALLEL_SWAP_SYNCS = exports.DEFAULT_MAX_PARALLEL_SWAP_TICKS = void 0;
 const events_1 = require("events");
 const IntermediaryError_1 = require("../errors/IntermediaryError");
 const Logger_1 = require("../utils/Logger");
 const TokenUtils_1 = require("../utils/TokenUtils");
 const UserError_1 = require("../errors/UserError");
+exports.DEFAULT_MAX_PARALLEL_SWAP_TICKS = 50;
+exports.DEFAULT_MAX_PARALLEL_SWAP_SYNCS = 50;
 /**
  * Base abstract class for swap handler implementations
  *
@@ -29,6 +31,10 @@ class ISwapWrapper {
          * @internal
          */
         this.isInitialized = false;
+        if (options?.maxParallelSwapTicks != null && options.maxParallelSwapTicks < 1)
+            throw new Error("maxParallelSwapTicks must be at least 1!");
+        if (options?.maxParallelSwapSyncs != null && options.maxParallelSwapSyncs < 1)
+            throw new Error("maxParallelSwapSyncs must be at least 1!");
         this.unifiedStorage = unifiedStorage;
         this.unifiedChainEvents = unifiedChainEvents;
         this.chainIdentifier = chainIdentifier;
@@ -128,9 +134,25 @@ class ISwapWrapper {
     startTickInterval() {
         if (this.tickSwapState == null || this.tickSwapState.length === 0)
             return;
-        this.tickInterval = setInterval(() => {
-            this.tick();
-        }, 1000);
+        if (this.tickAbortController != null)
+            this.tickAbortController.abort("New tick interval has been started!");
+        const abortController = this.tickAbortController = new AbortController();
+        let run;
+        run = async () => {
+            if (!this.isInitialized)
+                return;
+            await this.tick(undefined, abortController.signal).catch(e => {
+                if (abortController.signal.aborted)
+                    return;
+                this.logger.warn("startTickInterval(): Tick on swaps failed, error: ", e);
+            });
+            if (abortController.signal.aborted)
+                return;
+            if (!this.isInitialized)
+                return;
+            this.tickInterval = setTimeout(run, 1000);
+        };
+        run();
     }
     /**
      * Runs checks on passed swaps, syncing their state from on-chain data
@@ -186,10 +208,10 @@ class ISwapWrapper {
         }
         if (this.processEvent != null)
             this.unifiedChainEvents.registerListener(this.TYPE, this.processEvent.bind(this), this._swapDeserializer.bind(null, this));
+        this.isInitialized = true;
         if (!noTimers)
             this.startTickInterval();
         // this.logger.info("init(): Swap wrapper initialized");
-        this.isInitialized = true;
     }
     /**
      * Un-subscribes from event listeners on the smart chain, terminates the tick interval and stops this wrapper
@@ -198,8 +220,14 @@ class ISwapWrapper {
         this.isInitialized = false;
         this.unifiedChainEvents.unregisterListener(this.TYPE);
         this.logger.info("stop(): Swap wrapper stopped");
-        if (this.tickInterval != null)
-            clearInterval(this.tickInterval);
+        if (this.tickInterval != null) {
+            clearTimeout(this.tickInterval);
+            delete this.tickInterval;
+        }
+        if (this.tickAbortController != null) {
+            this.tickAbortController.abort("Wrapper instance stopped!");
+            delete this.tickAbortController;
+        }
     }
     /**
      * Runs checks on all the known pending swaps, syncing their state from on-chain data
@@ -211,16 +239,23 @@ class ISwapWrapper {
     async checkPastSwaps(pastSwaps, noSave) {
         if (pastSwaps == null)
             pastSwaps = await this.unifiedStorage.query([[{ key: "type", value: this.TYPE }, { key: "state", value: this._pendingSwapStates }]], (val) => new this._swapDeserializer(this, val));
-        const { removeSwaps, changedSwaps } = await this._checkPastSwaps(pastSwaps);
-        if (!noSave) {
-            await this.unifiedStorage.removeAll(removeSwaps);
-            await this.unifiedStorage.saveAll(changedSwaps);
-            changedSwaps.forEach(swap => swap._emitEvent());
-            removeSwaps.forEach(swap => swap._emitEvent());
+        const maxParallelSyncs = this._options.maxParallelSwapSyncs ?? exports.DEFAULT_MAX_PARALLEL_SWAP_SYNCS;
+        const totalRemoveSwaps = [];
+        const totalChangedSwaps = [];
+        for (let i = 0; i < pastSwaps.length; i += maxParallelSyncs) {
+            const { removeSwaps, changedSwaps } = await this._checkPastSwaps(pastSwaps.slice(i, i + maxParallelSyncs));
+            if (!noSave) {
+                await this.unifiedStorage.removeAll(removeSwaps);
+                await this.unifiedStorage.saveAll(changedSwaps);
+                changedSwaps.forEach(swap => swap._emitEvent());
+                removeSwaps.forEach(swap => swap._emitEvent());
+            }
+            totalRemoveSwaps.push(...removeSwaps);
+            totalChangedSwaps.push(...changedSwaps);
         }
         return {
-            removeSwaps,
-            changedSwaps
+            removeSwaps: totalRemoveSwaps,
+            changedSwaps: totalChangedSwaps
         };
     }
     /**
@@ -228,18 +263,39 @@ class ISwapWrapper {
      *
      * @param swaps Optional array of swaps to invoke `_tick()` on, otherwise all relevant swaps will be fetched
      *  from the persistent storage
+     * @param abortSignal Abort signal
      */
-    async tick(swaps) {
+    async tick(swaps, abortSignal) {
         if (swaps == null)
             swaps = await this.unifiedStorage.query([[{ key: "type", value: this.TYPE }, { key: "state", value: this.tickSwapState }]], (val) => new this._swapDeserializer(this, val));
+        abortSignal?.throwIfAborted();
+        const parallelTicks = this._options.maxParallelSwapTicks ?? exports.DEFAULT_MAX_PARALLEL_SWAP_TICKS;
+        let promises = [];
         for (let pendingSwap of this.pendingSwaps.values()) {
             const value = pendingSwap.deref();
             if (value != null)
-                value._tick(true);
+                promises.push(value._tick(true).catch(e => {
+                    this.logger.warn(`tick(): Error ticking swap ${value.getId()}: `, e);
+                }));
+            if (promises.length >= parallelTicks) {
+                await Promise.all(promises);
+                abortSignal?.throwIfAborted();
+                promises = [];
+            }
         }
-        swaps.forEach(value => {
-            value._tick(true);
-        });
+        for (let value of swaps) {
+            promises.push(value._tick(true).catch(e => {
+                this.logger.warn(`tick(): Error ticking swap ${value.getId()}: `, e);
+            }));
+            if (promises.length >= parallelTicks) {
+                await Promise.all(promises);
+                abortSignal?.throwIfAborted();
+                promises = [];
+            }
+        }
+        if (promises.length > 0)
+            await Promise.all(promises);
+        abortSignal?.throwIfAborted();
     }
     /**
      * Returns the smart chain's native token used to pay for fees

--- a/dist/swaps/escrow_swaps/IEscrowSelfInitSwap.d.ts
+++ b/dist/swaps/escrow_swaps/IEscrowSelfInitSwap.d.ts
@@ -46,15 +46,15 @@ export declare abstract class IEscrowSelfInitSwap<T extends ChainType = ChainTyp
     /**
      * Returns the transaction fee paid on the smart chain side to initiate the escrow
      */
-    getSmartChainNetworkFee(): Promise<TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>>;
+    getSmartChainNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>>;
     /**
      * Checks if the initiator/sender has enough balance on the smart chain side
      *  to cover the transaction fee for processing the swap
      */
     abstract hasEnoughForTxFees(): Promise<{
         enoughBalance: boolean;
-        balance: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
-        required: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+        balance: TokenAmount<SCToken<T["ChainId"]>, true>;
+        required: TokenAmount<SCToken<T["ChainId"]>, true>;
     }>;
     /**
      * Returns transactions for initiating (committing) the escrow on the smart chain side. After sending the

--- a/dist/swaps/escrow_swaps/IEscrowSwapWrapper.js
+++ b/dist/swaps/escrow_swaps/IEscrowSwapWrapper.js
@@ -23,8 +23,11 @@ class IEscrowSwapWrapper extends ISwapWrapper_1.ISwapWrapper {
      * @internal
      */
     preFetchSignData(signDataPrefetch) {
-        if (this._contract.preFetchForInitSignatureVerification == null)
+        if (this._contract.preFetchForInitSignatureVerification == null) {
+            // Catch promise rejections, should they happen
+            signDataPrefetch.catch(() => { });
             return Promise.resolve(undefined);
+        }
         return signDataPrefetch.then(obj => {
             if (obj == null)
                 return undefined;

--- a/dist/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.d.ts
@@ -91,35 +91,35 @@ export declare abstract class IFromBTCSelfInitSwap<T extends ChainType = ChainTy
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+    getOutput(): TokenAmount<SCToken<T["ChainId"]>, true>;
     /**
      * @inheritDoc
      */
-    abstract getInput(): TokenAmount<T["ChainId"], BtcToken>;
+    abstract getInput(): TokenAmount<BtcToken>;
     /**
      * @inheritDoc
      */
-    getInputWithoutFee(): TokenAmount<T["ChainId"], BtcToken>;
+    getInputWithoutFee(): TokenAmount<BtcToken>;
     /**
      * @inheritDoc
      */
     hasEnoughForTxFees(): Promise<{
         enoughBalance: boolean;
-        balance: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
-        required: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+        balance: TokenAmount<SCToken<T["ChainId"]>, true>;
+        required: TokenAmount<SCToken<T["ChainId"]>, true>;
     }>;
     /**
      * Returns the amount of native token of the destination chain locked up during initialization of the escrow
      *  to act as a security deposit that can be taken by the intermediary (LP) if the user doesn't go through
      *  with the swap
      */
-    getSecurityDeposit(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+    getSecurityDeposit(): TokenAmount<SCToken<T["ChainId"]>, true>;
     /**
      * Returns the total amount of native token of the destination chain locked up during initialization of the escrow.
      *  This covers the security deposit and the watchtower fee (if applicable), it is calculated a maximum of those
      *  two values.
      */
-    getTotalDeposit(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+    getTotalDeposit(): TokenAmount<SCToken<T["ChainId"]>, true>;
     /**
      * Returns transactions for initiating (committing) the escrow on the destination smart chain side, pre-locking the
      *  tokens from the intermediary (LP) into an escrow.
@@ -146,7 +146,7 @@ export declare abstract class IFromBTCSelfInitSwap<T extends ChainType = ChainTy
      * Returns the transaction fee required for the claim transaction to settle the escrow on the destination
      *  smart chain
      */
-    getClaimNetworkFee(): Promise<TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>>;
+    getClaimNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>>;
     /**
      * @inheritDoc
      */

--- a/dist/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.d.ts
@@ -42,7 +42,7 @@ export declare abstract class IFromBTCSelfInitSwap<T extends ChainType = ChainTy
      * Returns if the swap can be committed
      * @internal
      */
-    protected abstract canCommit(): boolean;
+    protected abstract canCommit(skipQuoteExpiryChecks?: boolean): boolean;
     /**
      * @inheritDoc
      * @internal

--- a/dist/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.d.ts
@@ -150,7 +150,7 @@ export declare abstract class IFromBTCSelfInitSwap<T extends ChainType = ChainTy
     /**
      * @inheritDoc
      */
-    abstract txsClaim(signer?: T["Signer"]): Promise<T["TX"][]>;
+    abstract txsClaim(signer?: string | T["Signer"] | T["NativeSigner"]): Promise<T["TX"][]>;
     /**
      * @inheritDoc
      */

--- a/dist/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.js
+++ b/dist/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.js
@@ -166,7 +166,7 @@ class IFromBTCSelfInitSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
      * @throws {Error} When in invalid state to commit the swap
      */
     async txsCommit(skipChecks) {
-        if (!this.canCommit())
+        if (!this.canCommit(skipChecks))
             throw new Error("Must be in CREATED state!");
         if (this._data == null || this.signatureData == null)
             throw new Error("data or signature data is null, invalid state?");

--- a/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.d.ts
@@ -400,7 +400,7 @@ export declare class FromBTCLNSwap<T extends ChainType = ChainType> extends IFro
      *
      * @throws {Error} If in invalid state (must be {@link FromBTCLNSwapState.CLAIM_COMMITED})
      */
-    txsClaim(_signer?: T["Signer"] | T["NativeSigner"], secret?: string): Promise<T["TX"][]>;
+    txsClaim(_signer?: string | T["Signer"] | T["NativeSigner"], secret?: string): Promise<T["TX"][]>;
     /**
      * @inheritDoc
      *

--- a/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.d.ts
@@ -152,7 +152,7 @@ export declare class FromBTCLNSwap<T extends ChainType = ChainType> extends IFro
      * @inheritDoc
      * @internal
      */
-    protected canCommit(): boolean;
+    protected canCommit(skipQuoteExpiryChecks?: boolean): boolean;
     /**
      * @inheritDoc
      */

--- a/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.d.ts
@@ -237,18 +237,18 @@ export declare class FromBTCLNSwap<T extends ChainType = ChainType> extends IFro
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], BtcToken<true>>;
+    getInput(): TokenAmount<BtcToken<true>>;
     /**
      * @inheritDoc
      */
-    getSmartChainNetworkFee(): Promise<TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>>;
+    getSmartChainNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>>;
     /**
      * @inheritDoc
      */
     hasEnoughForTxFees(): Promise<{
         enoughBalance: boolean;
-        balance: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
-        required: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+        balance: TokenAmount<SCToken<T["ChainId"]>, true>;
+        required: TokenAmount<SCToken<T["ChainId"]>, true>;
     }>;
     private isValidSecretPreimage;
     /**
@@ -422,7 +422,7 @@ export declare class FromBTCLNSwap<T extends ChainType = ChainType> extends IFro
      * Estimated transaction fee for commit & claim transactions combined, required
      *  to settle the swap on the smart chain destination side.
      */
-    getCommitAndClaimNetworkFee(): Promise<TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>>;
+    getCommitAndClaimNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>>;
     /**
      * Returns whether the underlying chain supports calling commit and claim in a single call,
      *  such that you can use the {@link commitAndClaim} function. If not you have to manually

--- a/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.js
@@ -224,8 +224,8 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
      * @inheritDoc
      * @internal
      */
-    canCommit() {
-        return this._state === FromBTCLNSwapState.PR_PAID;
+    canCommit(skipQuoteExpiryChecks) {
+        return this._state === FromBTCLNSwapState.PR_PAID || (!!skipQuoteExpiryChecks && this._state === FromBTCLNSwapState.QUOTE_SOFT_EXPIRED);
     }
     /**
      * @inheritDoc
@@ -773,7 +773,7 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
             return Promise.resolve();
         });
         this._commitTxId = result[result.length - 1];
-        if (this._state === FromBTCLNSwapState.PR_PAID || this._state === FromBTCLNSwapState.QUOTE_SOFT_EXPIRED) {
+        if (this._state === FromBTCLNSwapState.PR_PAID || this._state === FromBTCLNSwapState.QUOTE_SOFT_EXPIRED || this._state === FromBTCLNSwapState.QUOTE_EXPIRED) {
             await this._saveAndEmit(FromBTCLNSwapState.CLAIM_COMMITED);
         }
         return this._commitTxId;

--- a/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.js
@@ -821,6 +821,18 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
      * @internal
      */
     async _txsClaim(_signer, secret) {
+        let address = undefined;
+        if (_signer != null) {
+            if (typeof (_signer) === "string") {
+                address = _signer;
+            }
+            else if ((0, base_1.isAbstractSigner)(_signer)) {
+                address = _signer.getAddress();
+            }
+            else {
+                address = (await this.wrapper._chain.wrapSigner(_signer)).getAddress();
+            }
+        }
         if (this._data == null)
             throw new Error("Unknown data, wrong state?");
         const useSecret = secret ?? this.secret;
@@ -828,9 +840,7 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
             throw new Error("Swap secret pre-image not known and not provided, please provide the swap secret pre-image as an argument");
         if (!this.isValidSecretPreimage(useSecret))
             throw new Error("Invalid swap secret pre-image provided!");
-        return this.wrapper._contract.txsClaimWithSecret(_signer == null ?
-            this._getInitiator() :
-            ((0, base_1.isAbstractSigner)(_signer) ? _signer : await this.wrapper._chain.wrapSigner(_signer)), this._data, useSecret, true, true);
+        return this.wrapper._contract.txsClaimWithSecret(address ?? this._getInitiator(), this._data, useSecret, true, true);
     }
     /**
      * @inheritDoc

--- a/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.d.ts
@@ -18,9 +18,30 @@ import { AmountData } from "../../../../types/AmountData";
 import { LNURLWithdrawParamsWithUrl } from "../../../../types/lnurl/LNURLWithdraw";
 import { AllOptional } from "../../../../utils/TypeUtils";
 export type FromBTCLNOptions = {
-    paymentHash?: Buffer;
+    /**
+     * Instead of letting the SDK generate the preimage/paymentHash pair internally you can pass your computed
+     *  paymentHash here, this will create the swap with the provided payment hash. Note that you would then
+     *  have to reveal the preimage by passing it to the {@link FromBTCLNSwap.claim} or {@link FromBTCLNSwap.txsClaim}
+     *  functions
+     *
+     * Accepts both, a {@link Buffer} and a hexadecimal `string`
+     */
+    paymentHash?: Buffer | string;
+    /**
+     * Optional description to use for the swap lightning network invoice, keep the invoice length below 500 characters
+     */
     description?: string;
-    descriptionHash?: Buffer;
+    /**
+     * Optional description hash to use for the lightning network invoice, useful when returning the invoice as part of
+     *  an LNURL-pay service endpoint.
+     *
+     * Accepts both, a {@link Buffer} and a hexadecimal `string`
+     */
+    descriptionHash?: Buffer | string;
+    /**
+     * A flag to skip checking whether the lightning network node of the LP has enough channel liquidity to facilitate
+     *  the swap.
+     */
     unsafeSkipLnNodeCheck?: boolean;
 };
 export type FromBTCLNWrapperOptions = ISwapWrapperOptions & {

--- a/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.js
@@ -236,7 +236,6 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                             secret: secret?.toString("hex"),
                             exactIn: amountData.exactIn ?? true
                         });
-                        await quote._save();
                         return quote;
                     }
                     catch (e) {

--- a/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.js
@@ -199,8 +199,14 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                             feeRate: (0, Utils_1.throwIfUndefined)(_preFetches.feeRatePromise),
                             additionalParams
                         }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
+                        let lnCapacityPromise;
+                        if (!_options.unsafeSkipLnNodeCheck) {
+                            lnCapacityPromise = this.preFetchLnCapacity(lnPublicKey);
+                        }
+                        else
+                            lnPublicKey.catch(() => { });
                         return {
-                            lnCapacityPromise: _options.unsafeSkipLnNodeCheck ? null : this.preFetchLnCapacity(lnPublicKey),
+                            lnCapacityPromise,
                             resp: await response
                         };
                     }, undefined, RequestError_1.RequestError, abortController.signal);

--- a/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.js
@@ -36,6 +36,7 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
      */
     constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, lnApi, options, events) {
         super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, lnApi, {
+            ...options,
             safetyFactor: options?.safetyFactor ?? 2,
             bitcoinBlocktime: options?.bitcoinBlocktime ?? 10 * 60,
             unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? false

--- a/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.js
@@ -155,19 +155,18 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
     create(recipient, amountData, lps, options, additionalParams, abortSignal, preFetches) {
         if (!this.isInitialized)
             throw new Error("Not initialized, call init() first!");
-        if (options == null)
-            options = {};
-        options.unsafeSkipLnNodeCheck ??= this._options.unsafeSkipLnNodeCheck;
-        if (options.paymentHash != null && options.paymentHash.length !== 32)
-            throw new UserError_1.UserError("Invalid payment hash length, must be exactly 32 bytes!");
-        if (options.descriptionHash != null && options.descriptionHash.length !== 32)
-            throw new UserError_1.UserError("Invalid description hash length");
-        if (options.description != null && buffer_1.Buffer.byteLength(options.description, "utf8") > 500)
+        const _options = {
+            paymentHash: (0, Utils_1.parseHashValueExact32Bytes)(options?.paymentHash, "payment hash"),
+            description: options?.description,
+            descriptionHash: (0, Utils_1.parseHashValueExact32Bytes)(options?.descriptionHash, "description hash"),
+            unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? this._options.unsafeSkipLnNodeCheck
+        };
+        if (_options.description != null && buffer_1.Buffer.byteLength(_options.description, "utf8") > 500)
             throw new UserError_1.UserError("Invalid description length");
         let secret;
         let paymentHash;
-        if (options?.paymentHash != null) {
-            paymentHash = options.paymentHash;
+        if (_options.paymentHash != null) {
+            paymentHash = _options.paymentHash;
         }
         else {
             ({ secret, paymentHash } = this.getSecretAndHash());
@@ -194,14 +193,14 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                             amount: amountData.amount,
                             claimer: recipient,
                             token: amountData.token.toString(),
-                            description: options?.description,
-                            descriptionHash: options?.descriptionHash,
+                            description: _options.description,
+                            descriptionHash: _options.descriptionHash,
                             exactOut: !amountData.exactIn,
                             feeRate: (0, Utils_1.throwIfUndefined)(_preFetches.feeRatePromise),
                             additionalParams
                         }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
                         return {
-                            lnCapacityPromise: options?.unsafeSkipLnNodeCheck ? null : this.preFetchLnCapacity(lnPublicKey),
+                            lnCapacityPromise: _options.unsafeSkipLnNodeCheck ? null : this.preFetchLnCapacity(lnPublicKey),
                             resp: await response
                         };
                     }, undefined, RequestError_1.RequestError, abortController.signal);
@@ -212,7 +211,7 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                         throw new IntermediaryError_1.IntermediaryError("Invalid returned swap invoice, no expiry date field");
                     const amountIn = (BigInt(decodedPr.millisatoshis) + 999n) / 1000n;
                     try {
-                        this.verifyReturnedData(resp, amountData, lp, options ?? {}, decodedPr, paymentHash);
+                        this.verifyReturnedData(resp, amountData, lp, _options, decodedPr, paymentHash);
                         const [pricingInfo] = await Promise.all([
                             this.verifyReturnedPrice(lp.services[SwapType_1.SwapType.FROM_BTCLN], false, amountIn, resp.total, amountData.token, {}, _preFetches.pricePrefetchPromise, _preFetches.usdPricePrefetchPromise, abortController.signal),
                             this.verifyIntermediaryLiquidity(resp.total, (0, Utils_1.throwIfUndefined)(liquidityPromise)),
@@ -259,8 +258,12 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
     async createViaLNURL(recipient, lnurl, amountData, lps, options, additionalParams, abortSignal) {
         if (!this.isInitialized)
             throw new Error("Not initialized, call init() first!");
-        if (options?.paymentHash != null && options.paymentHash.length !== 32)
-            throw new UserError_1.UserError("Invalid payment hash length, must be exactly 32 bytes!");
+        const _options = {
+            paymentHash: (0, Utils_1.parseHashValueExact32Bytes)(options?.paymentHash, "payment hash"),
+            description: options?.description,
+            descriptionHash: (0, Utils_1.parseHashValueExact32Bytes)(options?.descriptionHash, "description hash"),
+            unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? this._options.unsafeSkipLnNodeCheck
+        };
         const abortController = (0, Utils_1.extendAbortController)(abortSignal);
         const preFetches = {
             pricePrefetchPromise: this.preFetchPrice(amountData, abortController.signal),
@@ -289,7 +292,7 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                 if ((amount * 105n / 100n) > max)
                     throw new UserError_1.UserError("Amount more than LNURL-withdraw maximum");
             }
-            return this.create(recipient, amountData, lps, options, additionalParams, abortSignal, preFetches).map(data => {
+            return this.create(recipient, amountData, lps, _options, additionalParams, abortSignal, preFetches).map(data => {
                 return {
                     quote: data.quote.then(quote => {
                         quote._setLNURLData(withdrawRequest.url, withdrawRequest.k1, withdrawRequest.callback);

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.d.ts
@@ -313,11 +313,11 @@ export declare class FromBTCLNAutoSwap<T extends ChainType = ChainType> extends 
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], BtcToken<true>>;
+    getInput(): TokenAmount<BtcToken<true>>;
     /**
      * @inheritDoc
      */
-    getInputWithoutFee(): TokenAmount<T["ChainId"], BtcToken<true>>;
+    getInputWithoutFee(): TokenAmount<BtcToken<true>>;
     /**
      * @inheritDoc
      */
@@ -325,11 +325,11 @@ export declare class FromBTCLNAutoSwap<T extends ChainType = ChainType> extends 
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+    getOutput(): TokenAmount<SCToken<T["ChainId"]>, true>;
     /**
      * @inheritDoc
      */
-    getGasDropOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+    getGasDropOutput(): TokenAmount<SCToken<T["ChainId"]>, true>;
     /**
      * Returns the swap fee charged by the intermediary (LP) on this swap
      *

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.d.ts
@@ -482,7 +482,7 @@ export declare class FromBTCLNAutoSwap<T extends ChainType = ChainType> extends 
      *
      * @throws {Error} If in invalid state (must be {@link FromBTCLNAutoSwapState.CLAIM_COMMITED})
      */
-    txsClaim(_signer?: T["Signer"] | T["NativeSigner"], secret?: string): Promise<T["TX"][]>;
+    txsClaim(_signer?: string | T["Signer"] | T["NativeSigner"], secret?: string): Promise<T["TX"][]>;
     /**
      * @inheritDoc
      *

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.js
@@ -441,7 +441,7 @@ class FromBTCLNAutoSwap extends IEscrowSwap_1.IEscrowSwap {
      * @internal
      */
     getInputAmountWithoutFee() {
-        if (this.btcAmountGas == null || this.btcAmountSwap)
+        if (this.btcAmountGas == null || this.btcAmountSwap == null)
             return null;
         return this.getInputSwapAmountWithoutFee() + this.getInputGasAmountWithoutFee() - this.getWatchtowerFeeAmountBtc();
     }

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.js
@@ -963,6 +963,18 @@ class FromBTCLNAutoSwap extends IEscrowSwap_1.IEscrowSwap {
      * @throws {Error} If in invalid state (must be {@link FromBTCLNAutoSwapState.CLAIM_COMMITED})
      */
     async txsClaim(_signer, secret) {
+        let address = undefined;
+        if (_signer != null) {
+            if (typeof (_signer) === "string") {
+                address = _signer;
+            }
+            else if ((0, base_1.isAbstractSigner)(_signer)) {
+                address = _signer.getAddress();
+            }
+            else {
+                address = (await this.wrapper._chain.wrapSigner(_signer)).getAddress();
+            }
+        }
         if (this._state !== FromBTCLNAutoSwapState.CLAIM_COMMITED)
             throw new Error("Must be in CLAIM_COMMITED state!");
         if (this._data == null)
@@ -972,9 +984,7 @@ class FromBTCLNAutoSwap extends IEscrowSwap_1.IEscrowSwap {
             throw new Error("Swap secret pre-image not known and not provided, please provide the swap secret pre-image as an argument");
         if (!this.isValidSecretPreimage(useSecret))
             throw new Error("Invalid swap secret pre-image provided!");
-        return await this.wrapper._contract.txsClaimWithSecret(_signer == null ?
-            this._getInitiator() :
-            ((0, base_1.isAbstractSigner)(_signer) ? _signer : await this.wrapper._chain.wrapSigner(_signer)), this._data, useSecret, true, true);
+        return await this.wrapper._contract.txsClaimWithSecret(address ?? this._getInitiator(), this._data, useSecret, true, true);
     }
     /**
      * @inheritDoc

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.d.ts
@@ -18,12 +18,53 @@ import { AmountData } from "../../../../types/AmountData";
 import { LNURLWithdrawParamsWithUrl } from "../../../../types/lnurl/LNURLWithdraw";
 import { AllOptional } from "../../../../utils/TypeUtils";
 export type FromBTCLNAutoOptions = {
-    paymentHash?: Buffer;
+    /**
+     * Instead of letting the SDK generate the preimage/paymentHash pair internally you can pass your computed
+     *  paymentHash here, this will create the swap with the provided payment hash. Note that swaps created this way
+     *  won't settle automatically (as the SDK is missing the preimage). Once the HTLC towards the user is created in
+     *  the {@link FromBTCLNAutoSwapState.CLAIM_COMMITED} state, you should pass the secret preimage manually in the
+     *  {@link FromBTCLNAutoSwap.waitTillClaimed}, {@link FromBTCLNAutoSwap.claim} or {@link FromBTCLNAutoSwap.txsClaim}
+     *  functions.
+     *
+     * Accepts both, a {@link Buffer} and a hexadecimal `string`
+     */
+    paymentHash?: Buffer | string;
+    /**
+     * Optional description to use for the swap lightning network invoice, keep the invoice length below 500 characters
+     */
     description?: string;
-    descriptionHash?: Buffer;
+    /**
+     * Optional description hash to use for the lightning network invoice, useful when returning the invoice as part of
+     *  an LNURL-pay service endpoint.
+     *
+     * Accepts both, a {@link Buffer} and a hexadecimal `string`
+     */
+    descriptionHash?: Buffer | string;
+    /**
+     * Optional additional native token to receive as an output of the swap (e.g. STRK on Starknet or cBTC on Citrea).
+     *  When passed as a `bigint` it is specified in base units of the token and in `string` it is the human readable
+     *  decimal format.
+     */
+    gasAmount?: bigint | string;
+    /**
+     * A flag to skip checking whether the lightning network node of the LP has enough channel liquidity to facilitate
+     *  the swap.
+     */
     unsafeSkipLnNodeCheck?: boolean;
-    gasAmount?: bigint;
+    /**
+     * A flag to attach 0 watchtower fee to the swap, this would make the settlement unattractive for the watchtowers
+     *  and therefore automatic settlement for such swaps will not be possible, you will have to settle manually
+     *  with {@link FromBTCLNSwap.claim} or {@link FromBTCLNSwap.txsClaim} functions.
+     */
     unsafeZeroWatchtowerFee?: boolean;
+    /**
+     * A safety factor to use when estimating the watchtower fee to attach to the swap (this has to cover the gas fee
+     *  of watchtowers settling the swap). A higher multiple here would mean that a swap is more attractive for
+     *  watchtowers to settle automatically.
+     *
+     * Uses a `1.25` multiple by default (i.e. the current network fee is multiplied by 1.25 and then used to estimate
+     *  the settlement gas fee cost)
+     */
     feeSafetyFactor?: number;
 };
 export type FromBTCLNAutoWrapperOptions = ISwapWrapperOptions & {

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
@@ -39,6 +39,7 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
      */
     constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, lnApi, messenger, options, events) {
         super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, lnApi, {
+            ...options,
             safetyFactor: options?.safetyFactor ?? 2,
             bitcoinBlocktime: options?.bitcoinBlocktime ?? 10 * 60,
             unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? false

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
@@ -276,8 +276,14 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                             gasAmount: _options.gasAmount,
                             claimerBounty: (0, Utils_1.throwIfUndefined)(_preFetches.claimerBountyPrefetch)
                         }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
+                        let lnCapacityPromise;
+                        if (!_options.unsafeSkipLnNodeCheck) {
+                            lnCapacityPromise = this.preFetchLnCapacity(lnPublicKey);
+                        }
+                        else
+                            lnPublicKey.catch(() => { });
                         return {
-                            lnCapacityPromise: _options.unsafeSkipLnNodeCheck ? undefined : this.preFetchLnCapacity(lnPublicKey),
+                            lnCapacityPromise,
                             resp: await response
                         };
                     }, undefined, RequestError_1.RequestError, abortController.signal);

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
@@ -321,8 +321,6 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                             exactIn: amountData.exactIn ?? true
                         };
                         const quote = new FromBTCLNAutoSwap_1.FromBTCLNAutoSwap(this, swapInit);
-                        await quote._save();
-                        this.logger.debug("create(): Created new FromBTCLNAutoSwap quote, claimHash (pseudo escrowHash): ", quote._getEscrowHash());
                         return quote;
                     }
                     catch (e) {

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
@@ -100,7 +100,6 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                 this.logger.error("processEventInitialize(" + swap.getId() + "): Error when processing event, escrow hashes don't match!");
                 return false;
             }
-            swap._commitTxId = event.meta?.txId;
             swap._commitedAt ??= Date.now();
             swap._state = FromBTCLNAutoSwap_1.FromBTCLNAutoSwapState.CLAIM_COMMITED;
             if (swap.hasSecretPreimage())
@@ -117,7 +116,6 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
      */
     processEventClaim(swap, event) {
         if (swap._state !== FromBTCLNAutoSwap_1.FromBTCLNAutoSwapState.FAILED && swap._state !== FromBTCLNAutoSwap_1.FromBTCLNAutoSwapState.CLAIM_CLAIMED) {
-            swap._claimTxId = event.meta?.txId;
             swap._state = FromBTCLNAutoSwap_1.FromBTCLNAutoSwapState.CLAIM_CLAIMED;
             swap._setSwapSecret(event.result);
             return Promise.resolve(true);
@@ -130,7 +128,6 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
      */
     processEventRefund(swap, event) {
         if (swap._state !== FromBTCLNAutoSwap_1.FromBTCLNAutoSwapState.CLAIM_CLAIMED && swap._state !== FromBTCLNAutoSwap_1.FromBTCLNAutoSwapState.FAILED) {
-            swap._refundTxId ??= event.meta?.txId;
             swap._state = FromBTCLNAutoSwap_1.FromBTCLNAutoSwapState.FAILED;
             return Promise.resolve(true);
         }

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
@@ -102,9 +102,10 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
             swap._commitTxId = event.meta?.txId;
             swap._commitedAt ??= Date.now();
             swap._state = FromBTCLNAutoSwap_1.FromBTCLNAutoSwapState.CLAIM_COMMITED;
-            swap._broadcastSecret().catch(e => {
-                this.logger.error("processEventInitialize(" + swap.getId() + "): Error when broadcasting swap secret: ", e);
-            });
+            if (swap.hasSecretPreimage())
+                swap._broadcastSecret().catch(e => {
+                    this.logger.error("processEventInitialize(" + swap.getId() + "): Error when broadcasting swap secret: ", e);
+                });
             return true;
         }
         return false;

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
@@ -221,22 +221,18 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
         if (!this.isInitialized)
             throw new Error("Not initialized, call init() first!");
         const _options = {
-            paymentHash: options?.paymentHash,
+            paymentHash: (0, Utils_1.parseHashValueExact32Bytes)(options?.paymentHash, "payment hash"),
             unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? this._options.unsafeSkipLnNodeCheck,
-            gasAmount: options?.gasAmount ?? 0n,
+            gasAmount: this.parseGasAmount(options?.gasAmount),
             feeSafetyFactor: options?.feeSafetyFactor ?? 1.25,
             unsafeZeroWatchtowerFee: options?.unsafeZeroWatchtowerFee ?? false,
             description: options?.description,
-            descriptionHash: options?.descriptionHash
+            descriptionHash: (0, Utils_1.parseHashValueExact32Bytes)(options?.descriptionHash, "description hash")
         };
-        if (_options.paymentHash != null && _options.paymentHash.length !== 32)
-            throw new UserError_1.UserError("Invalid payment hash length, must be exactly 32 bytes!");
-        if (_options.descriptionHash != null && _options.descriptionHash.length !== 32)
-            throw new UserError_1.UserError("Invalid description hash length");
+        if (amountData.token === this._chain.getNativeCurrencyAddress() && _options.gasAmount !== 0n)
+            throw new UserError_1.UserError("Cannot specify `gasAmount` for swaps to a native token!");
         if (_options.description != null && buffer_1.Buffer.byteLength(_options.description, "utf8") > 500)
             throw new UserError_1.UserError("Invalid description length");
-        if (preFetches == null)
-            preFetches = {};
         let secret;
         let paymentHash;
         if (_options?.paymentHash != null) {
@@ -248,6 +244,7 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
         const claimHash = this._contract.getHashForHtlc(paymentHash);
         const nativeTokenAddress = this._chain.getNativeCurrencyAddress();
         const _abortController = (0, Utils_1.extendAbortController)(abortSignal);
+        preFetches ??= {};
         const _preFetches = {
             pricePrefetchPromise: preFetches?.pricePrefetchPromise ?? this.preFetchPrice(amountData, _abortController.signal),
             usdPricePrefetchPromise: preFetches?.usdPricePrefetchPromise ?? this.preFetchUsdPrice(_abortController.signal),
@@ -348,16 +345,14 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
         if (!this.isInitialized)
             throw new Error("Not initialized, call init() first!");
         const _options = {
-            paymentHash: options?.paymentHash,
+            paymentHash: (0, Utils_1.parseHashValueExact32Bytes)(options?.paymentHash, "payment hash"),
             unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? this._options.unsafeSkipLnNodeCheck,
-            gasAmount: options?.gasAmount ?? 0n,
+            gasAmount: this.parseGasAmount(options?.gasAmount),
             feeSafetyFactor: options?.feeSafetyFactor ?? 1.25,
             unsafeZeroWatchtowerFee: options?.unsafeZeroWatchtowerFee ?? false,
             description: options?.description,
-            descriptionHash: options?.descriptionHash
+            descriptionHash: (0, Utils_1.parseHashValueExact32Bytes)(options?.descriptionHash, "description hash")
         };
-        if (_options.paymentHash != null && _options.paymentHash.length !== 32)
-            throw new UserError_1.UserError("Invalid payment hash length, must be exactly 32 bytes!");
         const abortController = (0, Utils_1.extendAbortController)(abortSignal);
         const preFetches = {
             pricePrefetchPromise: this.preFetchPrice(amountData, abortController.signal),

--- a/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.d.ts
@@ -444,6 +444,7 @@ export declare class FromBTCSwap<T extends ChainType = ChainType> extends IFromB
      * @internal
      */
     _sync(save?: boolean, quoteDefinitelyExpired?: boolean, commitStatus?: SwapCommitState): Promise<boolean>;
+    private btcTxLastChecked?;
     /**
      * @inheritDoc
      * @internal

--- a/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.d.ts
@@ -199,13 +199,13 @@ export declare class FromBTCSwap<T extends ChainType = ChainType> extends IFromB
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], BtcToken<false>>;
+    getInput(): TokenAmount<BtcToken<false>>;
     /**
      * Returns claimer bounty, acting as a reward for watchtowers to claim the swap automatically,
      *  this amount is pre-funded by the user on the destination chain when the swap escrow
      *  is initiated. For total pre-funded deposit amount see {@link getTotalDeposit}.
      */
-    getClaimerBounty(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+    getClaimerBounty(): TokenAmount<SCToken<T["ChainId"]>, true>;
     /**
      * If the required number of confirmations is not known, this function tries to infer it by looping through
      *  possible confirmation targets and comparing the claim hashes
@@ -281,7 +281,7 @@ export declare class FromBTCSwap<T extends ChainType = ChainType> extends IFromB
     /**
      * @inheritDoc
      */
-    estimateBitcoinFee(_bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<any, BtcToken<false>, true> | null>;
+    estimateBitcoinFee(_bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<BtcToken<false>, true> | null>;
     /**
      * @inheritDoc
      */

--- a/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.d.ts
@@ -191,7 +191,7 @@ export declare class FromBTCSwap<T extends ChainType = ChainType> extends IFromB
      * @inheritDoc
      * @internal
      */
-    protected canCommit(): boolean;
+    protected canCommit(skipQuoteExpiryChecks?: boolean): boolean;
     /**
      * @inheritDoc
      */

--- a/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.js
+++ b/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.js
@@ -260,8 +260,8 @@ class FromBTCSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
      * @inheritDoc
      * @internal
      */
-    canCommit() {
-        if (this._state !== FromBTCSwapState.PR_CREATED)
+    canCommit(skipQuoteExpiryChecks) {
+        if (this._state !== FromBTCSwapState.PR_CREATED && (!skipQuoteExpiryChecks || this._state !== FromBTCSwapState.QUOTE_SOFT_EXPIRED))
             return false;
         if (this.requiredConfirmations == null)
             return false;
@@ -742,7 +742,7 @@ class FromBTCSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
             return Promise.resolve();
         });
         this._commitTxId = result[result.length - 1];
-        if (this._state === FromBTCSwapState.PR_CREATED || this._state === FromBTCSwapState.QUOTE_SOFT_EXPIRED) {
+        if (this._state === FromBTCSwapState.PR_CREATED || this._state === FromBTCSwapState.QUOTE_SOFT_EXPIRED || this._state === FromBTCSwapState.QUOTE_EXPIRED) {
             await this._saveAndEmit(FromBTCSwapState.CLAIM_COMMITED);
         }
         return this._commitTxId;

--- a/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.js
+++ b/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.js
@@ -1045,6 +1045,7 @@ class FromBTCSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
                 }
                 if (this.address == null)
                     return save;
+                this.btcTxLastChecked = Date.now();
                 const res = await this.getBitcoinPayment();
                 if (res != null) {
                     if (this.txId !== res.txId) {
@@ -1086,10 +1087,11 @@ class FromBTCSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
                     return true;
                 }
             case FromBTCSwapState.EXPIRED:
-                //Check if bitcoin payment was received every 2 minutes
-                if (Math.floor(Date.now() / 1000) % 120 === 0) {
+                //Check if bitcoin payment was received at least every 2 minutes
+                if (this.btcTxLastChecked == null || Date.now() - this.btcTxLastChecked > 120000) {
                     if (this.address != null)
                         try {
+                            this.btcTxLastChecked = Date.now();
                             const res = await this.getBitcoinPayment();
                             if (res != null) {
                                 let shouldSave = false;

--- a/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.d.ts
@@ -16,9 +16,27 @@ import { IFromBTCSelfInitDefinition } from "../IFromBTCSelfInitSwap";
 import { AmountData } from "../../../../types/AmountData";
 import { AllOptional } from "../../../../utils/TypeUtils";
 export type FromBTCOptions = {
-    feeSafetyFactor?: bigint;
-    blockSafetyFactor?: number;
+    /**
+     * A flag to attach 0 watchtower fee to the swap, this would make the settlement unattractive for the watchtowers
+     *  and therefore automatic settlement for such swaps will not be possible, you will have to settle manually
+     *  with {@link FromBTCLNSwap.claim} or {@link FromBTCLNSwap.txsClaim} functions.
+     */
     unsafeZeroWatchtowerFee?: boolean;
+    /**
+     * A safety factor to use when estimating the watchtower fee to attach to the swap (this has to cover the gas fee
+     *  of watchtowers settling the swap). A higher multiple here would mean that a swap is more attractive for
+     *  watchtowers to settle automatically.
+     *
+     * Uses a `1.5` multiple by default (i.e. the current network fee is multiplied by 1.5 and then used to estimate
+     *  the settlement gas fee cost).
+     *
+     * Also accepts `bigint` for legacy reasons.
+     */
+    feeSafetyFactor?: number | bigint;
+    /**
+     * @deprecated Removed as it is deemed not necessary
+     */
+    blockSafetyFactor?: number;
 };
 export type FromBTCWrapperOptions = ISwapWrapperOptions & {
     safetyFactor: number;

--- a/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.js
@@ -295,8 +295,14 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
                                 feeRate: (0, Utils_1.throwIfUndefined)(feeRatePromise),
                                 additionalParams
                             }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
+                            let signDataPromise = _signDataPromise;
+                            if (signDataPromise == null) {
+                                signDataPromise = this.preFetchSignData(signDataPrefetch);
+                            }
+                            else
+                                signDataPrefetch.catch(() => { });
                             return {
-                                signDataPromise: _signDataPromise ?? this.preFetchSignData(signDataPrefetch),
+                                signDataPromise,
                                 resp: await response
                             };
                         }, undefined, e => e instanceof RequestError_1.RequestError, abortController.signal);

--- a/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.js
@@ -330,7 +330,6 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
                             exactIn: amountData.exactIn ?? true,
                             requiredConfirmations: resp.confirmations
                         });
-                        await quote._save();
                         return quote;
                     }
                     catch (e) {

--- a/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.js
@@ -37,6 +37,7 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
      */
     constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, btcRelay, synchronizer, btcRpc, options, events) {
         super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, {
+            ...options,
             bitcoinNetwork: options?.bitcoinNetwork ?? utils_1.TEST_NETWORK,
             safetyFactor: options?.safetyFactor ?? 2,
             blocksTillTxConfirms: options?.blocksTillTxConfirms ?? 12,

--- a/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.js
@@ -137,7 +137,7 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
                 feePerBlock: 0n,
                 safetyFactor: options.blockSafetyFactor,
                 startTimestamp: startTimestamp,
-                addBlock: 0,
+                addBlock: 0n,
                 addFee: 0n
             };
         }
@@ -155,11 +155,11 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
             const currentBtcRelayBlock = btcRelayData.blockheight;
             const addBlock = Math.max(currentBtcBlock - currentBtcRelayBlock, 0);
             return {
-                feePerBlock: feePerBlock * options.feeSafetyFactor,
+                feePerBlock: feePerBlock * options.feeSafetyFactorPPM / 1000000n,
                 safetyFactor: options.blockSafetyFactor,
                 startTimestamp: startTimestamp,
-                addBlock,
-                addFee: claimFeeRate * options.feeSafetyFactor
+                addBlock: BigInt(addBlock),
+                addFee: claimFeeRate * options.feeSafetyFactorPPM / 1000000n
             };
         }
         catch (e) {
@@ -178,8 +178,8 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
      */
     getClaimerBounty(data, options, claimerBounty) {
         const tsDelta = data.getExpiry() - claimerBounty.startTimestamp;
-        const blocksDelta = tsDelta / BigInt(this._options.bitcoinBlocktime) * BigInt(options.blockSafetyFactor);
-        const totalBlock = blocksDelta + BigInt(claimerBounty.addBlock);
+        const blocksDelta = tsDelta / BigInt(this._options.bitcoinBlocktime) * options.blockSafetyFactor;
+        const totalBlock = blocksDelta + claimerBounty.addBlock;
         return claimerBounty.addFee + (totalBlock * claimerBounty.feePerBlock);
     }
     /**
@@ -253,9 +253,16 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
      * @param abortSignal Abort signal
      */
     create(recipient, amountData, lps, options, additionalParams, abortSignal) {
+        let feeSafetyFactorPPM = 1500000n;
+        if (typeof (options?.feeSafetyFactor) === "bigint") {
+            feeSafetyFactorPPM = options.feeSafetyFactor * 1000000n;
+        }
+        else if (typeof (options?.feeSafetyFactor) === "number") {
+            feeSafetyFactorPPM = BigInt(Math.floor(options.feeSafetyFactor * 1000000));
+        }
         const _options = {
-            blockSafetyFactor: options?.blockSafetyFactor ?? 1,
-            feeSafetyFactor: options?.feeSafetyFactor ?? 2n,
+            blockSafetyFactor: options?.blockSafetyFactor != null ? BigInt(options.blockSafetyFactor) : 1n,
+            feeSafetyFactorPPM,
             unsafeZeroWatchtowerFee: options?.unsafeZeroWatchtowerFee ?? false
         };
         const sequence = this.getRandomSequence();

--- a/dist/swaps/escrow_swaps/tobtc/IToBTCSwap.d.ts
+++ b/dist/swaps/escrow_swaps/tobtc/IToBTCSwap.d.ts
@@ -222,18 +222,18 @@ export declare abstract class IToBTCSwap<T extends ChainType = ChainType, D exte
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+    getInput(): TokenAmount<SCToken<T["ChainId"]>, true>;
     /**
      * @inheritDoc
      */
-    getInputWithoutFee(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+    getInputWithoutFee(): TokenAmount<SCToken<T["ChainId"]>, true>;
     /**
      * Checks if the initiator/sender on the source chain has enough balance to go through with the swap
      */
     hasEnoughBalance(): Promise<{
         enoughBalance: boolean;
-        balance: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
-        required: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+        balance: TokenAmount<SCToken<T["ChainId"]>, true>;
+        required: TokenAmount<SCToken<T["ChainId"]>, true>;
     }>;
     /**
      * Checks if the initiator/sender on the source chain has enough native token balance
@@ -241,8 +241,8 @@ export declare abstract class IToBTCSwap<T extends ChainType = ChainType, D exte
      */
     hasEnoughForTxFees(): Promise<{
         enoughBalance: boolean;
-        balance: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
-        required: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+        balance: TokenAmount<SCToken<T["ChainId"]>, true>;
+        required: TokenAmount<SCToken<T["ChainId"]>, true>;
     }>;
     /**
      * Executes the swap with the provided smart chain wallet/signer
@@ -341,7 +341,7 @@ export declare abstract class IToBTCSwap<T extends ChainType = ChainType, D exte
     /**
      * Get the estimated smart chain transaction fee of the refund transaction
      */
-    getRefundNetworkFee(): Promise<TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>>;
+    getRefundNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>>;
     /**
      * @inheritDoc
      *

--- a/dist/swaps/escrow_swaps/tobtc/IToBTCSwap.js
+++ b/dist/swaps/escrow_swaps/tobtc/IToBTCSwap.js
@@ -453,7 +453,7 @@ class IToBTCSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
      * @throws {Error} When in invalid state (not {@link ToBTCSwapState.CREATED})
      */
     async txsCommit(skipChecks) {
-        if (this._state !== ToBTCSwapState.CREATED)
+        if (this._state !== ToBTCSwapState.CREATED && (!skipChecks || this._state !== ToBTCSwapState.QUOTE_SOFT_EXPIRED))
             throw new Error("Must be in CREATED state!");
         if (this.signatureData == null)
             throw new Error("Init signature data not known, cannot commit!");

--- a/dist/swaps/escrow_swaps/tobtc/IToBTCWrapper.js
+++ b/dist/swaps/escrow_swaps/tobtc/IToBTCWrapper.js
@@ -78,8 +78,6 @@ class IToBTCWrapper extends IEscrowSwapWrapper_1.IEscrowSwapWrapper {
     async processEventInitialize(swap, event) {
         if (swap._state === IToBTCSwap_1.ToBTCSwapState.CREATED || swap._state === IToBTCSwap_1.ToBTCSwapState.QUOTE_SOFT_EXPIRED) {
             swap._state = IToBTCSwap_1.ToBTCSwapState.COMMITED;
-            if (swap._commitTxId == null)
-                swap._commitTxId = event.meta?.txId;
             return true;
         }
         return false;
@@ -96,8 +94,6 @@ class IToBTCWrapper extends IEscrowSwapWrapper_1.IEscrowSwapWrapper {
                 this.logger.warn(`processEventClaim(): Failed to set payment result ${event.result}: `, e);
             });
             swap._state = IToBTCSwap_1.ToBTCSwapState.CLAIMED;
-            if (swap._claimTxId == null)
-                swap._claimTxId = event.meta?.txId;
             return true;
         }
         return false;
@@ -108,8 +104,6 @@ class IToBTCWrapper extends IEscrowSwapWrapper_1.IEscrowSwapWrapper {
     processEventRefund(swap, event) {
         if (swap._state !== IToBTCSwap_1.ToBTCSwapState.CLAIMED && swap._state !== IToBTCSwap_1.ToBTCSwapState.REFUNDED) {
             swap._state = IToBTCSwap_1.ToBTCSwapState.REFUNDED;
-            if (swap._refundTxId == null)
-                swap._refundTxId = event.meta?.txId;
             return Promise.resolve(true);
         }
         return Promise.resolve(false);

--- a/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNSwap.d.ts
+++ b/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNSwap.d.ts
@@ -61,7 +61,7 @@ export declare class ToBTCLNSwap<T extends ChainType = ChainType> extends IToBTC
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], BtcToken<true>>;
+    getOutput(): TokenAmount<BtcToken<true>>;
     /**
      * @inheritDoc
      */

--- a/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.d.ts
@@ -15,11 +15,55 @@ import { LNURLPayParamsWithUrl } from "../../../../types/lnurl/LNURLPay";
 import { AllOptional } from "../../../../utils/TypeUtils";
 import { LightningInvoiceCreateService } from "../../../../types/wallets/LightningInvoiceCreateService";
 export type ToBTCLNOptions = {
+    /**
+     * HTLC expiration timeout in seconds to use when offering the HTLC to the LP. Larger expirations mean that more
+     *  lightning network payment paths can be considered (every hop in the lightning network payment adds additional
+     *  timeout requirement). On the other side, larger expiration also means that user's funds are locked for longer
+     *  in case of a non-cooperative LP.
+     *
+     * Uses 5 days as default.
+     */
     expirySeconds?: number;
-    maxFee?: bigint | Promise<bigint>;
-    expiryTimestamp?: bigint;
-    maxRoutingPPM?: bigint;
+    /**
+     * Maximum fee for routing the swap output payment through the lightning network. Higher fee percentages means that
+     *  more payment routes can be considered (every hop in the lightning network payment adds additional fee
+     *  requirements).
+     *
+     * The fee is express as percentage of the swap value, uses `0.2` by default which means the maximum
+     *  routing fee is capped at 0.2% of the swap value.
+     *
+     * The full fee also contains the base component (set by `maxRoutingBaseFee` option), the resulting maximum routing
+     *  fee rate is:
+     *
+     * `maxRoutingFee` = `maxRoutingBaseFee` sats + `value` * `maxRoutingFeePercentage`%
+     */
+    maxRoutingFeePercentage?: number;
+    /**
+     *
+     * Maximum base fee (in sats) for routing the swap output payment through the lightning network. Higher fee
+     *  percentages means that more payment routes can be considered (every hop in the lightning network payment adds additional fee
+     *  requirements).
+     *
+     * Uses 10 sats as a default.
+     *
+     * The full fee also contains the value percentage component (set by `maxRoutingFeePercentage` option), the
+     *  resulting maximum routing fee rate is:
+     *
+     * `maxRoutingFee` = `maxRoutingBaseFee` sats + (`value` * `maxRoutingFeePercentage`%)
+     */
     maxRoutingBaseFee?: bigint;
+    /**
+     * @deprecated Use `maxRoutingFeePercentage` and express the routing fee in percentage instead!
+     */
+    maxRoutingPPM?: bigint;
+    /**
+     * @deprecated Adjust fee with `maxRoutingFeePercentage` & `maxRoutingBaseFee` params!
+     */
+    maxFee?: bigint | Promise<bigint>;
+    /**
+     * @deprecated Pass desired HTLC expiration timeout as `expirySeconds`
+     */
+    expiryTimestamp?: bigint;
 };
 export type ToBTCLNWrapperOptions = ISwapWrapperOptions & {
     lightningBaseFee: number;
@@ -71,7 +115,7 @@ export declare class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T
      * @param parsedPr Parsed bolt11 lightning invoice
      * @param token Smart chain token to be used in the swap
      * @param lp
-     * @param options Swap options as passed to the swap create function
+     * @param calculatedOptions Swap options computed from the swap create options
      * @param data Parsed swap data returned by the LP
      * @param requiredTotal Required total to be paid on the input (for exactIn swaps)
      *
@@ -88,7 +132,7 @@ export declare class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T
      * @param lp Intermediary
      * @param pr bolt11 lightning network invoice
      * @param parsedPr Parsed bolt11 lightning network invoice
-     * @param options Options as passed to the swap create function
+     * @param calculatedOptions Swap options computed from the swap create options
      * @param preFetches
      * @param abort Abort signal or controller, if AbortController is passed it is used as-is, when AbortSignal is passed
      *  it is extended with extendAbortController and then used
@@ -110,7 +154,9 @@ export declare class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T
      * @param abortSignal Abort signal
      * @param preFetches Optional existing pre-fetch promises for the swap (only used internally for LNURL swaps)
      */
-    create(signer: string, recipient: string, amountData: Omit<AmountData, "amount">, lps: Intermediary[], options?: ToBTCLNOptions, additionalParams?: Record<string, any>, abortSignal?: AbortSignal, preFetches?: {
+    create(signer: string, recipient: string, amountData: Omit<AmountData, "amount"> & {
+        exactIn: false;
+    }, lps: Intermediary[], options?: ToBTCLNOptions, additionalParams?: Record<string, any>, abortSignal?: AbortSignal, preFetches?: {
         feeRatePromise: Promise<string | undefined>;
         pricePreFetchPromise: Promise<bigint | undefined>;
         usdPricePrefetchPromise: Promise<number | undefined>;
@@ -138,7 +184,7 @@ export declare class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T
      * @param lp Intermediary (LPs) to get the quote from
      * @param dummyPr Dummy minimum value bolt11 lightning invoice returned from the LNURL-pay, used to estimate
      *  network fees for an actual invoice
-     * @param options Optional additional quote options
+     * @param calculatedOptions Swap options computed from the swap create options
      * @param preFetches Optional existing pre-fetch promises for the swap (only used internally for LNURL swaps)
      * @param abortSignal Abort signal
      * @param additionalParams Additional params to be sent to the intermediary

--- a/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.js
+++ b/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.js
@@ -23,7 +23,7 @@ const RetryUtils_1 = require("../../../../utils/RetryUtils");
 class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
     constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, options, events) {
         super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, {
-            paymentTimeoutSeconds: options?.paymentTimeoutSeconds ?? 4 * 24 * 60 * 60,
+            paymentTimeoutSeconds: options?.paymentTimeoutSeconds ?? 5 * 24 * 60 * 60,
             lightningBaseFee: options?.lightningBaseFee ?? 10,
             lightningFeePPM: options?.lightningFeePPM ?? 2000
         }, events);
@@ -36,7 +36,9 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
     toRequiredSwapOptions(amountData, options, pricePreFetchPromise, abortSignal) {
         const expirySeconds = options?.expirySeconds ?? this._options.paymentTimeoutSeconds;
         const maxRoutingBaseFee = options?.maxRoutingBaseFee ?? BigInt(this._options.lightningBaseFee);
-        const maxRoutingPPM = options?.maxRoutingPPM ?? BigInt(this._options.lightningFeePPM);
+        const maxRoutingPPM = options?.maxRoutingFeePercentage != null
+            ? BigInt(Math.floor(options.maxRoutingFeePercentage * 10000))
+            : options?.maxRoutingPPM ?? BigInt(this._options.lightningFeePPM);
         let maxFee;
         if (options?.maxFee != null) {
             maxFee = options.maxFee;
@@ -56,10 +58,7 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
             maxFee = this.calculateFeeForAmount(amountData.amount, maxRoutingBaseFee, maxRoutingPPM);
         }
         return {
-            expirySeconds,
             expiryTimestamp: options?.expiryTimestamp ?? BigInt(Math.floor(Date.now() / 1000) + expirySeconds),
-            maxRoutingBaseFee,
-            maxRoutingPPM,
             maxFee
         };
     }
@@ -101,7 +100,7 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
      * @param parsedPr Parsed bolt11 lightning invoice
      * @param token Smart chain token to be used in the swap
      * @param lp
-     * @param options Swap options as passed to the swap create function
+     * @param calculatedOptions Swap options computed from the swap create options
      * @param data Parsed swap data returned by the LP
      * @param requiredTotal Required total to be paid on the input (for exactIn swaps)
      *
@@ -109,8 +108,8 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
      *
      * @private
      */
-    async verifyReturnedData(signer, resp, parsedPr, token, lp, options, data, requiredTotal) {
-        if (resp.routingFeeSats > await options.maxFee)
+    async verifyReturnedData(signer, resp, parsedPr, token, lp, calculatedOptions, data, requiredTotal) {
+        if (resp.routingFeeSats > await calculatedOptions.maxFee)
             throw new IntermediaryError_1.IntermediaryError("Invalid max fee sats returned");
         if (requiredTotal != null && resp.total !== requiredTotal)
             throw new IntermediaryError_1.IntermediaryError("Invalid data returned - total amount");
@@ -119,7 +118,7 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
         const claimHash = this._contract.getHashForHtlc(Buffer.from(parsedPr.tagsObject.payment_hash, "hex"));
         if (data.getAmount() !== resp.total ||
             !Buffer.from(data.getClaimHash(), "hex").equals(claimHash) ||
-            data.getExpiry() !== options.expiryTimestamp ||
+            data.getExpiry() !== calculatedOptions.expiryTimestamp ||
             data.getType() !== base_1.ChainSwapType.HTLC ||
             !data.isPayIn() ||
             !data.isToken(token) ||
@@ -137,7 +136,7 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
      * @param lp Intermediary
      * @param pr bolt11 lightning network invoice
      * @param parsedPr Parsed bolt11 lightning network invoice
-     * @param options Options as passed to the swap create function
+     * @param calculatedOptions Swap options computed from the swap create options
      * @param preFetches
      * @param abort Abort signal or controller, if AbortController is passed it is used as-is, when AbortSignal is passed
      *  it is extended with extendAbortController and then used
@@ -145,7 +144,7 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
      *
      * @private
      */
-    async getIntermediaryQuote(signer, amountData, lp, pr, parsedPr, options, preFetches, abort, additionalParams) {
+    async getIntermediaryQuote(signer, amountData, lp, pr, parsedPr, calculatedOptions, preFetches, abort, additionalParams) {
         if (lp.services[SwapType_1.SwapType.TO_BTCLN] == null)
             throw new Error("LP service for processing to btcln swaps not found!");
         const abortController = abort instanceof AbortController ? abort : (0, Utils_1.extendAbortController)(abort);
@@ -155,8 +154,8 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                 const { signDataPrefetch, response } = IntermediaryAPI_1.IntermediaryAPI.initToBTCLN(this.chainIdentifier, lp.url, {
                     offerer: signer,
                     pr,
-                    maxFee: await options.maxFee,
-                    expiryTimestamp: options.expiryTimestamp,
+                    maxFee: await calculatedOptions.maxFee,
+                    expiryTimestamp: calculatedOptions.expiryTimestamp,
                     token: amountData.token,
                     feeRate: (0, Utils_1.throwIfUndefined)(preFetches.feeRatePromise),
                     additionalParams
@@ -172,7 +171,7 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
             const totalFee = resp.swapFee + resp.maxFee;
             const data = new this._swapDataDeserializer(resp.data);
             data.setOfferer(signer);
-            await this.verifyReturnedData(signer, resp, parsedPr, amountData.token, lp, options, data);
+            await this.verifyReturnedData(signer, resp, parsedPr, amountData.token, lp, calculatedOptions, data);
             const [pricingInfo, signatureExpiry, reputation] = await Promise.all([
                 this.verifyReturnedPrice(lp.services[SwapType_1.SwapType.TO_BTCLN], true, amountOut, data.getAmount(), amountData.token, { networkFee: resp.maxFee }, preFetches.pricePreFetchPromise, preFetches.usdPricePrefetchPromise, abortController.signal),
                 this.verifyReturnedSignature(signer, data, resp, preFetches.feeRatePromise, signDataPromise, abortController.signal),
@@ -223,16 +222,7 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
         if (parsedPr.millisatoshis == null)
             throw new UserError_1.UserError("Must be an invoice with amount");
         const amountOut = (BigInt(parsedPr.millisatoshis) + 999n) / 1000n;
-        const expirySeconds = options?.expirySeconds ?? this._options.paymentTimeoutSeconds;
-        const maxRoutingBaseFee = options?.maxRoutingBaseFee ?? BigInt(this._options.lightningBaseFee);
-        const maxRoutingPPM = options?.maxRoutingPPM ?? BigInt(this._options.lightningFeePPM);
-        const _options = {
-            expirySeconds,
-            expiryTimestamp: options?.expiryTimestamp ?? BigInt(Math.floor(Date.now() / 1000) + expirySeconds),
-            maxRoutingBaseFee,
-            maxRoutingPPM,
-            maxFee: options?.maxFee ?? this.calculateFeeForAmount(amountOut, maxRoutingBaseFee, maxRoutingPPM)
-        };
+        const _options = this.toRequiredSwapOptions({ ...amountData, amount: amountOut }, options);
         if (parsedPr.tagsObject.payment_hash == null)
             throw new Error("Provided lightning invoice doesn't contain payment hash field!");
         await this.checkPaymentHashWasPaid(parsedPr.tagsObject.payment_hash);
@@ -279,14 +269,14 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
      * @param lp Intermediary (LPs) to get the quote from
      * @param dummyPr Dummy minimum value bolt11 lightning invoice returned from the LNURL-pay, used to estimate
      *  network fees for an actual invoice
-     * @param options Optional additional quote options
+     * @param calculatedOptions Swap options computed from the swap create options
      * @param preFetches Optional existing pre-fetch promises for the swap (only used internally for LNURL swaps)
      * @param abortSignal Abort signal
      * @param additionalParams Additional params to be sent to the intermediary
      *
      * @private
      */
-    async getIntermediaryQuoteExactIn(signer, amountData, invoiceCreateService, lp, dummyPr, options, preFetches, abortSignal, additionalParams) {
+    async getIntermediaryQuoteExactIn(signer, amountData, invoiceCreateService, lp, dummyPr, calculatedOptions, preFetches, abortSignal, additionalParams) {
         if (lp.services[SwapType_1.SwapType.TO_BTCLN] == null)
             throw new Error("LP service for processing to btcln swaps not found!");
         const abortController = (0, Utils_1.extendAbortController)(abortSignal);
@@ -298,8 +288,8 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                     offerer: signer,
                     pr: dummyPr,
                     amount: amountData.amount,
-                    maxFee: await options.maxFee,
-                    expiryTimestamp: options.expiryTimestamp,
+                    maxFee: await calculatedOptions.maxFee,
+                    expiryTimestamp: calculatedOptions.expiryTimestamp,
                     additionalParams
                 }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
                 return {
@@ -331,7 +321,7 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
             const totalFee = resp.swapFee + resp.maxFee;
             const data = new this._swapDataDeserializer(resp.data);
             data.setOfferer(signer);
-            await this.verifyReturnedData(signer, resp, parsedInvoice, amountData.token, lp, options, data, amountData.amount);
+            await this.verifyReturnedData(signer, resp, parsedInvoice, amountData.token, lp, calculatedOptions, data, amountData.amount);
             const [pricingInfo, signatureExpiry, reputation] = await Promise.all([
                 this.verifyReturnedPrice(lp.services[SwapType_1.SwapType.TO_BTCLN], true, prepareResp.amount, data.getAmount(), amountData.token, { networkFee: resp.maxFee }, preFetches.pricePreFetchPromise, preFetches.usdPricePrefetchPromise, abortSignal),
                 this.verifyReturnedSignature(signer, data, resp, preFetches.feeRatePromise, signDataPromise, abortController.signal),
@@ -413,7 +403,7 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                         throw new UserError_1.UserError("Amount more than maximum");
                 }
                 const invoice = await invoiceCreateService.getInvoice(Number(amountData.amount), _abortController.signal);
-                return (await this.create(signer, invoice, amountData, lps, options, additionalParams, _abortController.signal, {
+                return (await this.create(signer, invoice, { ...amountData, exactIn: false }, lps, options, additionalParams, _abortController.signal, {
                     feeRatePromise,
                     pricePreFetchPromise,
                     usdPricePrefetchPromise,

--- a/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.js
+++ b/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.js
@@ -203,7 +203,6 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                 pr,
                 exactIn: false
             });
-            await quote._save();
             return quote;
         }
         catch (e) {
@@ -353,7 +352,6 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                 pr: invoice,
                 exactIn: true
             });
-            await quote._save();
             return quote;
         }
         catch (e) {

--- a/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.js
+++ b/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.js
@@ -23,6 +23,7 @@ const RetryUtils_1 = require("../../../../utils/RetryUtils");
 class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
     constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, options, events) {
         super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, {
+            ...options,
             paymentTimeoutSeconds: options?.paymentTimeoutSeconds ?? 5 * 24 * 60 * 60,
             lightningBaseFee: options?.lightningBaseFee ?? 10,
             lightningFeePPM: options?.lightningFeePPM ?? 2000

--- a/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.js
+++ b/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.js
@@ -160,8 +160,14 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                     feeRate: (0, Utils_1.throwIfUndefined)(preFetches.feeRatePromise),
                     additionalParams
                 }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
+                let signDataPromise = preFetches.signDataPrefetchPromise;
+                if (signDataPromise == null) {
+                    signDataPromise = this.preFetchSignData(signDataPrefetch);
+                }
+                else
+                    signDataPrefetch.catch(() => { });
                 return {
-                    signDataPromise: preFetches.signDataPrefetchPromise ?? this.preFetchSignData(signDataPrefetch),
+                    signDataPromise,
                     resp: await response
                 };
             }, undefined, e => e instanceof RequestError_1.RequestError, abortController.signal);

--- a/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCSwap.d.ts
+++ b/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCSwap.d.ts
@@ -53,7 +53,7 @@ export declare class ToBTCSwap<T extends ChainType = ChainType> extends IToBTCSw
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], BtcToken<false>>;
+    getOutput(): TokenAmount<BtcToken<false>>;
     /**
      * @inheritDoc
      */

--- a/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.d.ts
@@ -14,7 +14,13 @@ import { ISwap } from "../../../ISwap";
 import { AmountData } from "../../../../types/AmountData";
 import { AllOptional } from "../../../../utils/TypeUtils";
 export type ToBTCOptions = {
+    /**
+     * @deprecated Ignored by the LP anyway
+     */
     confirmationTarget?: number;
+    /**
+     * @deprecated Default 2 confirmations should be enough for any currently supported amount by atomiq
+     */
     confirmations?: number;
 };
 export type ToBTCWrapperOptions = ISwapWrapperOptions & {

--- a/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.js
+++ b/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.js
@@ -179,8 +179,14 @@ class ToBTCWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                                 feeRate: (0, Utils_1.throwIfUndefined)(feeRatePromise),
                                 additionalParams
                             }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
+                            let signDataPromise = _signDataPromise;
+                            if (signDataPromise == null) {
+                                signDataPromise = this.preFetchSignData(signDataPrefetch);
+                            }
+                            else
+                                signDataPrefetch.catch(() => { });
                             return {
-                                signDataPromise: _signDataPromise ?? this.preFetchSignData(signDataPrefetch),
+                                signDataPromise,
                                 resp: await response
                             };
                         }, undefined, RequestError_1.RequestError, abortController.signal);

--- a/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.js
+++ b/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.js
@@ -225,7 +225,6 @@ class ToBTCWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                             requiredConfirmations: _options.confirmations,
                             nonce
                         });
-                        await quote._save();
                         return quote;
                     }
                     catch (e) {

--- a/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.js
+++ b/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.js
@@ -35,6 +35,7 @@ class ToBTCWrapper extends IToBTCWrapper_1.IToBTCWrapper {
      */
     constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, btcRpc, options, events) {
         super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, {
+            ...options,
             bitcoinNetwork: options?.bitcoinNetwork ?? utils_1.TEST_NETWORK,
             safetyFactor: options?.safetyFactor ?? 2,
             maxConfirmations: options?.maxConfirmations ?? 6,

--- a/dist/swaps/spv_swaps/SpvFromBTCSwap.d.ts
+++ b/dist/swaps/spv_swaps/SpvFromBTCSwap.d.ts
@@ -119,6 +119,7 @@ export declare function isSpvFromBTCSwapInit(obj: any): obj is SpvFromBTCSwapIni
  * @category Swaps/Bitcoin → Smart chain
  */
 export declare class SpvFromBTCSwap<T extends ChainType> extends ISwap<T, SpvFromBTCTypeDefinition<T>> implements IBTCWalletSwap, ISwapWithGasDrop<T>, IClaimableSwap<T, SpvFromBTCTypeDefinition<T>, SpvFromBTCSwapState> {
+    protected readonly currentVersion: number;
     readonly TYPE: SwapType.SPV_VAULT_FROM_BTC;
     /**
      * @internal
@@ -169,6 +170,7 @@ export declare class SpvFromBTCSwap<T extends ChainType> extends ISwap<T, SpvFro
     private readonly frontingFeeShare;
     private readonly executionFeeShare;
     private readonly gasPricingInfo?;
+    private posted?;
     /**
      * @internal
      */

--- a/dist/swaps/spv_swaps/SpvFromBTCSwap.d.ts
+++ b/dist/swaps/spv_swaps/SpvFromBTCSwap.d.ts
@@ -601,6 +601,7 @@ export declare class SpvFromBTCSwap<T extends ChainType> extends ISwap<T, SpvFro
      * @internal
      */
     _setBitcoinTxId(txId: string): Promise<void>;
+    private btcTxLastChecked?;
     /**
      * @internal
      */

--- a/dist/swaps/spv_swaps/SpvFromBTCSwap.d.ts
+++ b/dist/swaps/spv_swaps/SpvFromBTCSwap.d.ts
@@ -323,7 +323,7 @@ export declare class SpvFromBTCSwap<T extends ChainType> extends ISwap<T, SpvFro
      *
      * @internal
      */
-    protected getOutputWithoutFee(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+    protected getOutputWithoutFee(): TokenAmount<SCToken<T["ChainId"]>, true>;
     /**
      * Returns the swap fee charged by the intermediary (LP) on this swap
      *
@@ -361,15 +361,15 @@ export declare class SpvFromBTCSwap<T extends ChainType> extends ISwap<T, SpvFro
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+    getOutput(): TokenAmount<SCToken<T["ChainId"]>, true>;
     /**
      * @inheritDoc
      */
-    getGasDropOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+    getGasDropOutput(): TokenAmount<SCToken<T["ChainId"]>, true>;
     /**
      * @inheritDoc
      */
-    getInputWithoutFee(): TokenAmount<T["ChainId"], BtcToken<false>, true>;
+    getInputWithoutFee(): TokenAmount<BtcToken<false>, true>;
     /**
      * @inheritDoc
      */
@@ -377,7 +377,7 @@ export declare class SpvFromBTCSwap<T extends ChainType> extends ISwap<T, SpvFro
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], BtcToken<false>, true>;
+    getInput(): TokenAmount<BtcToken<false>, true>;
     /**
      * @inheritDoc
      */
@@ -440,7 +440,7 @@ export declare class SpvFromBTCSwap<T extends ChainType> extends ISwap<T, SpvFro
     /**
      * @inheritDoc
      */
-    estimateBitcoinFee(_bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<any, BtcToken<false>, true> | null>;
+    estimateBitcoinFee(_bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<BtcToken<false>, true> | null>;
     /**
      * @inheritDoc
      */

--- a/dist/swaps/spv_swaps/SpvFromBTCSwap.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCSwap.js
@@ -143,6 +143,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
         if (isSpvFromBTCSwapInit(initOrObject) && initOrObject.url != null)
             initOrObject.url += "/frombtc_spv";
         super(wrapper, initOrObject);
+        this.currentVersion = 2;
         this.TYPE = SwapType_1.SwapType.SPV_VAULT_FROM_BTC;
         /**
          * @internal
@@ -213,6 +214,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
             this._frontTxId = initOrObject.frontTxId;
             this.gasPricingInfo = (0, PriceInfoType_1.deserializePriceInfoType)(initOrObject.gasPricingInfo);
             this.btcTxConfirmedAt = initOrObject.btcTxConfirmedAt;
+            this.posted = initOrObject.posted;
             if (initOrObject.data != null)
                 this._data = new this.wrapper._spvWithdrawalDataDeserializer(initOrObject.data);
         }
@@ -223,7 +225,11 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
      * @inheritDoc
      * @internal
      */
-    upgradeVersion() { }
+    upgradeVersion() {
+        if (this.version === 1) {
+            this.posted = this.initiated;
+        }
+    }
     /**
      * @inheritDoc
      * @internal
@@ -723,6 +729,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
         }
         this._data = data;
         this.initiated = true;
+        this.posted = true;
         await this._saveAndEmit(SpvFromBTCSwapState.SIGNED);
         try {
             await IntermediaryAPI_1.IntermediaryAPI.initSpvFromBTC(this.chainIdentifier, this.url, {
@@ -895,7 +902,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
     async waitForBitcoinTransaction(updateCallback, checkIntervalSeconds, abortSignal) {
         if (this._state !== SpvFromBTCSwapState.POSTED &&
             this._state !== SpvFromBTCSwapState.BROADCASTED &&
-            !(this._state === SpvFromBTCSwapState.QUOTE_SOFT_EXPIRED && this.initiated))
+            !(this._state === SpvFromBTCSwapState.QUOTE_SOFT_EXPIRED && this.posted))
             throw new Error("Must be in POSTED or BROADCASTED state!");
         if (this._data == null)
             throw new Error("Expected swap to have withdrawal data filled!");
@@ -1201,6 +1208,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
             executionFeeShare: this.executionFeeShare.toString(10),
             genesisSmartChainBlockHeight: this._genesisSmartChainBlockHeight,
             gasPricingInfo: (0, PriceInfoType_1.serializePriceInfoType)(this.gasPricingInfo),
+            posted: this.posted,
             senderAddress: this._senderAddress,
             claimTxId: this._claimTxId,
             frontTxId: this._frontTxId,
@@ -1362,7 +1370,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
                 return true;
             }
         }
-        if (this._state === SpvFromBTCSwapState.QUOTE_SOFT_EXPIRED && !this.initiated) {
+        if (this._state === SpvFromBTCSwapState.QUOTE_SOFT_EXPIRED && !this.posted) {
             if (this.expiry < Date.now()) {
                 this._state = SpvFromBTCSwapState.QUOTE_EXPIRED;
                 if (save)

--- a/dist/swaps/spv_swaps/SpvFromBTCSwap.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCSwap.js
@@ -1244,6 +1244,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
         if (this._data?.btcTx == null)
             return false;
         //Check if bitcoin payment was confirmed
+        this.btcTxLastChecked = Date.now();
         const res = await this.getBitcoinPayment();
         if (res == null) {
             //Check inputs double-spent
@@ -1379,7 +1380,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
                 return true;
             }
         }
-        if (Math.floor(Date.now() / 1000) % 120 === 0) {
+        if (this.btcTxLastChecked == null || Date.now() - this.btcTxLastChecked > 120000) {
             if (this._state === SpvFromBTCSwapState.POSTED ||
                 this._state === SpvFromBTCSwapState.BROADCASTED) {
                 try {

--- a/dist/swaps/spv_swaps/SpvFromBTCSwap.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCSwap.js
@@ -228,6 +228,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
     upgradeVersion() {
         if (this.version === 1) {
             this.posted = this.initiated;
+            this.version = 2;
         }
     }
     /**

--- a/dist/swaps/spv_swaps/SpvFromBTCSwap.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCSwap.js
@@ -227,7 +227,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
      */
     upgradeVersion() {
         if (this.version === 1) {
-            this.posted = this.initiated;
+            this.posted = this.initiated && this._data != null;
             this.version = 2;
         }
     }

--- a/dist/swaps/spv_swaps/SpvFromBTCWrapper.d.ts
+++ b/dist/swaps/spv_swaps/SpvFromBTCWrapper.d.ts
@@ -15,9 +15,40 @@ import { IClaimableSwapWrapper } from "../IClaimableSwapWrapper";
 import { AmountData } from "../../types/AmountData";
 import { AllOptional } from "../../utils/TypeUtils";
 export type SpvFromBTCOptions = {
-    gasAmount?: bigint;
+    /**
+     * Optional additional native token to receive as an output of the swap (e.g. STRK on Starknet or cBTC on Citrea).
+     *
+     * When passed as a `bigint` it is specified in base units of the token and in `string` it is the human readable
+     *  decimal format.
+     */
+    gasAmount?: bigint | string;
+    /**
+     * The LP enforces a minimum bitcoin fee rate in sats/vB for the swap transaction. With this config you can optionally
+     *  limit how high of a minimum fee rate would you accept.
+     *
+     * By default the maximum allowed fee rate is calculated dynamically based on current bitcoin fee rate as:
+     *
+     * `maxAllowedBitcoinFeeRate` = 10 + `currentBitcoinFeeRate` * 1.5
+     */
+    maxAllowedBitcoinFeeRate?: number;
+    /**
+     * A flag to attach 0 watchtower fee to the swap, this would make the settlement unattractive for the watchtowers
+     *  and therefore automatic settlement for such swaps will not be possible, you will have to settle manually
+     *  with {@link FromBTCLNSwap.claim} or {@link FromBTCLNSwap.txsClaim} functions.
+     */
     unsafeZeroWatchtowerFee?: boolean;
+    /**
+     * A safety factor to use when estimating the watchtower fee to attach to the swap (this has to cover the gas fee
+     *  of watchtowers settling the swap). A higher multiple here would mean that a swap is more attractive for
+     *  watchtowers to settle automatically.
+     *
+     * Uses a `1.25` multiple by default (i.e. the current network fee is multiplied by 1.25 and then used to estimate
+     *  the settlement gas fee cost)
+     */
     feeSafetyFactor?: number;
+    /**
+     * @deprecated Use `maxAllowedBitcoinFeeRate` instead!
+     */
     maxAllowedNetworkFeeRate?: number;
 };
 export type SpvFromBTCWrapperOptions = ISwapWrapperOptions & {

--- a/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
@@ -90,7 +90,6 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             swap._state === SpvFromBTCSwap_1.SpvFromBTCSwapState.BROADCASTED || swap._state === SpvFromBTCSwap_1.SpvFromBTCSwapState.DECLINED ||
             swap._state === SpvFromBTCSwap_1.SpvFromBTCSwapState.QUOTE_SOFT_EXPIRED || swap._state === SpvFromBTCSwap_1.SpvFromBTCSwapState.BTC_TX_CONFIRMED) {
             swap._state = SpvFromBTCSwap_1.SpvFromBTCSwapState.FRONTED;
-            swap._frontTxId = event.meta?.txId;
             await swap._setBitcoinTxId(event.btcTxId).catch(e => {
                 this.logger.warn("processEventFront(): Failed to set bitcoin txId: ", e);
             });
@@ -104,7 +103,6 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             swap._state === SpvFromBTCSwap_1.SpvFromBTCSwapState.QUOTE_SOFT_EXPIRED || swap._state === SpvFromBTCSwap_1.SpvFromBTCSwapState.FRONTED ||
             swap._state === SpvFromBTCSwap_1.SpvFromBTCSwapState.BTC_TX_CONFIRMED) {
             swap._state = SpvFromBTCSwap_1.SpvFromBTCSwapState.CLAIMED;
-            swap._claimTxId = event.meta?.txId;
             await swap._setBitcoinTxId(event.btcTxId).catch(e => {
                 this.logger.warn("processEventClaim(): Failed to set bitcoin txId: ", e);
             });

--- a/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
@@ -13,6 +13,7 @@ const RequestError_1 = require("../../errors/RequestError");
 const IntermediaryError_1 = require("../../errors/IntermediaryError");
 const btc_signer_1 = require("@scure/btc-signer");
 const RetryUtils_1 = require("../../utils/RetryUtils");
+const UserError_1 = require("../../errors/UserError");
 /**
  * New spv vault (UTXO-controlled vault) based swaps for Bitcoin -> Smart chain swaps not requiring
  *  any initiation on the destination chain, and with the added possibility for the user to receive
@@ -316,7 +317,7 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
                     if (resp.total !== adjustedAmount)
                         throw new IntermediaryError_1.IntermediaryError("Invalid total returned");
                 }
-                if (options.gasAmount == null || options.gasAmount === 0n) {
+                if (options.gasAmount === 0n) {
                     if (resp.totalGas !== 0n)
                         throw new IntermediaryError_1.IntermediaryError("Invalid gas total returned");
                 }
@@ -420,11 +421,13 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
      */
     create(recipient, amountData, lps, options, additionalParams, abortSignal) {
         const _options = {
-            gasAmount: options?.gasAmount ?? 0n,
+            gasAmount: this.parseGasAmount(options?.gasAmount),
             unsafeZeroWatchtowerFee: options?.unsafeZeroWatchtowerFee ?? false,
             feeSafetyFactor: options?.feeSafetyFactor ?? 1.25,
-            maxAllowedNetworkFeeRate: options?.maxAllowedNetworkFeeRate ?? Infinity
+            maxAllowedBitcoinFeeRate: options?.maxAllowedBitcoinFeeRate ?? options?.maxAllowedNetworkFeeRate ?? Infinity
         };
+        if (amountData.token === this._chain.getNativeCurrencyAddress() && _options.gasAmount !== 0n)
+            throw new UserError_1.UserError("Cannot specify `gasAmount` for swaps to a native token!");
         const _abortController = (0, Utils_1.extendAbortController)(abortSignal);
         const pricePrefetchPromise = this.preFetchPrice(amountData, _abortController.signal);
         const usdPricePrefetchPromise = this.preFetchUsdPrice(_abortController.signal);
@@ -434,8 +437,8 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             undefined :
             this.preFetchPrice({ token: nativeTokenAddress }, _abortController.signal);
         const callerFeePrefetchPromise = this.preFetchCallerFeeShare(amountData, _options, pricePrefetchPromise, gasTokenPricePrefetchPromise, _abortController);
-        const bitcoinFeeRatePromise = _options.maxAllowedNetworkFeeRate != Infinity ?
-            Promise.resolve(_options.maxAllowedNetworkFeeRate) :
+        const bitcoinFeeRatePromise = _options.maxAllowedBitcoinFeeRate != Infinity ?
+            Promise.resolve(_options.maxAllowedBitcoinFeeRate) :
             this._btcRpc.getFeeRate().then(x => this._options.maxBtcFeeOffset + (x * this._options.maxBtcFeeMultiplier)).catch(e => {
                 _abortController.abort(e);
                 return undefined;

--- a/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
@@ -507,7 +507,6 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
                             genesisSmartChainBlockHeight: await (0, Utils_1.throwIfUndefined)(finalizedBlockHeightPrefetchPromise, "Finalize block height promise failed!")
                         };
                         const quote = new SpvFromBTCSwap_1.SpvFromBTCSwap(this, swapInit);
-                        await quote._save();
                         return quote;
                     }
                     catch (e) {

--- a/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
@@ -39,6 +39,7 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
      */
     constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, spvWithdrawalDataDeserializer, btcRelay, synchronizer, btcRpc, options, events) {
         super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, {
+            ...options,
             bitcoinNetwork: options?.bitcoinNetwork ?? utils_1.TEST_NETWORK,
             maxConfirmations: options?.maxConfirmations ?? 6,
             bitcoinBlocktime: options?.bitcoinBlocktime ?? 10 * 60,

--- a/dist/swaps/trusted/ln/LnForGasSwap.d.ts
+++ b/dist/swaps/trusted/ln/LnForGasSwap.d.ts
@@ -179,7 +179,7 @@ export declare class LnForGasSwap<T extends ChainType = ChainType> extends ISwap
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+    getOutput(): TokenAmount<SCToken<T["ChainId"]>, true>;
     /**
      * @inheritDoc
      */
@@ -187,11 +187,11 @@ export declare class LnForGasSwap<T extends ChainType = ChainType> extends ISwap
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], BtcToken<true>, true>;
+    getInput(): TokenAmount<BtcToken<true>, true>;
     /**
      * @inheritDoc
      */
-    getInputWithoutFee(): TokenAmount<T["ChainId"], BtcToken<true>, true>;
+    getInputWithoutFee(): TokenAmount<BtcToken<true>, true>;
     /**
      * Returns the swap fee charged by the intermediary (LP) on this swap
      *

--- a/dist/swaps/trusted/ln/LnForGasWrapper.js
+++ b/dist/swaps/trusted/ln/LnForGasWrapper.js
@@ -76,7 +76,6 @@ class LnForGasWrapper extends ISwapWrapper_1.ISwapWrapper {
             exactIn: false
         };
         const quote = new LnForGasSwap_1.LnForGasSwap(this, quoteInit);
-        await quote._save();
         return quote;
     }
 }

--- a/dist/swaps/trusted/onchain/OnchainForGasSwap.d.ts
+++ b/dist/swaps/trusted/onchain/OnchainForGasSwap.d.ts
@@ -199,7 +199,7 @@ export declare class OnchainForGasSwap<T extends ChainType = ChainType> extends 
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>;
+    getOutput(): TokenAmount<SCToken<T["ChainId"]>, true>;
     /**
      * @inheritDoc
      */
@@ -207,11 +207,11 @@ export declare class OnchainForGasSwap<T extends ChainType = ChainType> extends 
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], BtcToken<false>, true>;
+    getInput(): TokenAmount<BtcToken<false>, true>;
     /**
      * @inheritDoc
      */
-    getInputWithoutFee(): TokenAmount<T["ChainId"], BtcToken<false>, true>;
+    getInputWithoutFee(): TokenAmount<BtcToken<false>, true>;
     /**
      * Returns the swap fee charged by the intermediary (LP) on this swap
      *
@@ -255,7 +255,7 @@ export declare class OnchainForGasSwap<T extends ChainType = ChainType> extends 
     /**
      * @inheritDoc
      */
-    estimateBitcoinFee(_bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<any, BtcToken<false>, true> | null>;
+    estimateBitcoinFee(_bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<BtcToken<false>, true> | null>;
     /**
      * @inheritDoc
      */

--- a/dist/swaps/trusted/onchain/OnchainForGasWrapper.js
+++ b/dist/swaps/trusted/onchain/OnchainForGasWrapper.js
@@ -86,7 +86,6 @@ class OnchainForGasWrapper extends ISwapWrapper_1.ISwapWrapper {
             exactIn: false,
             token
         });
-        await quote._save();
         return quote;
     }
 }

--- a/dist/types/Token.d.ts
+++ b/dist/types/Token.d.ts
@@ -1,15 +1,40 @@
 /**
+ * Type for all token types (BTC or smart chain)
+ *
+ * @category Tokens
+ */
+export type Token<ChainIdentifier extends string = string> = {
+    chainId: ChainIdentifier | "BITCOIN" | "LIGHTNING";
+    ticker: string;
+    name: string;
+    decimals: number;
+    displayDecimals?: number;
+    address: string;
+    chain: "SC" | "BTC";
+    lightning?: boolean;
+    equals: (other: Token) => boolean;
+    toString: () => string;
+};
+/**
+ * Type guard for a {@link Token} type, encompassing all tokens (BTC or smart chain)
+ *
+ * @category Tokens
+ */
+export declare function isToken(obj: any): obj is Token;
+/**
  * Bitcoin token type (BTC on on-chain or lightning)
  *
  * @category Tokens
  */
-export type BtcToken<L = boolean> = {
+export type BtcToken<L = boolean> = Token & {
+    chainId: L extends true ? "LIGHTNING" : "BITCOIN";
+    ticker: "BTC";
+    name: L extends true ? "Bitcoin (lightning L2)" : "Bitcoin (on-chain L1)";
+    decimals: 8;
+    displayDecimals: 8;
+    address: "";
     chain: "BTC";
     lightning: L;
-    ticker: "BTC";
-    decimals: 8;
-    name: L extends true ? "Bitcoin (lightning L2)" : "Bitcoin (on-chain L1)";
-    displayDecimals?: number;
 };
 /**
  * Type guard for {@link BtcToken} (token on the bitcoin network - lightning or on-chain)
@@ -31,29 +56,12 @@ export declare const BitcoinTokens: {
  *
  * @category Tokens
  */
-export type SCToken<ChainIdentifier extends string = string> = {
-    chain: "SC";
+export type SCToken<ChainIdentifier extends string = string> = Token<ChainIdentifier> & {
     chainId: ChainIdentifier;
-    address: string;
-    ticker: string;
-    decimals: number;
-    displayDecimals?: number;
-    name: string;
+    chain: "SC";
 };
 /**
  * Type guard for {@link SCToken} (token on the smart chain)
  * @category Tokens
  */
-export declare function isSCToken(obj: any): obj is SCToken;
-/**
- * Union type for all token types (BTC or smart chain)
- *
- * @category Tokens
- */
-export type Token<ChainIdentifier extends string = string> = BtcToken | SCToken<ChainIdentifier>;
-/**
- * Type guard for an union {@link Token} type, encompassing all tokens (BTC or smart chain)
- *
- * @category Tokens
- */
-export declare function isToken(obj: any): obj is Token;
+export declare function isSCToken<ChainIdentifier extends string = string>(obj: any, chainIdentifier?: ChainIdentifier[]): obj is SCToken<ChainIdentifier>;

--- a/dist/types/Token.d.ts
+++ b/dist/types/Token.d.ts
@@ -4,15 +4,45 @@
  * @category Tokens
  */
 export type Token<ChainIdentifier extends string = string> = {
+    /**
+     * Chain identifier for the token's chain
+     */
     chainId: ChainIdentifier | "BITCOIN" | "LIGHTNING";
+    /**
+     * Ticker of the token
+     */
     ticker: string;
+    /**
+     * Full name of the token
+     */
     name: string;
+    /**
+     * Actual decimal places of the tokens
+     */
     decimals: number;
+    /**
+     * The decimal places that should be rendered and displayed to the user
+     */
     displayDecimals?: number;
+    /**
+     * Address of the token contract, or `""` for Bitcoin
+     */
     address: string;
+    /**
+     * Legacy chain identifier distinguishing between Smart Chain and Bitcoin tokens
+     */
     chain: "SC" | "BTC";
+    /**
+     * Legacy lightning flag, determines whether a Bitcoin token is an Lightning or on-chain one
+     */
     lightning?: boolean;
+    /**
+     * Equality check between tokens
+     */
     equals: (other: Token) => boolean;
+    /**
+     * Returns the
+     */
     toString: () => string;
 };
 /**
@@ -35,6 +65,7 @@ export type BtcToken<L = boolean> = Token & {
     address: "";
     chain: "BTC";
     lightning: L;
+    toString: () => L extends true ? "BTC-LN" : "BTC";
 };
 /**
  * Type guard for {@link BtcToken} (token on the bitcoin network - lightning or on-chain)
@@ -59,6 +90,7 @@ export declare const BitcoinTokens: {
 export type SCToken<ChainIdentifier extends string = string> = Token<ChainIdentifier> & {
     chainId: ChainIdentifier;
     chain: "SC";
+    toString: () => `${ChainIdentifier}-${string}`;
 };
 /**
  * Type guard for {@link SCToken} (token on the smart chain)

--- a/dist/types/Token.js
+++ b/dist/types/Token.js
@@ -1,6 +1,19 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isToken = exports.isSCToken = exports.BitcoinTokens = exports.isBtcToken = void 0;
+exports.isSCToken = exports.BitcoinTokens = exports.isBtcToken = exports.isToken = void 0;
+/**
+ * Type guard for a {@link Token} type, encompassing all tokens (BTC or smart chain)
+ *
+ * @category Tokens
+ */
+function isToken(obj) {
+    return typeof (obj) === "object" &&
+        (obj.chain === "SC" || obj.chain === "BTC") &&
+        typeof (obj.ticker) === "string" &&
+        typeof (obj.decimals) === "number" &&
+        typeof (obj.name) === "string";
+}
+exports.isToken = isToken;
 /**
  * Type guard for {@link BtcToken} (token on the bitcoin network - lightning or on-chain)
  *
@@ -23,39 +36,41 @@ exports.isBtcToken = isBtcToken;
 exports.BitcoinTokens = {
     BTC: {
         chain: "BTC",
+        chainId: "BITCOIN",
         lightning: false,
         ticker: "BTC",
         decimals: 8,
-        name: "Bitcoin (on-chain L1)"
+        displayDecimals: 8,
+        name: "Bitcoin (on-chain L1)",
+        address: "",
+        equals: (other) => other.chainId === "BITCOIN" && other.ticker === "BTC",
+        toString: () => "BTC"
     },
     BTCLN: {
         chain: "BTC",
+        chainId: "LIGHTNING",
         lightning: true,
         ticker: "BTC",
         decimals: 8,
-        name: "Bitcoin (lightning L2)"
+        displayDecimals: 8,
+        name: "Bitcoin (lightning L2)",
+        address: "",
+        equals: (other) => other.chainId === "LIGHTNING" && other.ticker === "BTC",
+        toString: () => "BTC-LN"
     }
 };
 /**
  * Type guard for {@link SCToken} (token on the smart chain)
  * @category Tokens
  */
-function isSCToken(obj) {
+function isSCToken(obj, chainIdentifier) {
     return typeof (obj) === "object" &&
         obj.chain === "SC" &&
         typeof (obj.chainId) === "string" &&
+        (chainIdentifier == null || chainIdentifier.includes(obj.chainId)) &&
         typeof (obj.address) === "string" &&
         typeof (obj.ticker) === "string" &&
         typeof (obj.decimals) === "number" &&
         typeof (obj.name) === "string";
 }
 exports.isSCToken = isSCToken;
-/**
- * Type guard for an union {@link Token} type, encompassing all tokens (BTC or smart chain)
- *
- * @category Tokens
- */
-function isToken(obj) {
-    return isBtcToken(obj) || isSCToken(obj);
-}
-exports.isToken = isToken;

--- a/dist/types/TokenAmount.d.ts
+++ b/dist/types/TokenAmount.d.ts
@@ -6,7 +6,7 @@ import { PriceInfoType } from "./PriceInfoType";
  *
  * @category Tokens
  */
-export type TokenAmount<ChainIdentifier extends string = string, T extends Token<ChainIdentifier> = Token<ChainIdentifier>, Known extends boolean = boolean> = {
+export type TokenAmount<T extends Token = Token, Known extends boolean = boolean> = {
     /**
      * Raw amount in base units represented as bigint, might be `undefined` when the amount is unknown
      */
@@ -66,4 +66,4 @@ export type TokenAmount<ChainIdentifier extends string = string, T extends Token
  * @category Tokens
  * @internal
  */
-export declare function toTokenAmount<ChainIdentifier extends string = string, T extends Token<ChainIdentifier> = Token<ChainIdentifier>, Known extends boolean = boolean>(amount: Known extends true ? bigint : null, token: T, prices: ISwapPrice, pricingInfo?: PriceInfoType): TokenAmount<ChainIdentifier, T, Known>;
+export declare function toTokenAmount<T extends Token = Token, Known extends boolean = boolean>(amount: Known extends true ? bigint : null, token: T, prices: ISwapPrice, pricingInfo?: PriceInfoType): TokenAmount<T, Known>;

--- a/dist/types/fees/Fee.d.ts
+++ b/dist/types/fees/Fee.d.ts
@@ -11,11 +11,11 @@ export type Fee<ChainIdentifier extends string = string, TSrc extends Token<Chai
     /**
      * Fee value equivalent in source token
      */
-    amountInSrcToken: TokenAmount<ChainIdentifier, TSrc, true>;
+    amountInSrcToken: TokenAmount<TSrc, true>;
     /**
      * Fee value equivalent in destination token
      */
-    amountInDstToken: TokenAmount<ChainIdentifier, TDst, true>;
+    amountInDstToken: TokenAmount<TDst, true>;
     /**
      * Fetches the current USD value of the fee
      *
@@ -44,7 +44,7 @@ export type Fee<ChainIdentifier extends string = string, TSrc extends Token<Chai
      *  base_fee + amount * percentage_fee
      */
     composition?: {
-        base: TokenAmount<ChainIdentifier>;
+        base: TokenAmount;
         percentage: PercentagePPM;
     };
 };

--- a/dist/utils/Utils.d.ts
+++ b/dist/utils/Utils.d.ts
@@ -55,3 +55,4 @@ export declare function randomBytes(bytesLength: number): Buffer;
 export declare function getTxoHash(outputScriptHex: string, value: number): Buffer;
 export declare function fromDecimal(amount: string, decimalCount: number): bigint;
 export declare function toDecimal(amount: bigint, decimalCount: number, cut?: boolean, displayDecimals?: number): string;
+export declare function parseHashValueExact32Bytes(value?: Buffer | string, variableName?: string): Buffer | undefined;

--- a/dist/utils/Utils.js
+++ b/dist/utils/Utils.js
@@ -1,10 +1,11 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.toDecimal = exports.fromDecimal = exports.getTxoHash = exports.randomBytes = exports.toBigInt = exports.bigIntCompare = exports.bigIntMax = exports.bigIntMin = exports.extendAbortController = exports.mapToArray = exports.objectMap = exports.promiseAny = exports.throwIfUndefined = void 0;
+exports.parseHashValueExact32Bytes = exports.toDecimal = exports.fromDecimal = exports.getTxoHash = exports.randomBytes = exports.toBigInt = exports.bigIntCompare = exports.bigIntMax = exports.bigIntMin = exports.extendAbortController = exports.mapToArray = exports.objectMap = exports.promiseAny = exports.throwIfUndefined = void 0;
 const buffer_1 = require("buffer");
 const utils_1 = require("@noble/hashes/utils");
 const sha2_1 = require("@noble/hashes/sha2");
 const base_1 = require("@atomiqlabs/base");
+const UserError_1 = require("../errors/UserError");
 /**
  * Returns a promise that rejects if the passed promise resolves to `undefined` or `null`
  *
@@ -176,3 +177,18 @@ function toDecimal(amount, decimalCount, cut, displayDecimals) {
     return amountStr.substring(0, splitPoint) + "." + decimalPart.substring(0, cutTo);
 }
 exports.toDecimal = toDecimal;
+function parseHashValueExact32Bytes(value, variableName) {
+    let hash;
+    if (typeof (value) === "string") {
+        if (value.length !== 64)
+            throw new UserError_1.UserError(`Invalid ${variableName} length, must be exactly 64 hexadecimal characters!`);
+        hash = buffer_1.Buffer.from(value, "hex");
+    }
+    else {
+        hash = value;
+    }
+    if (hash != null && hash.length !== 32)
+        throw new UserError_1.UserError(`Invalid ${variableName} length, must be exactly 32 bytes!`);
+    return hash;
+}
+exports.parseHashValueExact32Bytes = parseHashValueExact32Bytes;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.4.5",
+  "version": "8.4.6",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.4.4",
+  "version": "8.4.5",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.4.7",
+  "version": "8.5.0",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.4.6",
+  "version": "8.4.7",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/src/enums/SwapSide.ts
+++ b/src/enums/SwapSide.ts
@@ -1,0 +1,16 @@
+
+/**
+ * Enum representing the side of the swap for querying available input/output tokens
+ *
+ * @category Core
+ */
+export enum SwapSide {
+    /**
+     * Represents input / source side of the swap
+     */
+    INPUT = 1,
+    /**
+     * Represents output / destination side of the swap
+     */
+    OUTPUT = 0
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export {CoinselectAddressTypes} from "./bitcoin/coinselect2";
 export * from "./enums/FeeType";
 export * from "./enums/SwapAmountType";
 export * from "./enums/SwapDirection";
+export * from "./enums/SwapSide";
 export * from "./enums/SwapType";
 
 export * from "./errors/IntermediaryError";

--- a/src/intermediaries/apis/IntermediaryAPI.ts
+++ b/src/intermediaries/apis/IntermediaryAPI.ts
@@ -204,9 +204,9 @@ export type FromBTCInit = BaseFromBTCSwapInit & {
     sequence: bigint,
     claimerBounty: Promise<{
         feePerBlock: bigint,
-        safetyFactor: number,
+        safetyFactor: bigint,
         startTimestamp: bigint,
-        addBlock: number,
+        addBlock: bigint,
         addFee: bigint
     }>
 }
@@ -532,9 +532,9 @@ export class IntermediaryAPI {
                 claimerBounty: init.claimerBounty.then(claimerBounty => {
                     return {
                         feePerBlock: claimerBounty.feePerBlock.toString(10),
-                        safetyFactor: claimerBounty.safetyFactor,
+                        safetyFactor: claimerBounty.safetyFactor.toString(10),
                         startTimestamp: claimerBounty.startTimestamp.toString(10),
-                        addBlock: claimerBounty.addBlock,
+                        addBlock: claimerBounty.addBlock.toString(10),
                         addFee: claimerBounty.addFee.toString(10)
                     }
                 }),

--- a/src/storage/UnifiedSwapStorage.ts
+++ b/src/storage/UnifiedSwapStorage.ts
@@ -18,6 +18,7 @@ const indexes = [
  * Simple index types for SDK swap storage
  *
  * @category Storage
+ * @useDeclaredType
  */
 export type UnifiedSwapStorageIndexes = typeof indexes;
 
@@ -31,6 +32,7 @@ const compositeIndexes = [
  * Composite index types for SDK swap storage
  *
  * @category Storage
+ * @useDeclaredType
  */
 export type UnifiedSwapStorageCompositeIndexes = typeof compositeIndexes;
 

--- a/src/storage/UnifiedSwapStorage.ts
+++ b/src/storage/UnifiedSwapStorage.ts
@@ -89,6 +89,7 @@ export class UnifiedSwapStorage<T extends ChainType> {
             }
             const value = reviver(rawObj);
             if(value==null) return;
+            value._persisted = true;
             if(!this.noWeakRefMap) this.weakRefCache.set(rawObj.id, new WeakRef<ISwap<T>>(value));
             result.push(value);
         });
@@ -101,36 +102,40 @@ export class UnifiedSwapStorage<T extends ChainType> {
      *
      * @param value Swap to save
      */
-    save<S extends ISwap<T>>(value: S): Promise<void> {
+    async save<S extends ISwap<T>>(value: S): Promise<void> {
         if(!this.noWeakRefMap) this.weakRefCache.set(value.getId(), new WeakRef<ISwap<T>>(value));
-        return this.storage.save(value.serialize());
+        await this.storage.save(value.serialize());
+        value._persisted = true;
     }
 
     /**
      * Saves multiple swaps to storage in a batch operation
      * @param values Array of swaps to save
      */
-    saveAll<S extends ISwap<T>>(values: S[]): Promise<void> {
+    async saveAll<S extends ISwap<T>>(values: S[]): Promise<void> {
         if(!this.noWeakRefMap) values.forEach(value => this.weakRefCache.set(value.getId(), new WeakRef<ISwap<T>>(value)));
-        return this.storage.saveAll(values.map(obj => obj.serialize()));
+        await this.storage.saveAll(values.map(obj => obj.serialize()));
+        values.forEach(value => value._persisted = true);
     }
 
     /**
      * Removes a swap from storage
      * @param value Swap to remove
      */
-    remove<S extends ISwap<T>>(value: S): Promise<void> {
+    async remove<S extends ISwap<T>>(value: S): Promise<void> {
         if(!this.noWeakRefMap) this.weakRefCache.delete(value.getId());
-        return this.storage.remove(value.serialize());
+        await this.storage.remove(value.serialize());
+        value._persisted = false;
     }
 
     /**
      * Removes multiple swaps from storage in a batch operation
      * @param values Array of swaps to remove
      */
-    removeAll<S extends ISwap<T>>(values: S[]): Promise<void> {
+    async removeAll<S extends ISwap<T>>(values: S[]): Promise<void> {
         if(!this.noWeakRefMap) values.forEach(value => this.weakRefCache.delete(value.getId()));
-        return this.storage.removeAll(values.map(obj => obj.serialize()));
+        await this.storage.removeAll(values.map(obj => obj.serialize()));
+        values.forEach(value => value._persisted = false);
     }
 
 }

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -202,6 +202,16 @@ type CtorMultiChainData<T extends MultiChain> = {
     [chainIdentifier in keyof T]: ChainData<T[chainIdentifier]>
 };
 
+type SwapperCtorTokens<T extends MultiChain = MultiChain> = {
+    ticker: string,
+    name: string,
+    chains: {[chainId in ChainIds<T>]?: {
+        address: string,
+        decimals: number,
+        displayDecimals?: number
+    }}
+}[];
+
 /**
  * Type extracting chain identifiers from a MultiChain type
  * @category Core
@@ -300,7 +310,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         bitcoinSynchronizer: (btcRelay: BtcRelay<any, any, any>) => RelaySynchronizer<any, any, any>,
         chainsData: CtorMultiChainData<T>,
         pricing: ISwapPrice<T>,
-        tokens: WrapperCtorTokens<T>,
+        tokens: SwapperCtorTokens<T>,
         messenger: Messenger,
         options?: SwapperOptions
     ) {
@@ -341,7 +351,9 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                     name: tokenData.name,
                     decimals: chainData.decimals,
                     displayDecimals: chainData.displayDecimals,
-                    address: chainData.address
+                    address: chainData.address,
+                    equals: (other: Token) => other.chainId===chainId && other.ticker===tokenData.ticker && other.address===chainData.address,
+                    toString: () => chainId + "-" + tokenData.ticker
                 }
             }
         }
@@ -353,11 +365,12 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         this._chains = objectMap<CtorMultiChainData<T>, MultiChainData<T>>(chainsData, <InputKey extends keyof CtorMultiChainData<T>>(chainData: CtorMultiChainData<T>[InputKey], key: string) => {
             const {
                 swapContract, chainEvents, btcRelay,
-                chainInterface, spvVaultContract, spvVaultWithdrawalDataConstructor
+                chainInterface, spvVaultContract, spvVaultWithdrawalDataConstructor,
+                chainId
             } = chainData;
             const synchronizer = bitcoinSynchronizer(btcRelay);
 
-            const storageHandler = swapStorage(storagePrefix + chainData.chainId);
+            const storageHandler = swapStorage(storagePrefix + chainId);
             const unifiedSwapStorage = new UnifiedSwapStorage<T[InputKey]>(storageHandler, this.options.noSwapCache);
             const unifiedChainEvents = new UnifiedSwapEventListener<T[InputKey]>(unifiedSwapStorage, chainEvents);
 
@@ -370,7 +383,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 chainInterface,
                 swapContract,
                 pricing,
-                tokens,
+                this._tokens[chainId],
                 chainData.swapDataConstructor,
                 {
                     getRequestTimeout: this.options.getRequestTimeout,
@@ -384,7 +397,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 chainInterface,
                 swapContract,
                 pricing,
-                tokens,
+                this._tokens[chainId],
                 chainData.swapDataConstructor,
                 this._bitcoinRpc,
                 {
@@ -400,7 +413,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 chainInterface,
                 swapContract,
                 pricing,
-                tokens,
+                this._tokens[chainId],
                 chainData.swapDataConstructor,
                 lightningApi,
                 {
@@ -416,7 +429,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 chainInterface,
                 swapContract,
                 pricing,
-                tokens,
+                this._tokens[chainId],
                 chainData.swapDataConstructor,
                 btcRelay,
                 synchronizer,
@@ -433,7 +446,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 unifiedChainEvents,
                 chainInterface,
                 pricing,
-                tokens,
+                this._tokens[chainId],
                 {
                     getRequestTimeout: this.options.getRequestTimeout,
                     postRequestTimeout: this.options.postRequestTimeout
@@ -445,7 +458,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 unifiedChainEvents,
                 chainInterface,
                 pricing,
-                tokens,
+                this._tokens[chainId],
                 bitcoinRpc,
                 {
                     getRequestTimeout: this.options.getRequestTimeout,
@@ -462,7 +475,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                     chainInterface,
                     spvVaultContract,
                     pricing,
-                    tokens,
+                    this._tokens[chainId],
                     spvVaultWithdrawalDataConstructor,
                     btcRelay,
                     synchronizer,
@@ -483,7 +496,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                     chainInterface,
                     swapContract,
                     pricing,
-                    tokens,
+                    this._tokens[chainId],
                     chainData.swapDataConstructor,
                     lightningApi,
                     this.messenger,
@@ -1471,8 +1484,8 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         const srcToken = typeof(_srcToken)==="string" ? this.getToken(_srcToken) as Token<C> : _srcToken;
         const dstToken = typeof(_dstToken)==="string" ? this.getToken(_dstToken) as Token<C> : _dstToken;
         const amount = _amount==null ? null : (typeof(_amount)==="bigint" ? _amount : fromDecimal(_amount, exactIn ? srcToken.decimals : dstToken.decimals));
-        if(srcToken.chain==="BTC") {
-            if(dstToken.chain==="SC") {
+        if(isBtcToken(srcToken)) {
+            if(isSCToken<C>(dstToken)) {
                 if(typeof(dst)!=="string") throw new Error("Destination for BTC/BTC-LN -> smart chain swaps must be a smart chain address!");
                 if(amount==null) throw new Error("Amount cannot be null for from btc swaps!");
                 if(srcToken.lightning) {
@@ -1496,8 +1509,8 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                     }
                 }
             }
-        } else {
-            if(dstToken.chain==="BTC") {
+        } else if(isSCToken<C>(srcToken)) {
+            if(isBtcToken(dstToken)) {
                 if(typeof(src)!=="string") throw new Error("Source address for BTC/BTC-LN -> smart chain swaps must be a smart chain address!");
                 if(dstToken.lightning) {
                     //TO_BTCLN
@@ -1996,8 +2009,8 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
      */
     getToken(tickerOrAddress: string): Token<ChainIds<T>> {
         //Btc tokens - BTC, BTCLN, BTC-LN
-        if(tickerOrAddress==="BTC") return BitcoinTokens.BTC;
-        if(tickerOrAddress==="BTCLN" || tickerOrAddress==="BTC-LN") return BitcoinTokens.BTCLN;
+        if(tickerOrAddress==="BTC" || tickerOrAddress==="BITCOIN-BTC") return BitcoinTokens.BTC;
+        if(tickerOrAddress==="BTCLN" || tickerOrAddress==="BTC-LN" || tickerOrAddress==="LIGHTNING-BTC") return BitcoinTokens.BTCLN;
 
         //Check if the ticker is in format <chainId>-<ticker>, i.e. SOLANA-USDC, STARKNET-WBTC
         if(tickerOrAddress.includes("-")) {

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -316,7 +316,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         bitcoinSynchronizer: (btcRelay: BtcRelay<any, any, any>) => RelaySynchronizer<any, any, any>,
         chainsData: CtorMultiChainData<T>,
         pricing: ISwapPrice<T>,
-        tokens: SwapperCtorTokens<T>,
+        tokens: SCToken[],
         messenger: Messenger,
         options?: SwapperOptions
     ) {
@@ -347,22 +347,10 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         this._tokens = {};
         this._tokensByTicker = {};
         for(let tokenData of tokens) {
-            for(let chainId in tokenData.chains) {
-                const chainData = tokenData.chains[chainId]!;
-                this._tokens[chainId] ??= {};
-                this._tokensByTicker[chainId] ??= {};
-                this._tokens[chainId][chainData.address] = this._tokensByTicker[chainId][tokenData.ticker] = {
-                    chain: "SC",
-                    chainId,
-                    ticker: tokenData.ticker,
-                    name: tokenData.name,
-                    decimals: chainData.decimals,
-                    displayDecimals: chainData.displayDecimals,
-                    address: chainData.address,
-                    equals: (other: Token) => other.chainId===chainId && other.ticker===tokenData.ticker && other.address===chainData.address,
-                    toString: () => `${chainId}-${tokenData.ticker}`
-                }
-            }
+            const chainId = tokenData.chainId;
+            this._tokens[chainId] ??= {};
+            this._tokensByTicker[chainId] ??= {};
+            this._tokens[chainId][tokenData.address] = this._tokensByTicker[chainId][tokenData.ticker] = tokenData;
         }
 
         this.swapStateListener = (swap: ISwap) => {

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -889,9 +889,6 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         if(!this.Utils.isValidBitcoinAddress(address)) throw new Error("Invalid bitcoin address");
         if(!this._chains[chainIdentifier].chainInterface.isValidAddress(signer, true)) throw new Error("Invalid "+chainIdentifier+" address");
         signer = this._chains[chainIdentifier].chainInterface.normalizeAddress(signer);
-        options ??= {};
-        options.confirmationTarget ??= 3;
-        options.confirmations ??= 2;
         const amountData = {
             amount,
             token: tokenAddress,
@@ -933,7 +930,6 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         options?: ToBTCLNOptions
     ): Promise<ToBTCLNSwap<T[ChainIdentifier]>> {
         if(this._chains[chainIdentifier]==null) throw new Error("Invalid chain identifier! Unknown chain: "+chainIdentifier);
-        options ??= {};
         if(paymentRequest.startsWith("lightning:")) paymentRequest = paymentRequest.substring(10);
         if(!this.Utils.isValidLightningInvoice(paymentRequest)) throw new Error("Invalid lightning network invoice");
         if(!this._chains[chainIdentifier].chainInterface.isValidAddress(signer, true)) throw new Error("Invalid "+chainIdentifier+" address");
@@ -943,9 +939,8 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         const amountData = {
             amount: (BigInt(parsedPR.millisatoshis) + 999n) / 1000n,
             token: tokenAddress,
-            exactIn: false
+            exactIn: false as const
         };
-        options.expirySeconds ??= 5*24*3600;
         return this.createSwap(
             chainIdentifier as ChainIdentifier,
             (candidates: Intermediary[], abortSignal: AbortSignal, chain) => chain.wrappers[SwapType.TO_BTCLN].create(
@@ -993,8 +988,6 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
             token: tokenAddress,
             exactIn
         };
-        options ??= {};
-        options.expirySeconds ??= 5*24*3600;
         return this.createSwap(
             chainIdentifier as ChainIdentifier,
             (candidates: Intermediary[], abortSignal: AbortSignal, chain) => chain.wrappers[SwapType.TO_BTCLN].createViaLNURL(
@@ -1036,13 +1029,11 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         if(this._chains[chainIdentifier]==null) throw new Error("Invalid chain identifier! Unknown chain: "+chainIdentifier);
         if(!this._chains[chainIdentifier].chainInterface.isValidAddress(signer, true)) throw new Error("Invalid "+chainIdentifier+" address");
         signer = this._chains[chainIdentifier].chainInterface.normalizeAddress(signer);
-        options ??= {};
         const amountData = {
             amount,
             token: tokenAddress,
             exactIn
         };
-        options.expirySeconds ??= 5*24*3600;
         return this.createSwap(
             chainIdentifier as ChainIdentifier,
             (candidates: Intermediary[], abortSignal: AbortSignal, chain) => chain.wrappers[SwapType.TO_BTCLN].createViaInvoiceCreateService(

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -2155,8 +2155,8 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
      * @param dstToken Destination token
      */
     getSwapLimits<C extends ChainIds<T>, A extends Token<C>, B extends Token<C>>(srcToken: A, dstToken: B): {
-        input: {min: TokenAmount<string, A>, max?: TokenAmount<string, A>},
-        output: {min: TokenAmount<string, B>, max?: TokenAmount<string, B>}
+        input: {min: TokenAmount<A>, max?: TokenAmount<A>},
+        output: {min: TokenAmount<B>, max?: TokenAmount<B>}
     } {
         const swapType = this.getSwapType(srcToken, dstToken);
         const scToken = isSCToken(srcToken) ? srcToken : isSCToken(dstToken) ? dstToken : null;

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -1322,13 +1322,15 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
      * @param trustedIntermediaryOrUrl  URL or Intermediary object of the trusted intermediary to use, otherwise uses default
      * @throws {Error} If no trusted intermediary specified
      */
-    createTrustedLNForGasSwap<C extends ChainIds<T>>(chainIdentifier: C, recipient: string, amount: bigint, trustedIntermediaryOrUrl?: Intermediary | string): Promise<LnForGasSwap<T[C]>> {
+    async createTrustedLNForGasSwap<C extends ChainIds<T>>(chainIdentifier: C, recipient: string, amount: bigint, trustedIntermediaryOrUrl?: Intermediary | string): Promise<LnForGasSwap<T[C]>> {
         if(this._chains[chainIdentifier]==null) throw new Error("Invalid chain identifier! Unknown chain: "+chainIdentifier);
         if(!this._chains[chainIdentifier].chainInterface.isValidAddress(recipient, true)) throw new Error("Invalid "+chainIdentifier+" address");
         recipient = this._chains[chainIdentifier].chainInterface.normalizeAddress(recipient);
         const useUrl = trustedIntermediaryOrUrl ?? this.defaultTrustedIntermediary ?? this.options.defaultTrustedIntermediaryUrl;
         if(useUrl==null) throw new Error("No trusted intermediary specified!");
-        return this._chains[chainIdentifier as C].wrappers[SwapType.TRUSTED_FROM_BTCLN].create(recipient, amount, useUrl);
+        const swap = await this._chains[chainIdentifier as C].wrappers[SwapType.TRUSTED_FROM_BTCLN].create(recipient, amount, useUrl);
+        await swap._save();
+        return swap;
     }
 
     /**
@@ -1341,7 +1343,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
      * @param trustedIntermediaryOrUrl URL or Intermediary object of the trusted intermediary to use, otherwise uses default
      * @throws {Error} If no trusted intermediary specified
      */
-    createTrustedOnchainForGasSwap<C extends ChainIds<T>>(
+    async createTrustedOnchainForGasSwap<C extends ChainIds<T>>(
         chainIdentifier: C, recipient: string,
         amount: bigint, refundAddress?: string,
         trustedIntermediaryOrUrl?: Intermediary | string
@@ -1351,7 +1353,9 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         recipient = this._chains[chainIdentifier].chainInterface.normalizeAddress(recipient);
         const useUrl = trustedIntermediaryOrUrl ?? this.defaultTrustedIntermediary ?? this.options.defaultTrustedIntermediaryUrl;
         if(useUrl==null) throw new Error("No trusted intermediary specified!");
-        return this._chains[chainIdentifier as C].wrappers[SwapType.TRUSTED_FROM_BTC].create(recipient, amount, useUrl, refundAddress);
+        const swap = await this._chains[chainIdentifier as C].wrappers[SwapType.TRUSTED_FROM_BTC].create(recipient, amount, useUrl, refundAddress);
+        await swap._save();
+        return swap;
     }
 
     /**

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -353,7 +353,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                     displayDecimals: chainData.displayDecimals,
                     address: chainData.address,
                     equals: (other: Token) => other.chainId===chainId && other.ticker===tokenData.ticker && other.address===chainData.address,
-                    toString: () => chainId + "-" + tokenData.ticker
+                    toString: () => `${chainId}-${tokenData.ticker}`
                 }
             }
         }
@@ -1428,23 +1428,23 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
     /**
      * @internal
      */
-    swap<C extends ChainIds<T>>(srcToken: BtcToken<true>, dstToken: SCToken<C>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string | LNURLWithdraw, dstSmartchainWallet: string, options?: (SupportsSwapType<T[C], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoOptions : FromBTCLNOptions)): Promise<(SupportsSwapType<T[C], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoSwap<T[C]> : FromBTCLNSwap<T[C]>)>;
+    swap<C extends ChainIds<T>>(srcToken: BtcToken<true> | "BTCLN" | "BTC-LN" | "LIGHTNING-BTC", dstToken: SCToken<C> | string, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string | LNURLWithdraw, dstSmartchainWallet: string, options?: (SupportsSwapType<T[C], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoOptions : FromBTCLNOptions)): Promise<(SupportsSwapType<T[C], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoSwap<T[C]> : FromBTCLNSwap<T[C]>)>;
     /**
      * @internal
      */
-    swap<C extends ChainIds<T>>(srcToken: BtcToken<false>, dstToken: SCToken<C>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string, dstSmartchainWallet: string, options?: (SupportsSwapType<T[C], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCOptions : FromBTCOptions)): Promise<(SupportsSwapType<T[C], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCSwap<T[C]> : FromBTCSwap<T[C]>)>;
+    swap<C extends ChainIds<T>>(srcToken: BtcToken<false> | "BTC" | "BITCOIN-BTC", dstToken: SCToken<C> | string, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string, dstSmartchainWallet: string, options?: (SupportsSwapType<T[C], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCOptions : FromBTCOptions)): Promise<(SupportsSwapType<T[C], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCSwap<T[C]> : FromBTCSwap<T[C]>)>;
     /**
      * @internal
      */
-    swap<C extends ChainIds<T>>(srcToken: SCToken<C>, dstToken: BtcToken<false>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstAddress: string, options?: ToBTCOptions): Promise<ToBTCSwap<T[C]>>;
+    swap<C extends ChainIds<T>>(srcToken: SCToken<C> | string, dstToken: BtcToken<false> | "BTC" | "BITCOIN-BTC", amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstAddress: string, options?: ToBTCOptions): Promise<ToBTCSwap<T[C]>>;
     /**
      * @internal
      */
-    swap<C extends ChainIds<T>>(srcToken: SCToken<C>, dstToken: BtcToken<true>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstLnurlPayOrInvoiceCreateService: string | LNURLPay | LightningInvoiceCreateService, options?: ToBTCLNOptions & {comment?: string}): Promise<ToBTCLNSwap<T[C]>>;
+    swap<C extends ChainIds<T>>(srcToken: SCToken<C> | string, dstToken: BtcToken<true> | "BTCLN" | "BTC-LN" | "LIGHTNING-BTC", amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstLnurlPayOrInvoiceCreateService: string | LNURLPay | LightningInvoiceCreateService, options?: ToBTCLNOptions & {comment?: string}): Promise<ToBTCLNSwap<T[C]>>;
     /**
      * @internal
      */
-    swap<C extends ChainIds<T>>(srcToken: SCToken<C>, dstToken: BtcToken<true>, amount: undefined, exactIn: false | SwapAmountType.EXACT_OUT, src: string, dstLightningInvoice: string, options?: ToBTCLNOptions): Promise<ToBTCLNSwap<T[C]>>;
+    swap<C extends ChainIds<T>>(srcToken: SCToken<C> | string, dstToken: BtcToken<true> | "BTCLN" | "BTC-LN" | "LIGHTNING-BTC", amount: undefined, exactIn: false | SwapAmountType.EXACT_OUT, src: string, dstLightningInvoice: string, options?: ToBTCLNOptions): Promise<ToBTCLNSwap<T[C]>>;
     /**
      * Creates a swap from srcToken to dstToken, of a specific token amount, either specifying input amount (if `exactIn=true`)
      *  or output amount (if `exactIn=false`), NOTE: For regular Smart chain -> BTC-LN (lightning) swaps the passed amount is ignored and
@@ -1999,6 +1999,10 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         return recoveredSwaps;
     }
 
+    getToken(ticker: "BTC" | "BITCOIN-BTC"): BtcToken<false>;
+    getToken(ticker: "BTCLN" | "BTC-LN" | "LIGHTNING-BTC"): BtcToken<true>;
+    getToken<ChainIdentifier extends ChainIds<T>>(ticker: `${ChainIdentifier}-${string}`): SCToken<ChainIdentifier>;
+    getToken(tickerOrAddress: string): Token<ChainIds<T>>;
     /**
      * Returns the {@link Token} object for a given token
      *

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -383,6 +383,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 {
                     getRequestTimeout: this.options.getRequestTimeout,
                     postRequestTimeout: this.options.postRequestTimeout,
+                    saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                 }
             );
             wrappers[SwapType.TO_BTC] = new ToBTCWrapper<T[InputKey]>(
@@ -398,6 +399,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 {
                     getRequestTimeout: this.options.getRequestTimeout,
                     postRequestTimeout: this.options.postRequestTimeout,
+                    saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                     bitcoinNetwork: this._btcNetwork
                 }
             );
@@ -414,6 +416,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 {
                     getRequestTimeout: this.options.getRequestTimeout,
                     postRequestTimeout: this.options.postRequestTimeout,
+                    saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                     unsafeSkipLnNodeCheck: this.bitcoinNetwork===BitcoinNetwork.TESTNET4 || this.bitcoinNetwork===BitcoinNetwork.REGTEST
                 }
             );
@@ -432,6 +435,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 {
                     getRequestTimeout: this.options.getRequestTimeout,
                     postRequestTimeout: this.options.postRequestTimeout,
+                    saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                     bitcoinNetwork: this._btcNetwork
                 }
             );
@@ -444,7 +448,8 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 this._tokens[chainId],
                 {
                     getRequestTimeout: this.options.getRequestTimeout,
-                    postRequestTimeout: this.options.postRequestTimeout
+                    postRequestTimeout: this.options.postRequestTimeout,
+                    saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                 }
             );
             wrappers[SwapType.TRUSTED_FROM_BTC] = new OnchainForGasWrapper<T[InputKey]>(
@@ -458,6 +463,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 {
                     getRequestTimeout: this.options.getRequestTimeout,
                     postRequestTimeout: this.options.postRequestTimeout,
+                    saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                     bitcoinNetwork: this._btcNetwork
                 }
             );
@@ -478,6 +484,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                     {
                         getRequestTimeout: this.options.getRequestTimeout,
                         postRequestTimeout: this.options.postRequestTimeout,
+                        saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                         bitcoinNetwork: this._btcNetwork
                     }
                 );
@@ -498,6 +505,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                     {
                         getRequestTimeout: this.options.getRequestTimeout,
                         postRequestTimeout: this.options.postRequestTimeout,
+                        saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                         unsafeSkipLnNodeCheck: this.bitcoinNetwork===BitcoinNetwork.TESTNET4 || this.bitcoinNetwork===BitcoinNetwork.REGTEST
                     }
                 );
@@ -844,10 +852,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
             if(swapLimitsChanged) this.emit("swapLimitsChanged");
 
             const quote = quotes[0].quote;
-            if(this.options.saveUninitializedSwaps) {
-                quote._setInitiated();
-                await quote._save();
-            }
+            await quote._save();
             return quote;
         } catch (e) {
             if(swapLimitsChanged) this.emit("swapLimitsChanged");

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -152,9 +152,15 @@ export type SwapperOptions = {
      */
     dontFetchLPs?: boolean,
     /**
-     * By setting this flag the SDK persists all created swaps. By default, the SDK only saves and persists swaps that
-     *  are considered initiated, i.e. when `commit()`, `execute()` or `waitTillPayment` is called (or their respective
-     *  txs... prefixed variations).
+     * Defaults to `true`, this means every swap regardless of it being initiated (i.e. when `commit()`, `execute()` or
+     *  `waitTillPayment` is called) is saved to the persistent storage. This is a reasonable default for when you
+     *  want to only create a swap, and then later on retrieve it with the `swapper.getSwapById()` function.
+     *
+     * Setting this to `false` means the SDK only saves and persists swaps that are considered initiated, i.e. when
+     *  `commit()`, `execute()` or `waitTillPayment` is called (or their respective txs... prefixed variations). This
+     *  might save calls to the persistent storage for swaps that are never initiated. This is useful in e.g.
+     *  frontend implementations where the frontend holds the swap object reference until it is initiated anyway, not
+     *  necessitating the saving of the swap data to the persistent storage until it is actually initiated.
      */
     saveUninitializedSwaps?: boolean,
     /**
@@ -318,6 +324,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         const storagePrefix = options?.storagePrefix ?? "atomiq-";
 
         options ??= {};
+        options.saveUninitializedSwaps ??= true;
         options.bitcoinNetwork = options.bitcoinNetwork==null ? BitcoinNetwork.TESTNET : options.bitcoinNetwork;
         const swapStorage = options.swapStorage ??= (name: string) => new IndexedDBUnifiedStorage(name);
 

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -64,6 +64,7 @@ import {tryWithRetries} from "../utils/RetryUtils";
 import {NotNever} from "../utils/TypeUtils";
 import {IEscrowSwap} from "../swaps/escrow_swaps/IEscrowSwap";
 import {LightningInvoiceCreateService, isLightningInvoiceCreateService} from "../types/wallets/LightningInvoiceCreateService";
+import {SwapSide} from "../enums/SwapSide";
 
 /**
  * Configuration options for the Swapper
@@ -2172,7 +2173,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
      *
      * @param input Whether to return input tokens or output tokens
      */
-    getSupportedTokens(input: boolean): Token[] {
+    getSupportedTokens(input: SwapSide | boolean): Token[] {
         const tokens: {[chainId: string]: Set<string>} = {};
         let lightning = false;
         let btc = false;
@@ -2275,7 +2276,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
      * Returns tokens that you can swap to (if input=true) from a given token,
      *  or tokens that you can swap from (if input=false) to a given token
      */
-    getSwapCounterTokens(token: Token, input: boolean): Token[] {
+    getSwapCounterTokens(token: Token, input: SwapSide | boolean): Token[] {
         if(isSCToken(token)) {
             const result: Token[] = [];
             if(input) {

--- a/src/swapper/SwapperFactory.ts
+++ b/src/swapper/SwapperFactory.ts
@@ -9,7 +9,7 @@ import {SmartChainAssets, SmartChainAssetTickers} from "../SmartChainAssets";
 import {NostrMessenger} from "@atomiqlabs/messenger-nostr";
 import {Swapper, SwapperOptions} from "./Swapper";
 import {CustomPriceProvider} from "../prices/providers/CustomPriceProvider";
-import {BitcoinTokens, BtcToken, SCToken} from "../types/Token";
+import {BitcoinTokens, BtcToken, SCToken, Token} from "../types/Token";
 import {SwapType} from "../enums/SwapType";
 import {SwapTypeMapping} from "../utils/SwapUtils";
 import {RedundantSwapPrice, RedundantSwapPriceAssets} from "../prices/RedundantSwapPrice";
@@ -191,6 +191,8 @@ export class SwapperFactory<T extends readonly ChainInitializer<any, ChainType, 
      */
     TokenResolver: TypedTokenResolvers<T> = {} as any;
 
+    private smartChainTokens: SCToken[] = [];
+
     constructor(readonly initializers: T) {
         this.initializers = initializers;
         initializers.forEach(initializer => {
@@ -200,15 +202,19 @@ export class SwapperFactory<T extends readonly ChainInitializer<any, ChainType, 
 
             for(let ticker in initializer.tokens) {
                 const assetData = initializer.tokens[ticker] as any;
-                tokens[ticker] = addressMap[assetData.address] = {
+                const token: SCToken = {
                     chain: "SC",
                     chainId: initializer.chainId,
-                    address: assetData.address,
+                    ticker,
                     name: SmartChainAssets[ticker as SmartChainAssetTickers]?.name ?? ticker,
                     decimals: assetData.decimals,
                     displayDecimals: assetData.displayDecimals,
-                    ticker
-                } as any;
+                    address: assetData.address,
+                    equals: (other: Token) => other.chainId===initializer.chainId && other.ticker===ticker && other.address===assetData.address,
+                    toString: () => `${initializer.chainId}-${ticker}`
+                };
+                this.smartChainTokens.push(token);
+                tokens[ticker] = addressMap[assetData.address] = token;
             }
 
             this.TokenResolver[initializer.chainId as keyof TypedTokenResolvers<T>] = {
@@ -280,7 +286,7 @@ export class SwapperFactory<T extends readonly ChainInitializer<any, ChainType, 
             (btcRelay: BtcRelay<any, any, any>) => new MempoolBtcRelaySynchronizer(btcRelay, bitcoinRpc),
             chains as any,
             swapPricing,
-            pricingAssets,
+            this.smartChainTokens,
             options.messenger,
             options
         );

--- a/src/swapper/SwapperWithChain.ts
+++ b/src/swapper/SwapperWithChain.ts
@@ -387,23 +387,23 @@ export class SwapperWithChain<T extends MultiChain, ChainIdentifier extends Chai
     /**
      * @internal
      */
-    swap(srcToken: BtcToken<true>, dstToken: SCToken<ChainIdentifier>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string | LNURLWithdraw, dstSmartchainWallet: string, options?: (SupportsSwapType<T[ChainIdentifier], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoOptions : FromBTCLNOptions)): Promise<SupportsSwapType<T[ChainIdentifier], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoSwap<T[ChainIdentifier]> : FromBTCLNSwap<T[ChainIdentifier]>>;
+    swap(srcToken: BtcToken<true> | "BTCLN" | "BTC-LN" | "LIGHTNING-BTC", dstToken: SCToken<ChainIdentifier>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string | LNURLWithdraw, dstSmartchainWallet: string, options?: (SupportsSwapType<T[ChainIdentifier], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoOptions : FromBTCLNOptions)): Promise<SupportsSwapType<T[ChainIdentifier], SwapType.FROM_BTCLN_AUTO> extends true ? FromBTCLNAutoSwap<T[ChainIdentifier]> : FromBTCLNSwap<T[ChainIdentifier]>>;
     /**
      * @internal
      */
-    swap(srcToken: BtcToken<false>, dstToken: SCToken<ChainIdentifier>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string, dstSmartchainWallet: string, options?: (SupportsSwapType<T[ChainIdentifier], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCOptions : FromBTCOptions)): Promise<(SupportsSwapType<T[ChainIdentifier], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCSwap<T[ChainIdentifier]> : FromBTCSwap<T[ChainIdentifier]>)>;
+    swap(srcToken: BtcToken<false> | "BTC" | "BITCOIN-BTC", dstToken: SCToken<ChainIdentifier>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: undefined | string, dstSmartchainWallet: string, options?: (SupportsSwapType<T[ChainIdentifier], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCOptions : FromBTCOptions)): Promise<(SupportsSwapType<T[ChainIdentifier], SwapType.SPV_VAULT_FROM_BTC> extends true ? SpvFromBTCSwap<T[ChainIdentifier]> : FromBTCSwap<T[ChainIdentifier]>)>;
     /**
      * @internal
      */
-    swap(srcToken: SCToken<ChainIdentifier>, dstToken: BtcToken<false>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstAddress: string, options?: ToBTCOptions): Promise<ToBTCSwap<T[ChainIdentifier]>>;
+    swap(srcToken: SCToken<ChainIdentifier>, dstToken: BtcToken<false> | "BTC" | "BITCOIN-BTC", amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstAddress: string, options?: ToBTCOptions): Promise<ToBTCSwap<T[ChainIdentifier]>>;
     /**
      * @internal
      */
-    swap(srcToken: SCToken<ChainIdentifier>, dstToken: BtcToken<true>, amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstLnurlPayOrInvoiceCreateService: string | LNURLPay | LightningInvoiceCreateService, options?: ToBTCLNOptions & {comment?: string}): Promise<ToBTCLNSwap<T[ChainIdentifier]>>;
+    swap(srcToken: SCToken<ChainIdentifier>, dstToken: BtcToken<true> | "BTCLN" | "BTC-LN" | "LIGHTNING-BTC", amount: bigint | string, exactIn: boolean | SwapAmountType, src: string, dstLnurlPayOrInvoiceCreateService: string | LNURLPay | LightningInvoiceCreateService, options?: ToBTCLNOptions & {comment?: string}): Promise<ToBTCLNSwap<T[ChainIdentifier]>>;
     /**
      * @internal
      */
-    swap(srcToken: SCToken<ChainIdentifier>, dstToken: BtcToken<true>, amount: undefined, exactIn: false | SwapAmountType.EXACT_OUT, src: string, dstLightningInvoice: string, options?: ToBTCLNOptions): Promise<ToBTCLNSwap<T[ChainIdentifier]>>;
+    swap(srcToken: SCToken<ChainIdentifier>, dstToken: BtcToken<true> | "BTCLN" | "BTC-LN" | "LIGHTNING-BTC", amount: undefined, exactIn: false | SwapAmountType.EXACT_OUT, src: string, dstLightningInvoice: string, options?: ToBTCLNOptions): Promise<ToBTCLNSwap<T[ChainIdentifier]>>;
     /**
      * Creates a swap from srcToken to dstToken, of a specific token amount, either specifying input amount (exactIn=true)
      *  or output amount (exactIn=false), NOTE: For regular SmartChain -> BTC-LN (lightning) swaps the passed amount is ignored and
@@ -518,6 +518,10 @@ export class SwapperWithChain<T extends MultiChain, ChainIdentifier extends Chai
         return this.swapper.recoverSwaps(this.chainIdentifier, signer, startBlockheight);
     }
 
+    getToken(ticker: "BTC" | "BITCOIN-BTC"): BtcToken<false>;
+    getToken(ticker: "BTCLN" | "BTC-LN" | "LIGHTNING-BTC"): BtcToken<true>;
+    getToken(ticker: `${ChainIdentifier}-${string}`): SCToken<ChainIdentifier>;
+    getToken(tickerOrAddress: string): Token<ChainIdentifier>;
     /**
      * Returns the {@link Token} object for a given token
      *

--- a/src/swapper/SwapperWithChain.ts
+++ b/src/swapper/SwapperWithChain.ts
@@ -609,8 +609,8 @@ export class SwapperWithChain<T extends MultiChain, ChainIdentifier extends Chai
      * @param dstToken Destination token
      */
     getSwapLimits<A extends Token<ChainIdentifier>, B extends Token<ChainIdentifier>>(srcToken: A, dstToken: B): {
-        input: {min: TokenAmount<string, A>, max?: TokenAmount<string, A>},
-        output: {min: TokenAmount<string, B>, max?: TokenAmount<string, B>}
+        input: {min: TokenAmount<A>, max?: TokenAmount<A>},
+        output: {min: TokenAmount<B>, max?: TokenAmount<B>}
     } {
         return this.swapper.getSwapLimits<ChainIdentifier, A, B>(srcToken, dstToken);
     }

--- a/src/swapper/SwapperWithChain.ts
+++ b/src/swapper/SwapperWithChain.ts
@@ -528,8 +528,8 @@ export class SwapperWithChain<T extends MultiChain, ChainIdentifier extends Chai
      */
     getToken(tickerOrAddress: string): Token<ChainIdentifier> {
         //Btc tokens - BTC, BTCLN, BTC-LN
-        if(tickerOrAddress==="BTC") return BitcoinTokens.BTC;
-        if(tickerOrAddress==="BTCLN" || tickerOrAddress==="BTC-LN") return BitcoinTokens.BTCLN;
+        if(tickerOrAddress==="BTC" || tickerOrAddress==="BITCOIN-BTC") return BitcoinTokens.BTC;
+        if(tickerOrAddress==="BTCLN" || tickerOrAddress==="BTC-LN" || tickerOrAddress==="LIGHTNING-BTC") return BitcoinTokens.BTCLN;
 
         //Check if the ticker is in format <chainId>-<ticker>, i.e. SOLANA-USDC, STARKNET-WBTC
         if(tickerOrAddress.includes("-")) {

--- a/src/swapper/SwapperWithChain.ts
+++ b/src/swapper/SwapperWithChain.ts
@@ -33,6 +33,7 @@ import {LightningInvoiceCreateService} from "../types/wallets/LightningInvoiceCr
 import {Messenger} from "@atomiqlabs/base";
 import {Intermediary} from "../intermediaries/Intermediary";
 import {SwapTypeMapping} from "../utils/SwapUtils";
+import {SwapSide} from "../enums/SwapSide";
 
 /**
  * Chain-specific wrapper around Swapper for a particular blockchain
@@ -650,7 +651,7 @@ export class SwapperWithChain<T extends MultiChain, ChainIdentifier extends Chai
      * Returns tokens that you can swap to (if input=true) from a given token,
      *  or tokens that you can swap from (if input=false) to a given token
      */
-    getSwapCounterTokens(token: Token, input: boolean): Token<ChainIdentifier>[] {
+    getSwapCounterTokens(token: Token, input: SwapSide | boolean): Token<ChainIdentifier>[] {
         if(isSCToken(token)) {
             const result: Token<ChainIdentifier>[] = [];
             if(input) {

--- a/src/swapper/SwapperWithSigner.ts
+++ b/src/swapper/SwapperWithSigner.ts
@@ -31,6 +31,7 @@ import {LightningInvoiceCreateService} from "../types/wallets/LightningInvoiceCr
 import {Intermediary} from "../intermediaries/Intermediary";
 import {SpvFromBTCOptions} from "../swaps/spv_swaps/SpvFromBTCWrapper";
 import {SwapTypeMapping} from "../utils/SwapUtils";
+import {SwapSide} from "../enums/SwapSide";
 
 /**
  * Chain and signer-specific wrapper for automatic signer injection into swap methods
@@ -499,7 +500,7 @@ export class SwapperWithSigner<T extends MultiChain, ChainIdentifier extends Cha
      * Returns tokens that you can swap to (if input=true) from a given token,
      *  or tokens that you can swap from (if input=false) to a given token
      */
-    getSwapCounterTokens(token: Token, input: boolean): Token<ChainIdentifier>[] {
+    getSwapCounterTokens(token: Token, input: SwapSide | boolean): Token<ChainIdentifier>[] {
         return this.swapper.getSwapCounterTokens(token, input);
     }
 

--- a/src/swapper/SwapperWithSigner.ts
+++ b/src/swapper/SwapperWithSigner.ts
@@ -427,6 +427,10 @@ export class SwapperWithSigner<T extends MultiChain, ChainIdentifier extends Cha
         return this.swapper.recoverSwaps(this.signer.getAddress(), startBlockheight);
     }
 
+    getToken(ticker: "BTC" | "BITCOIN-BTC"): BtcToken<false>;
+    getToken(ticker: "BTCLN" | "BTC-LN" | "LIGHTNING-BTC"): BtcToken<true>;
+    getToken(ticker: `${ChainIdentifier}-${string}`): SCToken<ChainIdentifier>;
+    getToken(tickerOrAddress: string): Token<ChainIdentifier>;
     /**
      * Returns the {@link Token} object for a given token
      *

--- a/src/swapper/SwapperWithSigner.ts
+++ b/src/swapper/SwapperWithSigner.ts
@@ -494,8 +494,8 @@ export class SwapperWithSigner<T extends MultiChain, ChainIdentifier extends Cha
      * @param dstToken Destination token
      */
     getSwapLimits<A extends Token<ChainIdentifier>, B extends Token<ChainIdentifier>>(srcToken: A, dstToken: B): {
-        input: {min: TokenAmount<string, A>, max?: TokenAmount<string, A>},
-        output: {min: TokenAmount<string, B>, max?: TokenAmount<string, B>}
+        input: {min: TokenAmount<A>, max?: TokenAmount<A>},
+        output: {min: TokenAmount<B>, max?: TokenAmount<B>}
     } {
         return this.swapper.getSwapLimits<A, B>(srcToken, dstToken);
     }

--- a/src/swaps/IBTCWalletSwap.ts
+++ b/src/swaps/IBTCWalletSwap.ts
@@ -57,7 +57,7 @@ export interface IBTCWalletSwap {
      * @param wallet Sender's bitcoin wallet
      * @param feeRate Optional fee rate in sats/vB for the transaction
      */
-    estimateBitcoinFee(wallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<any, BtcToken<false>> | null>;
+    estimateBitcoinFee(wallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<BtcToken<false>> | null>;
 
     /**
      * Sends a swap bitcoin transaction via the passed bitcoin wallet

--- a/src/swaps/ISwap.ts
+++ b/src/swaps/ISwap.ts
@@ -132,6 +132,14 @@ export abstract class ISwap<
      * @internal
      */
     _randomNonce: string;
+    /**
+     * Whether the swap is saved in the persistent storage or not.
+     *
+     * @remarks This field itself is not persisted but is instead derived during runtime
+     *
+     * @internal
+     */
+    _persisted: boolean = false;
 
 
     /**

--- a/src/swaps/ISwap.ts
+++ b/src/swaps/ISwap.ts
@@ -229,9 +229,9 @@ export abstract class ISwap<
         //TODO: This doesn't hold strong reference to the swap, hence if no other strong reference to the
         // swap exists, it will just never resolve!
         return new Promise((resolve, reject) => {
-            let listener: (swap: D["Swap"]) => void;
-            listener = (swap) => {
-                if(type==="eq" ? swap._state===targetState : type==="gte" ? swap._state>=targetState : swap._state!=targetState) {
+            let listener: () => void;
+            listener = () => {
+                if(type==="eq" ? this._state===targetState : type==="gte" ? this._state>=targetState : this._state!=targetState) {
                     resolve();
                     this.events.removeListener("swapState", listener);
                 }

--- a/src/swaps/ISwap.ts
+++ b/src/swaps/ISwap.ts
@@ -226,6 +226,8 @@ export abstract class ISwap<
      * @internal
      */
     protected waitTillState(targetState: S, type: "eq" | "gte" | "neq" = "eq", abortSignal?: AbortSignal): Promise<void> {
+        //TODO: This doesn't hold strong reference to the swap, hence if no other strong reference to the
+        // swap exists, it will just never resolve!
         return new Promise((resolve, reject) => {
             let listener: (swap: D["Swap"]) => void;
             listener = (swap) => {

--- a/src/swaps/ISwapWithGasDrop.ts
+++ b/src/swaps/ISwapWithGasDrop.ts
@@ -21,5 +21,5 @@ export interface ISwapWithGasDrop<T extends ChainType> {
      * Returns the output of the "gas drop", additional native token received by the user on
      *  the destination chain
      */
-    getGasDropOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>>;
+    getGasDropOutput(): TokenAmount<SCToken<T["ChainId"]>>;
 }

--- a/src/swaps/ISwapWrapper.ts
+++ b/src/swaps/ISwapWrapper.ts
@@ -402,6 +402,8 @@ export abstract class ISwapWrapper<
     /**
      * Runs checks on all the known pending swaps, syncing their state from on-chain data
      *
+     * @remarks Doesn't work properly if you pass non-persisted swaps
+     *
      * @param pastSwaps Optional array of past swaps to check, otherwise all relevant swaps will be fetched
      *  from the persistent storage
      * @param noSave Whether to skip saving the swap changes in the persistent storage
@@ -513,7 +515,7 @@ export abstract class ISwapWrapper<
      */
     _removeSwapData(swap: D["Swap"]): Promise<void> {
         this.pendingSwaps.delete(swap.getId());
-        if(!swap.isInitiated()) return Promise.resolve();
+        if(!swap._persisted) return Promise.resolve();
         return this.unifiedStorage.remove(swap);
     }
 

--- a/src/swaps/ISwapWrapper.ts
+++ b/src/swaps/ISwapWrapper.ts
@@ -31,7 +31,11 @@ export type ISwapWrapperOptions = {
     /**
      * How many swaps to call `_sync()` for in parallel
      */
-    maxParallelSwapSyncs?: number
+    maxParallelSwapSyncs?: number,
+    /**
+     * Whether to save swaps that are not initialized into the persistent storage
+     */
+    saveUninitializedSwaps?: boolean
 };
 
 /**
@@ -496,12 +500,14 @@ export abstract class ISwapWrapper<
      * @internal
      */
     _saveSwapData(swap: D["Swap"]): Promise<void> {
-        if(!swap.isInitiated()) {
-            this.logger.debug("saveSwapData(): Swap "+swap.getId()+" not initiated, saving to pending swaps");
-            this.pendingSwaps.set(swap.getId(), new WeakRef<D["Swap"]>(swap));
-            return Promise.resolve();
-        } else {
-            this.pendingSwaps.delete(swap.getId());
+        if(!this._options.saveUninitializedSwaps) {
+            if(!swap.isInitiated()) {
+                this.logger.debug("saveSwapData(): Swap "+swap.getId()+" not initiated, saving to pending swaps");
+                this.pendingSwaps.set(swap.getId(), new WeakRef<D["Swap"]>(swap));
+                return Promise.resolve();
+            } else {
+                this.pendingSwaps.delete(swap.getId());
+            }
         }
         return this.unifiedStorage.save(swap);
     }

--- a/src/swaps/ISwapWrapper.ts
+++ b/src/swaps/ISwapWrapper.ts
@@ -13,6 +13,9 @@ import {PriceInfoType} from "../types/PriceInfoType";
 import {fromHumanReadableString} from "../utils/TokenUtils";
 import {UserError} from "../errors/UserError";
 
+export const DEFAULT_MAX_PARALLEL_SWAP_TICKS = 50;
+export const DEFAULT_MAX_PARALLEL_SWAP_SYNCS = 50;
+
 /**
  * Options for swap wrapper configuration
  *
@@ -20,7 +23,15 @@ import {UserError} from "../errors/UserError";
  */
 export type ISwapWrapperOptions = {
     getRequestTimeout?: number,
-    postRequestTimeout?: number
+    postRequestTimeout?: number,
+    /**
+     * How many swaps to call `_tick()` for in parallel
+     */
+    maxParallelSwapTicks?: number,
+    /**
+     * How many swaps to call `_sync()` for in parallel
+     */
+    maxParallelSwapSyncs?: number
 };
 
 /**
@@ -101,6 +112,11 @@ export abstract class ISwapWrapper<
      * @internal
      */
     protected tickInterval?: NodeJS.Timeout;
+    /**
+     * An internal abort controller for the running tick handler
+     * @internal
+     */
+    protected tickAbortController?: AbortController;
 
 
     /**
@@ -152,6 +168,11 @@ export abstract class ISwapWrapper<
         options: O,
         events?: EventEmitter<{swapState: [ISwap]}>
     ) {
+        if(options?.maxParallelSwapTicks!=null && options.maxParallelSwapTicks < 1)
+            throw new Error("maxParallelSwapTicks must be at least 1!");
+        if(options?.maxParallelSwapSyncs!=null && options.maxParallelSwapSyncs < 1)
+            throw new Error("maxParallelSwapSyncs must be at least 1!");
+
         this.unifiedStorage = unifiedStorage;
         this.unifiedChainEvents = unifiedChainEvents;
 
@@ -274,9 +295,20 @@ export abstract class ISwapWrapper<
      */
     protected startTickInterval(): void {
         if(this.tickSwapState==null || this.tickSwapState.length===0) return;
-        this.tickInterval = setInterval(() => {
-            this.tick();
-        }, 1000);
+        if(this.tickAbortController!=null) this.tickAbortController.abort("New tick interval has been started!");
+        const abortController = this.tickAbortController = new AbortController();
+        let run: () => Promise<void>;
+        run = async () => {
+            if(!this.isInitialized) return;
+            await this.tick(undefined, abortController.signal).catch(e => {
+                if(abortController.signal.aborted) return;
+                this.logger.warn("startTickInterval(): Tick on swaps failed, error: ", e);
+            });
+            if(abortController.signal.aborted) return;
+            if(!this.isInitialized) return;
+            this.tickInterval = setTimeout(run, 1000);
+        }
+        run();
     }
 
     /**
@@ -343,11 +375,11 @@ export abstract class ISwapWrapper<
 
         if(this.processEvent!=null) this.unifiedChainEvents.registerListener(this.TYPE, this.processEvent.bind(this), this._swapDeserializer.bind(null, this));
 
+        this.isInitialized = true;
+
         if(!noTimers) this.startTickInterval();
 
         // this.logger.info("init(): Swap wrapper initialized");
-
-        this.isInitialized = true;
     }
 
     /**
@@ -357,7 +389,14 @@ export abstract class ISwapWrapper<
         this.isInitialized = false;
         this.unifiedChainEvents.unregisterListener(this.TYPE);
         this.logger.info("stop(): Swap wrapper stopped");
-        if(this.tickInterval!=null) clearInterval(this.tickInterval);
+        if(this.tickInterval!=null) {
+            clearTimeout(this.tickInterval);
+            delete this.tickInterval;
+        }
+        if(this.tickAbortController!=null) {
+            this.tickAbortController.abort("Wrapper instance stopped!");
+            delete this.tickAbortController;
+        }
     }
 
     /**
@@ -373,18 +412,25 @@ export abstract class ISwapWrapper<
             (val: any) => new this._swapDeserializer(this, val)
         );
 
-        const {removeSwaps, changedSwaps} = await this._checkPastSwaps(pastSwaps);
+        const maxParallelSyncs = this._options.maxParallelSwapSyncs ?? DEFAULT_MAX_PARALLEL_SWAP_SYNCS;
 
-        if (!noSave) {
-            await this.unifiedStorage.removeAll(removeSwaps);
-            await this.unifiedStorage.saveAll(changedSwaps);
-            changedSwaps.forEach(swap => swap._emitEvent());
-            removeSwaps.forEach(swap => swap._emitEvent());
+        const totalRemoveSwaps: D["Swap"][] = [];
+        const totalChangedSwaps: D["Swap"][] = [];
+        for(let i=0; i<pastSwaps.length; i+=maxParallelSyncs) {
+            const {removeSwaps, changedSwaps} = await this._checkPastSwaps(pastSwaps.slice(i, i+maxParallelSyncs));
+            if (!noSave) {
+                await this.unifiedStorage.removeAll(removeSwaps);
+                await this.unifiedStorage.saveAll(changedSwaps);
+                changedSwaps.forEach(swap => swap._emitEvent());
+                removeSwaps.forEach(swap => swap._emitEvent());
+            }
+            totalRemoveSwaps.push(...removeSwaps);
+            totalChangedSwaps.push(...changedSwaps);
         }
 
         return {
-            removeSwaps,
-            changedSwaps
+            removeSwaps: totalRemoveSwaps,
+            changedSwaps: totalChangedSwaps
         }
     }
 
@@ -393,21 +439,43 @@ export abstract class ISwapWrapper<
      *
      * @param swaps Optional array of swaps to invoke `_tick()` on, otherwise all relevant swaps will be fetched
      *  from the persistent storage
+     * @param abortSignal Abort signal
      */
-    public async tick(swaps?: D["Swap"][]): Promise<void> {
+    public async tick(swaps?: D["Swap"][], abortSignal?: AbortSignal): Promise<void> {
         if(swaps==null) swaps = await this.unifiedStorage.query<D["Swap"]>(
             [[{key: "type", value: this.TYPE}, {key: "state", value: this.tickSwapState}]],
             (val: any) => new this._swapDeserializer(this, val)
         );
+        abortSignal?.throwIfAborted();
 
+        const parallelTicks = this._options.maxParallelSwapTicks ?? DEFAULT_MAX_PARALLEL_SWAP_TICKS;
+
+        let promises: Promise<any>[] = [];
         for(let pendingSwap of this.pendingSwaps.values()) {
             const value = pendingSwap.deref();
-            if(value != null) value._tick(true);
+            if(value != null) promises.push(value._tick(true).catch(e => {
+                this.logger.warn(`tick(): Error ticking swap ${value.getId()}: `, e);
+            }));
+            if(promises.length >= parallelTicks) {
+                await Promise.all(promises);
+                abortSignal?.throwIfAborted();
+                promises = [];
+            }
         }
 
-        swaps.forEach(value => {
-            value._tick(true)
-        });
+        for(let value of swaps) {
+            promises.push(value._tick(true).catch(e => {
+                this.logger.warn(`tick(): Error ticking swap ${value.getId()}: `, e);
+            }));
+            if(promises.length >= parallelTicks) {
+                await Promise.all(promises);
+                abortSignal?.throwIfAborted();
+                promises = [];
+            }
+        }
+
+        if(promises.length>0) await Promise.all(promises);
+        abortSignal?.throwIfAborted();
     }
 
     /**

--- a/src/swaps/ISwapWrapper.ts
+++ b/src/swaps/ISwapWrapper.ts
@@ -26,15 +26,9 @@ export type ISwapWrapperOptions = {
  *
  * @category Swaps/Base
  */
-export type WrapperCtorTokens<T extends MultiChain = MultiChain> = {
-    ticker: string,
-    name: string,
-    chains: {[chainId in ChainIds<T>]?: {
-        address: string,
-        decimals: number,
-        displayDecimals?: number
-    }}
-}[];
+export type WrapperCtorTokens<T extends ChainType = ChainType> = {
+    [tokenAddress: string]: SCToken<T["ChainId"]>
+};
 
 /**
  * Type definition linking wrapper and swap types
@@ -164,20 +158,7 @@ export abstract class ISwapWrapper<
         this._prices = prices;
         this.events = events || new EventEmitter();
         this._options = options;
-        this._tokens = {};
-        for(let tokenData of tokens) {
-            const chainData = tokenData.chains[chainIdentifier];
-            if(chainData==null) continue;
-            this._tokens[chainData.address] = {
-                chain: "SC",
-                chainId: this.chainIdentifier,
-                address: chainData.address,
-                decimals: chainData.decimals,
-                ticker: tokenData.ticker,
-                name: tokenData.name,
-                displayDecimals: chainData.displayDecimals
-            };
-        }
+        this._tokens = tokens;
     }
 
 

--- a/src/swaps/ISwapWrapper.ts
+++ b/src/swaps/ISwapWrapper.ts
@@ -10,6 +10,8 @@ import {UnifiedSwapStorage} from "../storage/UnifiedSwapStorage";
 import {SCToken} from "../types/Token";
 import {getLogger} from "../utils/Logger";
 import {PriceInfoType} from "../types/PriceInfoType";
+import {fromHumanReadableString} from "../utils/TokenUtils";
+import {UserError} from "../errors/UserError";
 
 /**
  * Options for swap wrapper configuration
@@ -161,6 +163,24 @@ export abstract class ISwapWrapper<
         this._tokens = tokens;
     }
 
+    /**
+     * Parses the provided gas amount from its `string` or `bigint` representation to `bigint` base units.
+     *
+     * Defaults to `0n` if no gasAmount is provided
+     *
+     * @param gasAmount
+     * @internal
+     */
+    protected parseGasAmount(gasAmount?: string | bigint): bigint {
+        let result: bigint | undefined | null;
+        if(typeof(gasAmount)==="string") {
+            result = fromHumanReadableString(gasAmount, this._getNativeToken());
+            if(result==null) throw new UserError("Invalid `gasAmount` option provided, not a numerical string!");
+        } else {
+            result = gasAmount;
+        }
+        return result ?? 0n;
+    }
 
     /**
      * Pre-fetches swap price for a given swap

--- a/src/swaps/escrow_swaps/IEscrowSelfInitSwap.ts
+++ b/src/swaps/escrow_swaps/IEscrowSelfInitSwap.ts
@@ -112,7 +112,7 @@ export abstract class IEscrowSelfInitSwap<
     /**
      * Returns the transaction fee paid on the smart chain side to initiate the escrow
      */
-    async getSmartChainNetworkFee(): Promise<TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>> {
+    async getSmartChainNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>> {
         const swapContract: T["Contract"] = this.wrapper._contract;
         return toTokenAmount(
             await (
@@ -131,8 +131,8 @@ export abstract class IEscrowSelfInitSwap<
      */
     abstract hasEnoughForTxFees(): Promise<{
         enoughBalance: boolean,
-        balance: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>,
-        required: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>
+        balance: TokenAmount<SCToken<T["ChainId"]>, true>,
+        required: TokenAmount<SCToken<T["ChainId"]>, true>
     }>;
 
 

--- a/src/swaps/escrow_swaps/IEscrowSwapWrapper.ts
+++ b/src/swaps/escrow_swaps/IEscrowSwapWrapper.ts
@@ -66,7 +66,11 @@ export abstract class IEscrowSwapWrapper<
      * @internal
      */
     protected preFetchSignData(signDataPrefetch: Promise<any | null>): Promise<T["PreFetchVerification"] | undefined> {
-        if(this._contract.preFetchForInitSignatureVerification==null) return Promise.resolve(undefined);
+        if(this._contract.preFetchForInitSignatureVerification==null) {
+            // Catch promise rejections, should they happen
+            signDataPrefetch.catch(() => {});
+            return Promise.resolve(undefined);
+        }
         return signDataPrefetch.then(obj => {
             if(obj==null) return undefined;
             return this._contract.preFetchForInitSignatureVerification!(obj);

--- a/src/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.ts
@@ -169,19 +169,19 @@ export abstract class IFromBTCSelfInitSwap<
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true> {
+    getOutput(): TokenAmount<SCToken<T["ChainId"]>, true> {
         return toTokenAmount(this.getSwapData().getAmount(), this.wrapper._tokens[this.getSwapData().getToken()], this.wrapper._prices, this.pricingInfo);
     }
 
     /**
      * @inheritDoc
      */
-    abstract getInput(): TokenAmount<T["ChainId"], BtcToken>;
+    abstract getInput(): TokenAmount<BtcToken>;
 
     /**
      * @inheritDoc
      */
-    getInputWithoutFee(): TokenAmount<T["ChainId"], BtcToken> {
+    getInputWithoutFee(): TokenAmount<BtcToken> {
         const input = this.getInput();
         if(input.rawAmount==null) return toTokenAmount(null, this.inputToken, this.wrapper._prices, this.pricingInfo);
         return toTokenAmount(input.rawAmount - this.swapFeeBtc, this.inputToken, this.wrapper._prices, this.pricingInfo);
@@ -192,8 +192,8 @@ export abstract class IFromBTCSelfInitSwap<
      */
     async hasEnoughForTxFees(): Promise<{
         enoughBalance: boolean,
-        balance: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>,
-        required: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>
+        balance: TokenAmount<SCToken<T["ChainId"]>, true>,
+        required: TokenAmount<SCToken<T["ChainId"]>, true>
     }> {
         const [balance, commitFee] = await Promise.all([
             this.wrapper._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
@@ -212,7 +212,7 @@ export abstract class IFromBTCSelfInitSwap<
      *  to act as a security deposit that can be taken by the intermediary (LP) if the user doesn't go through
      *  with the swap
      */
-    getSecurityDeposit(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true> {
+    getSecurityDeposit(): TokenAmount<SCToken<T["ChainId"]>, true> {
         return toTokenAmount(this.getSwapData().getSecurityDeposit(), this.wrapper._getNativeToken(), this.wrapper._prices, this.pricingInfo);
     }
 
@@ -221,7 +221,7 @@ export abstract class IFromBTCSelfInitSwap<
      *  This covers the security deposit and the watchtower fee (if applicable), it is calculated a maximum of those
      *  two values.
      */
-    getTotalDeposit(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true> {
+    getTotalDeposit(): TokenAmount<SCToken<T["ChainId"]>, true> {
         return toTokenAmount(this.getSwapData().getTotalDeposit(), this.wrapper._getNativeToken(), this.wrapper._prices, this.pricingInfo);
     }
 
@@ -273,7 +273,7 @@ export abstract class IFromBTCSelfInitSwap<
      * Returns the transaction fee required for the claim transaction to settle the escrow on the destination
      *  smart chain
      */
-    async getClaimNetworkFee(): Promise<TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>> {
+    async getClaimNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>> {
         const swapContract: T["Contract"] = this.wrapper._contract;
         return toTokenAmount(
             await swapContract.getClaimFee(this._getInitiator(), this.getSwapData()),

--- a/src/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.ts
@@ -71,7 +71,7 @@ export abstract class IFromBTCSelfInitSwap<
      * Returns if the swap can be committed
      * @internal
      */
-    protected abstract canCommit(): boolean;
+    protected abstract canCommit(skipQuoteExpiryChecks?: boolean): boolean;
 
     /**
      * @inheritDoc
@@ -239,7 +239,7 @@ export abstract class IFromBTCSelfInitSwap<
      * @throws {Error} When in invalid state to commit the swap
      */
     async txsCommit(skipChecks?: boolean): Promise<T["TX"][]> {
-        if(!this.canCommit()) throw new Error("Must be in CREATED state!");
+        if(!this.canCommit(skipChecks)) throw new Error("Must be in CREATED state!");
         if(this._data==null || this.signatureData==null) throw new Error("data or signature data is null, invalid state?");
 
         if(!this.initiated) {

--- a/src/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.ts
@@ -285,7 +285,7 @@ export abstract class IFromBTCSelfInitSwap<
     /**
      * @inheritDoc
      */
-    abstract txsClaim(signer?: T["Signer"]): Promise<T["TX"][]>;
+    abstract txsClaim(signer?: string | T["Signer"] | T["NativeSigner"]): Promise<T["TX"][]>;
 
     /**
      * @inheritDoc

--- a/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.ts
@@ -953,7 +953,18 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
      *
      * @internal
      */
-    private async _txsClaim(_signer?: T["Signer"] | T["NativeSigner"], secret?: string): Promise<T["TX"][]> {
+    private async _txsClaim(_signer?: string | T["Signer"] | T["NativeSigner"], secret?: string): Promise<T["TX"][]> {
+        let address: string | undefined = undefined;
+        if(_signer!=null) {
+            if (typeof (_signer) === "string") {
+                address = _signer;
+            } else if (isAbstractSigner(_signer)) {
+                address = _signer.getAddress();
+            } else {
+                address = (await this.wrapper._chain.wrapSigner(_signer)).getAddress();
+            }
+        }
+
         if(this._data==null) throw new Error("Unknown data, wrong state?");
         const useSecret = secret ?? this.secret;
         if(useSecret==null)
@@ -962,9 +973,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
             throw new Error("Invalid swap secret pre-image provided!");
 
         return this.wrapper._contract.txsClaimWithSecret(
-            _signer==null ?
-                this._getInitiator() :
-                (isAbstractSigner(_signer) ? _signer : await this.wrapper._chain.wrapSigner(_signer)),
+            address ?? this._getInitiator(),
             this._data, useSecret, true, true
         );
     }
@@ -978,7 +987,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
      *
      * @throws {Error} If in invalid state (must be {@link FromBTCLNSwapState.CLAIM_COMMITED})
      */
-    async txsClaim(_signer?: T["Signer"] | T["NativeSigner"], secret?: string): Promise<T["TX"][]> {
+    async txsClaim(_signer?: string | T["Signer"] | T["NativeSigner"], secret?: string): Promise<T["TX"][]> {
         if(this._state!==FromBTCLNSwapState.CLAIM_COMMITED) throw new Error("Must be in CLAIM_COMMITED state!");
         return this._txsClaim(_signer, secret);
     }

--- a/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.ts
@@ -448,7 +448,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], BtcToken<true>> {
+    getInput(): TokenAmount<BtcToken<true>> {
         if(this.pr==null || !this.pr.toLowerCase().startsWith("ln"))
             return toTokenAmount(null, this.inputToken, this.wrapper._prices, this.pricingInfo);
 
@@ -461,7 +461,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
     /**
      * @inheritDoc
      */
-    getSmartChainNetworkFee(): Promise<TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>> {
+    getSmartChainNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>> {
         return this.getCommitAndClaimNetworkFee();
     }
 
@@ -470,8 +470,8 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
      */
     async hasEnoughForTxFees(): Promise<{
         enoughBalance: boolean,
-        balance: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>,
-        required: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>
+        balance: TokenAmount<SCToken<T["ChainId"]>, true>,
+        required: TokenAmount<SCToken<T["ChainId"]>, true>
     }> {
         const [balance, feeRate] = await Promise.all([
             this.wrapper._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
@@ -1082,7 +1082,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
      * Estimated transaction fee for commit & claim transactions combined, required
      *  to settle the swap on the smart chain destination side.
      */
-    async getCommitAndClaimNetworkFee(): Promise<TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>> {
+    async getCommitAndClaimNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>> {
         const swapContract: T["Contract"] = this.wrapper._contract;
         const feeRate = this.feeRate ?? await swapContract.getInitFeeRate(
             this.getSwapData().getOfferer(),

--- a/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.ts
@@ -282,8 +282,8 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
      * @inheritDoc
      * @internal
      */
-    protected canCommit(): boolean {
-        return this._state===FromBTCLNSwapState.PR_PAID;
+    protected canCommit(skipQuoteExpiryChecks?: boolean): boolean {
+        return this._state===FromBTCLNSwapState.PR_PAID || (!!skipQuoteExpiryChecks && this._state===FromBTCLNSwapState.QUOTE_SOFT_EXPIRED);
     }
 
     /**
@@ -899,7 +899,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
         );
 
         this._commitTxId = result[result.length-1];
-        if(this._state===FromBTCLNSwapState.PR_PAID || this._state===FromBTCLNSwapState.QUOTE_SOFT_EXPIRED) {
+        if(this._state===FromBTCLNSwapState.PR_PAID || this._state===FromBTCLNSwapState.QUOTE_SOFT_EXPIRED || this._state===FromBTCLNSwapState.QUOTE_EXPIRED) {
             await this._saveAndEmit(FromBTCLNSwapState.CLAIM_COMMITED);
         }
         return this._commitTxId;

--- a/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.ts
@@ -362,7 +362,6 @@ export class FromBTCLNWrapper<
                             secret: secret?.toString("hex"),
                             exactIn: amountData.exactIn ?? true
                         } as FromBTCLNSwapInit<T["Data"]>);
-                        await quote._save();
                         return quote;
                     } catch (e) {
                         abortController.abort(e);

--- a/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.ts
@@ -137,6 +137,7 @@ export class FromBTCLNWrapper<
         super(
             chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, lnApi,
             {
+                ...options,
                 safetyFactor: options?.safetyFactor ?? 2,
                 bitcoinBlocktime: options?.bitcoinBlocktime ?? 10*60,
                 unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? false

--- a/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.ts
@@ -4,7 +4,7 @@ import {
     ChainSwapType,
     ChainType,
     ClaimEvent,
-    InitializeEvent, LightningNetworkApi,
+    InitializeEvent, LightningNetworkApi, LNNodeLiquidity,
     RefundEvent, SwapCommitState, SwapCommitStateType
 } from "@atomiqlabs/base";
 import {Intermediary} from "../../../../intermediaries/Intermediary";
@@ -317,8 +317,13 @@ export class FromBTCLNWrapper<
                             this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined
                         );
 
+                        let lnCapacityPromise: Promise<LNNodeLiquidity | null> | undefined;
+                        if(!_options.unsafeSkipLnNodeCheck) {
+                            lnCapacityPromise = this.preFetchLnCapacity(lnPublicKey);
+                        } else lnPublicKey.catch(() => {});
+
                         return {
-                            lnCapacityPromise: _options.unsafeSkipLnNodeCheck ? null : this.preFetchLnCapacity(lnPublicKey),
+                            lnCapacityPromise,
                             resp: await response
                         };
                     }, undefined, RequestError, abortController.signal);

--- a/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.ts
@@ -13,7 +13,7 @@ import {UserError} from "../../../../errors/UserError";
 import {IntermediaryError} from "../../../../errors/IntermediaryError";
 import {SwapType} from "../../../../enums/SwapType";
 import {
-    extendAbortController,
+    extendAbortController, parseHashValueExact32Bytes,
     throwIfUndefined
 } from "../../../../utils/Utils";
 import {FromBTCLNResponseType, IntermediaryAPI} from "../../../../intermediaries/apis/IntermediaryAPI";
@@ -33,9 +33,30 @@ import {AllOptional} from "../../../../utils/TypeUtils";
 import {sha256} from "@noble/hashes/sha2";
 
 export type FromBTCLNOptions = {
-    paymentHash?: Buffer,
+    /**
+     * Instead of letting the SDK generate the preimage/paymentHash pair internally you can pass your computed
+     *  paymentHash here, this will create the swap with the provided payment hash. Note that you would then
+     *  have to reveal the preimage by passing it to the {@link FromBTCLNSwap.claim} or {@link FromBTCLNSwap.txsClaim}
+     *  functions
+     *
+     * Accepts both, a {@link Buffer} and a hexadecimal `string`
+     */
+    paymentHash?: Buffer | string,
+    /**
+     * Optional description to use for the swap lightning network invoice, keep the invoice length below 500 characters
+     */
     description?: string,
-    descriptionHash?: Buffer,
+    /**
+     * Optional description hash to use for the lightning network invoice, useful when returning the invoice as part of
+     *  an LNURL-pay service endpoint.
+     *
+     * Accepts both, a {@link Buffer} and a hexadecimal `string`
+     */
+    descriptionHash?: Buffer | string,
+    /**
+     * A flag to skip checking whether the lightning network node of the LP has enough channel liquidity to facilitate
+     *  the swap.
+     */
     unsafeSkipLnNodeCheck?: boolean
 };
 
@@ -179,7 +200,10 @@ export class FromBTCLNWrapper<
         resp: FromBTCLNResponseType,
         amountData: AmountData,
         lp: Intermediary,
-        options: FromBTCLNOptions,
+        options: {
+            descriptionHash?: Buffer,
+            description?: string
+        },
         decodedPr: PaymentRequestObject & {tagsObject: TagsObject},
         paymentHash: Buffer
     ): void {
@@ -238,22 +262,20 @@ export class FromBTCLNWrapper<
     }[] {
         if(!this.isInitialized) throw new Error("Not initialized, call init() first!");
 
-        if(options==null) options = {};
-        options.unsafeSkipLnNodeCheck ??= this._options.unsafeSkipLnNodeCheck;
+        const _options = {
+            paymentHash: parseHashValueExact32Bytes(options?.paymentHash, "payment hash"),
+            description: options?.description,
+            descriptionHash: parseHashValueExact32Bytes(options?.descriptionHash, "description hash"),
+            unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? this._options.unsafeSkipLnNodeCheck
+        };
 
-        if(options.paymentHash!=null && options.paymentHash.length!==32)
-            throw new UserError("Invalid payment hash length, must be exactly 32 bytes!");
-
-        if(options.descriptionHash!=null && options.descriptionHash.length!==32)
-            throw new UserError("Invalid description hash length");
-
-        if(options.description!=null && Buffer.byteLength(options.description, "utf8") > 500)
+        if(_options.description!=null && Buffer.byteLength(_options.description, "utf8") > 500)
             throw new UserError("Invalid description length");
 
         let secret: Buffer | undefined;
         let paymentHash: Buffer;
-        if(options?.paymentHash!=null) {
-            paymentHash = options.paymentHash;
+        if(_options.paymentHash!=null) {
+            paymentHash = _options.paymentHash;
         } else {
             ({secret, paymentHash} = this.getSecretAndHash());
         }
@@ -286,8 +308,8 @@ export class FromBTCLNWrapper<
                                 amount: amountData.amount,
                                 claimer: recipient,
                                 token: amountData.token.toString(),
-                                description: options?.description,
-                                descriptionHash: options?.descriptionHash,
+                                description: _options.description,
+                                descriptionHash: _options.descriptionHash,
                                 exactOut: !amountData.exactIn,
                                 feeRate: throwIfUndefined(_preFetches.feeRatePromise),
                                 additionalParams
@@ -296,7 +318,7 @@ export class FromBTCLNWrapper<
                         );
 
                         return {
-                            lnCapacityPromise: options?.unsafeSkipLnNodeCheck ? null : this.preFetchLnCapacity(lnPublicKey),
+                            lnCapacityPromise: _options.unsafeSkipLnNodeCheck ? null : this.preFetchLnCapacity(lnPublicKey),
                             resp: await response
                         };
                     }, undefined, RequestError, abortController.signal);
@@ -307,7 +329,7 @@ export class FromBTCLNWrapper<
                     const amountIn = (BigInt(decodedPr.millisatoshis) + 999n) / 1000n;
 
                     try {
-                        this.verifyReturnedData(resp, amountData, lp, options ?? {}, decodedPr, paymentHash);
+                        this.verifyReturnedData(resp, amountData, lp, _options, decodedPr, paymentHash);
                         const [pricingInfo] = await Promise.all([
                             this.verifyReturnedPrice(
                                 lp.services[SwapType.FROM_BTCLN], false, amountIn, resp.total,
@@ -374,8 +396,12 @@ export class FromBTCLNWrapper<
     }[]> {
         if(!this.isInitialized) throw new Error("Not initialized, call init() first!");
 
-        if(options?.paymentHash!=null && options.paymentHash.length!==32)
-            throw new UserError("Invalid payment hash length, must be exactly 32 bytes!");
+        const _options = {
+            paymentHash: parseHashValueExact32Bytes(options?.paymentHash, "payment hash"),
+            description: options?.description,
+            descriptionHash: parseHashValueExact32Bytes(options?.descriptionHash, "description hash"),
+            unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? this._options.unsafeSkipLnNodeCheck
+        };
 
         const abortController = extendAbortController(abortSignal);
         const preFetches = {
@@ -408,7 +434,7 @@ export class FromBTCLNWrapper<
                 if((amount * 105n / 100n) > max) throw new UserError("Amount more than LNURL-withdraw maximum");
             }
 
-            return this.create(recipient, amountData, lps, options, additionalParams, abortSignal, preFetches).map(data => {
+            return this.create(recipient, amountData, lps, _options, additionalParams, abortSignal, preFetches).map(data => {
                 return {
                     quote: data.quote.then(quote => {
                         quote._setLNURLData(

--- a/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.ts
@@ -1144,7 +1144,17 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
      *
      * @throws {Error} If in invalid state (must be {@link FromBTCLNAutoSwapState.CLAIM_COMMITED})
      */
-    async txsClaim(_signer?: T["Signer"] | T["NativeSigner"], secret?: string): Promise<T["TX"][]> {
+    async txsClaim(_signer?: string | T["Signer"] | T["NativeSigner"], secret?: string): Promise<T["TX"][]> {
+        let address: string | undefined = undefined;
+        if(_signer!=null) {
+            if (typeof (_signer) === "string") {
+                address = _signer;
+            } else if (isAbstractSigner(_signer)) {
+                address = _signer.getAddress();
+            } else {
+                address = (await this.wrapper._chain.wrapSigner(_signer)).getAddress();
+            }
+        }
         if(this._state!==FromBTCLNAutoSwapState.CLAIM_COMMITED) throw new Error("Must be in CLAIM_COMMITED state!");
         if(this._data==null) throw new Error("Unknown data, wrong state?");
 
@@ -1155,9 +1165,7 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
             throw new Error("Invalid swap secret pre-image provided!");
 
         return await this.wrapper._contract.txsClaimWithSecret(
-            _signer==null ?
-                this._getInitiator() :
-                (isAbstractSigner(_signer) ? _signer : await this.wrapper._chain.wrapSigner(_signer)),
+            address ?? this._getInitiator(),
             this._data, useSecret, true, true
         );
     }

--- a/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.ts
@@ -566,7 +566,7 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
      * @internal
      */
     protected getInputAmountWithoutFee(): bigint | null {
-        if(this.btcAmountGas==null || this.btcAmountSwap) return null;
+        if(this.btcAmountGas==null || this.btcAmountSwap==null) return null;
         return this.getInputSwapAmountWithoutFee()! + this.getInputGasAmountWithoutFee()! - this.getWatchtowerFeeAmountBtc()!;
     }
 

--- a/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.ts
@@ -589,14 +589,14 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], BtcToken<true>> {
+    getInput(): TokenAmount<BtcToken<true>> {
         return toTokenAmount(this.getLightningInvoiceSats(), this.inputToken, this.wrapper._prices, this.pricingInfo);
     }
 
     /**
      * @inheritDoc
      */
-    getInputWithoutFee(): TokenAmount<T["ChainId"], BtcToken<true>> {
+    getInputWithoutFee(): TokenAmount<BtcToken<true>> {
         return toTokenAmount(this.getInputAmountWithoutFee(), this.inputToken, this.wrapper._prices, this.pricingInfo);
     }
 
@@ -610,14 +610,14 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true> {
+    getOutput(): TokenAmount<SCToken<T["ChainId"]>, true> {
         return toTokenAmount(this.getSwapData().getAmount(), this.wrapper._tokens[this.getSwapData().getToken()], this.wrapper._prices, this.pricingInfo);
     }
 
     /**
      * @inheritDoc
      */
-    getGasDropOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true> {
+    getGasDropOutput(): TokenAmount<SCToken<T["ChainId"]>, true> {
         return toTokenAmount(
             this.getSwapData().getSecurityDeposit() - this.getSwapData().getClaimerBounty(),
             this.wrapper._tokens[this.getSwapData().getDepositToken()], this.wrapper._prices, this.gasPricingInfo

--- a/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
@@ -213,7 +213,7 @@ export class FromBTCLNAutoWrapper<
             swap._commitTxId = event.meta?.txId;
             swap._commitedAt ??= Date.now();
             swap._state = FromBTCLNAutoSwapState.CLAIM_COMMITED;
-            swap._broadcastSecret().catch(e => {
+            if(swap.hasSecretPreimage()) swap._broadcastSecret().catch(e => {
                 this.logger.error("processEventInitialize("+swap.getId()+"): Error when broadcasting swap secret: ", e);
             });
             return true;

--- a/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
@@ -12,7 +12,7 @@ import {UserError} from "../../../../errors/UserError";
 import {IntermediaryError} from "../../../../errors/IntermediaryError";
 import {SwapType} from "../../../../enums/SwapType";
 import {
-    extendAbortController,
+    extendAbortController, parseHashValueExact32Bytes,
     randomBytes,
     throwIfUndefined
 } from "../../../../utils/Utils";
@@ -35,14 +35,56 @@ import {LNURLWithdrawParamsWithUrl} from "../../../../types/lnurl/LNURLWithdraw"
 import {tryWithRetries} from "../../../../utils/RetryUtils";
 import {AllOptional} from "../../../../utils/TypeUtils";
 import {sha256} from "@noble/hashes/sha2";
+import {fromHumanReadableString} from "../../../../utils/TokenUtils";
 
 export type FromBTCLNAutoOptions = {
-    paymentHash?: Buffer,
+    /**
+     * Instead of letting the SDK generate the preimage/paymentHash pair internally you can pass your computed
+     *  paymentHash here, this will create the swap with the provided payment hash. Note that swaps created this way
+     *  won't settle automatically (as the SDK is missing the preimage). Once the HTLC towards the user is created in
+     *  the {@link FromBTCLNAutoSwapState.CLAIM_COMMITED} state, you should pass the secret preimage manually in the
+     *  {@link FromBTCLNAutoSwap.waitTillClaimed}, {@link FromBTCLNAutoSwap.claim} or {@link FromBTCLNAutoSwap.txsClaim}
+     *  functions.
+     *
+     * Accepts both, a {@link Buffer} and a hexadecimal `string`
+     */
+    paymentHash?: Buffer | string,
+    /**
+     * Optional description to use for the swap lightning network invoice, keep the invoice length below 500 characters
+     */
     description?: string,
-    descriptionHash?: Buffer,
+    /**
+     * Optional description hash to use for the lightning network invoice, useful when returning the invoice as part of
+     *  an LNURL-pay service endpoint.
+     *
+     * Accepts both, a {@link Buffer} and a hexadecimal `string`
+     */
+    descriptionHash?: Buffer | string,
+    /**
+     * Optional additional native token to receive as an output of the swap (e.g. STRK on Starknet or cBTC on Citrea).
+     *  When passed as a `bigint` it is specified in base units of the token and in `string` it is the human readable
+     *  decimal format.
+     */
+    gasAmount?: bigint | string,
+    /**
+     * A flag to skip checking whether the lightning network node of the LP has enough channel liquidity to facilitate
+     *  the swap.
+     */
     unsafeSkipLnNodeCheck?: boolean,
-    gasAmount?: bigint,
+    /**
+     * A flag to attach 0 watchtower fee to the swap, this would make the settlement unattractive for the watchtowers
+     *  and therefore automatic settlement for such swaps will not be possible, you will have to settle manually
+     *  with {@link FromBTCLNSwap.claim} or {@link FromBTCLNSwap.txsClaim} functions.
+     */
     unsafeZeroWatchtowerFee?: boolean,
+    /**
+     * A safety factor to use when estimating the watchtower fee to attach to the swap (this has to cover the gas fee
+     *  of watchtowers settling the swap). A higher multiple here would mean that a swap is more attractive for
+     *  watchtowers to settle automatically.
+     *
+     * Uses a `1.25` multiple by default (i.e. the current network fee is multiplied by 1.25 and then used to estimate
+     *  the settlement gas fee cost)
+     */
     feeSafetyFactor?: number
 };
 
@@ -326,25 +368,20 @@ export class FromBTCLNAutoWrapper<
         if(!this.isInitialized) throw new Error("Not initialized, call init() first!");
 
         const _options = {
-            paymentHash: options?.paymentHash,
+            paymentHash: parseHashValueExact32Bytes(options?.paymentHash, "payment hash"),
             unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? this._options.unsafeSkipLnNodeCheck,
-            gasAmount: options?.gasAmount ?? 0n,
+            gasAmount: this.parseGasAmount(options?.gasAmount),
             feeSafetyFactor: options?.feeSafetyFactor ?? 1.25, //No need to add much of a margin, since the claim should happen rather soon
             unsafeZeroWatchtowerFee: options?.unsafeZeroWatchtowerFee ?? false,
             description: options?.description,
-            descriptionHash: options?.descriptionHash
+            descriptionHash: parseHashValueExact32Bytes(options?.descriptionHash, "description hash")
         };
 
-        if(_options.paymentHash!=null && _options.paymentHash.length!==32)
-            throw new UserError("Invalid payment hash length, must be exactly 32 bytes!");
-
-        if(_options.descriptionHash!=null && _options.descriptionHash.length!==32)
-            throw new UserError("Invalid description hash length");
+        if(amountData.token===this._chain.getNativeCurrencyAddress() && _options.gasAmount!==0n)
+            throw new UserError("Cannot specify `gasAmount` for swaps to a native token!");
 
         if(_options.description!=null && Buffer.byteLength(_options.description, "utf8") > 500)
             throw new UserError("Invalid description length");
-
-        if(preFetches==null) preFetches = {};
 
         let secret: Buffer | undefined;
         let paymentHash: Buffer;
@@ -358,6 +395,8 @@ export class FromBTCLNAutoWrapper<
         const nativeTokenAddress = this._chain.getNativeCurrencyAddress();
 
         const _abortController = extendAbortController(abortSignal);
+
+        preFetches ??= {};
         const _preFetches = {
             pricePrefetchPromise: preFetches?.pricePrefetchPromise ?? this.preFetchPrice(amountData, _abortController.signal),
             usdPricePrefetchPromise: preFetches?.usdPricePrefetchPromise ?? this.preFetchUsdPrice(_abortController.signal),
@@ -497,17 +536,14 @@ export class FromBTCLNAutoWrapper<
         if(!this.isInitialized) throw new Error("Not initialized, call init() first!");
 
         const _options = {
-            paymentHash: options?.paymentHash,
+            paymentHash: parseHashValueExact32Bytes(options?.paymentHash, "payment hash"),
             unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? this._options.unsafeSkipLnNodeCheck,
-            gasAmount: options?.gasAmount ?? 0n,
+            gasAmount: this.parseGasAmount(options?.gasAmount),
             feeSafetyFactor: options?.feeSafetyFactor ?? 1.25, //No need to add much of a margin, since the claim should happen rather soon
             unsafeZeroWatchtowerFee: options?.unsafeZeroWatchtowerFee ?? false,
             description: options?.description,
-            descriptionHash: options?.descriptionHash
+            descriptionHash: parseHashValueExact32Bytes(options?.descriptionHash, "description hash")
         };
-
-        if(_options.paymentHash!=null && _options.paymentHash.length!==32)
-            throw new UserError("Invalid payment hash length, must be exactly 32 bytes!");
 
         const abortController = extendAbortController(abortSignal);
         const preFetches = {

--- a/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
@@ -174,6 +174,7 @@ export class FromBTCLNAutoWrapper<
         super(
             chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, lnApi,
             {
+                ...options,
                 safetyFactor: options?.safetyFactor ?? 2,
                 bitcoinBlocktime: options?.bitcoinBlocktime ?? 10*60,
                 unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? false

--- a/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
@@ -499,8 +499,6 @@ export class FromBTCLNAutoWrapper<
                             exactIn: amountData.exactIn ?? true
                         };
                         const quote = new FromBTCLNAutoSwap<T>(this, swapInit);
-                        await quote._save();
-                        this.logger.debug("create(): Created new FromBTCLNAutoSwap quote, claimHash (pseudo escrowHash): ", quote._getEscrowHash());
                         return quote;
                     } catch (e) {
                         abortController.abort(e);

--- a/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
@@ -3,7 +3,7 @@ import {
     ChainSwapType,
     ChainType,
     ClaimEvent,
-    InitializeEvent, LightningNetworkApi, Messenger,
+    InitializeEvent, LightningNetworkApi, LNNodeLiquidity, Messenger,
     RefundEvent, SwapCommitState, SwapCommitStateType
 } from "@atomiqlabs/base";
 import {Intermediary} from "../../../../intermediaries/Intermediary";
@@ -435,8 +435,13 @@ export class FromBTCLNAutoWrapper<
                             this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined
                         );
 
+                        let lnCapacityPromise: Promise<LNNodeLiquidity | null> | undefined;
+                        if(!_options.unsafeSkipLnNodeCheck) {
+                            lnCapacityPromise = this.preFetchLnCapacity(lnPublicKey);
+                        } else lnPublicKey.catch(() => {});
+
                         return {
-                            lnCapacityPromise: _options.unsafeSkipLnNodeCheck ? undefined : this.preFetchLnCapacity(lnPublicKey),
+                            lnCapacityPromise,
                             resp: await response
                         };
                     }, undefined, RequestError, abortController.signal);

--- a/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
@@ -211,7 +211,6 @@ export class FromBTCLNAutoWrapper<
                 return false;
             }
 
-            swap._commitTxId = event.meta?.txId;
             swap._commitedAt ??= Date.now();
             swap._state = FromBTCLNAutoSwapState.CLAIM_COMMITED;
             if(swap.hasSecretPreimage()) swap._broadcastSecret().catch(e => {
@@ -228,7 +227,6 @@ export class FromBTCLNAutoWrapper<
      */
     protected processEventClaim(swap: FromBTCLNAutoSwap<T>, event: ClaimEvent<T["Data"]>): Promise<boolean> {
         if(swap._state!==FromBTCLNAutoSwapState.FAILED && swap._state!==FromBTCLNAutoSwapState.CLAIM_CLAIMED) {
-            swap._claimTxId = event.meta?.txId;
             swap._state = FromBTCLNAutoSwapState.CLAIM_CLAIMED;
             swap._setSwapSecret(event.result);
             return Promise.resolve(true);
@@ -242,7 +240,6 @@ export class FromBTCLNAutoWrapper<
      */
     protected processEventRefund(swap: FromBTCLNAutoSwap<T>, event: RefundEvent<T["Data"]>): Promise<boolean> {
         if(swap._state!==FromBTCLNAutoSwapState.CLAIM_CLAIMED && swap._state!==FromBTCLNAutoSwapState.FAILED) {
-            swap._refundTxId ??= event.meta?.txId;
             swap._state = FromBTCLNAutoSwapState.FAILED;
             return Promise.resolve(true);
         }

--- a/src/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.ts
@@ -1191,6 +1191,8 @@ export class FromBTCSwap<T extends ChainType = ChainType>
         return changed;
     }
 
+    private btcTxLastChecked?: number;
+
     /**
      * @inheritDoc
      * @internal
@@ -1222,6 +1224,7 @@ export class FromBTCSwap<T extends ChainType = ChainType>
                 }
                 if(this.address==null) return save;
 
+                this.btcTxLastChecked = Date.now();
                 const res = await this.getBitcoinPayment();
                 if(res!=null) {
                     if(this.txId!==res.txId) {
@@ -1261,9 +1264,10 @@ export class FromBTCSwap<T extends ChainType = ChainType>
                     return true;
                 }
             case FromBTCSwapState.EXPIRED:
-                //Check if bitcoin payment was received every 2 minutes
-                if(Math.floor(Date.now()/1000)%120===0) {
+                //Check if bitcoin payment was received at least every 2 minutes
+                if(this.btcTxLastChecked==null || Date.now() - this.btcTxLastChecked > 120_000) {
                     if(this.address!=null) try {
+                        this.btcTxLastChecked = Date.now();
                         const res = await this.getBitcoinPayment();
                         if(res!=null) {
                             let shouldSave: boolean = false;

--- a/src/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.ts
@@ -333,8 +333,8 @@ export class FromBTCSwap<T extends ChainType = ChainType>
      * @inheritDoc
      * @internal
      */
-    protected canCommit(): boolean {
-        if(this._state!==FromBTCSwapState.PR_CREATED) return false;
+    protected canCommit(skipQuoteExpiryChecks?: boolean): boolean {
+        if(this._state!==FromBTCSwapState.PR_CREATED && (!skipQuoteExpiryChecks || this._state!==FromBTCSwapState.QUOTE_SOFT_EXPIRED)) return false;
         if(this.requiredConfirmations==null) return false;
         const expiry = this.wrapper._getOnchainSendTimeout(this._data, this.requiredConfirmations);
         const currentTimestamp = BigInt(Math.floor(Date.now()/1000));
@@ -900,7 +900,7 @@ export class FromBTCSwap<T extends ChainType = ChainType>
         );
 
         this._commitTxId = result[result.length - 1];
-        if(this._state===FromBTCSwapState.PR_CREATED || this._state===FromBTCSwapState.QUOTE_SOFT_EXPIRED) {
+        if(this._state===FromBTCSwapState.PR_CREATED || this._state===FromBTCSwapState.QUOTE_SOFT_EXPIRED || this._state===FromBTCSwapState.QUOTE_EXPIRED) {
             await this._saveAndEmit(FromBTCSwapState.CLAIM_COMMITED);
         }
         return this._commitTxId;

--- a/src/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.ts
@@ -356,7 +356,7 @@ export class FromBTCSwap<T extends ChainType = ChainType>
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], BtcToken<false>> {
+    getInput(): TokenAmount<BtcToken<false>> {
         return toTokenAmount(this.amount ?? null, this.inputToken, this.wrapper._prices);
     }
 
@@ -365,7 +365,7 @@ export class FromBTCSwap<T extends ChainType = ChainType>
      *  this amount is pre-funded by the user on the destination chain when the swap escrow
      *  is initiated. For total pre-funded deposit amount see {@link getTotalDeposit}.
      */
-    getClaimerBounty(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true> {
+    getClaimerBounty(): TokenAmount<SCToken<T["ChainId"]>, true> {
         return toTokenAmount(this._data.getClaimerBounty(), this.wrapper._tokens[this._data.getDepositToken()], this.wrapper._prices);
     }
 
@@ -661,7 +661,7 @@ export class FromBTCSwap<T extends ChainType = ChainType>
     /**
      * @inheritDoc
      */
-    async estimateBitcoinFee(_bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<any, BtcToken<false>, true> | null> {
+    async estimateBitcoinFee(_bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<BtcToken<false>, true> | null> {
         if(this.address==null || this.amount==null) return null;
         const bitcoinWallet: IBitcoinWallet = toBitcoinWallet(_bitcoinWallet, this.wrapper._btcRpc, this.wrapper._options.bitcoinNetwork);
         const txFee = await bitcoinWallet.getTransactionFee(this.address, this.amount, feeRate);

--- a/src/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.ts
@@ -512,7 +512,6 @@ export class FromBTCWrapper<
                             exactIn: amountData.exactIn ?? true,
                             requiredConfirmations: resp.confirmations
                         } as FromBTCSwapInit<T["Data"]>);
-                        await quote._save();
                         return quote;
                     } catch (e) {
                         abortController.abort(e);

--- a/src/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.ts
@@ -472,8 +472,13 @@ export class FromBTCWrapper<
                                 this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined
                             );
 
+                            let signDataPromise = _signDataPromise;
+                            if(signDataPromise==null) {
+                                signDataPromise = this.preFetchSignData(signDataPrefetch);
+                            } else signDataPrefetch.catch(() => {});
+
                             return {
-                                signDataPromise: _signDataPromise ?? this.preFetchSignData(signDataPrefetch),
+                                signDataPromise,
                                 resp: await response
                             };
                         }, undefined, e => e instanceof RequestError, abortController.signal);

--- a/src/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.ts
@@ -150,6 +150,7 @@ export class FromBTCWrapper<
         super(
             chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer,
             {
+                ...options,
                 bitcoinNetwork: options?.bitcoinNetwork ?? TEST_NETWORK,
                 safetyFactor: options?.safetyFactor ?? 2,
                 blocksTillTxConfirms: options?.blocksTillTxConfirms ?? 12,

--- a/src/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.ts
@@ -33,12 +33,32 @@ import {IClaimableSwapWrapper} from "../../../IClaimableSwapWrapper";
 import {IFromBTCSelfInitDefinition} from "../IFromBTCSelfInitSwap";
 import {AmountData} from "../../../../types/AmountData";
 import {tryWithRetries} from "../../../../utils/RetryUtils";
-import {AllOptional, AllRequired} from "../../../../utils/TypeUtils";
+import {AllOptional} from "../../../../utils/TypeUtils";
+import {UserError} from "../../../../errors/UserError";
 
 export type FromBTCOptions = {
-    feeSafetyFactor?: bigint,
-    blockSafetyFactor?: number,
-    unsafeZeroWatchtowerFee?: boolean
+    /**
+     * A flag to attach 0 watchtower fee to the swap, this would make the settlement unattractive for the watchtowers
+     *  and therefore automatic settlement for such swaps will not be possible, you will have to settle manually
+     *  with {@link FromBTCLNSwap.claim} or {@link FromBTCLNSwap.txsClaim} functions.
+     */
+    unsafeZeroWatchtowerFee?: boolean,
+    /**
+     * A safety factor to use when estimating the watchtower fee to attach to the swap (this has to cover the gas fee
+     *  of watchtowers settling the swap). A higher multiple here would mean that a swap is more attractive for
+     *  watchtowers to settle automatically.
+     *
+     * Uses a `1.5` multiple by default (i.e. the current network fee is multiplied by 1.5 and then used to estimate
+     *  the settlement gas fee cost).
+     *
+     * Also accepts `bigint` for legacy reasons.
+     */
+    feeSafetyFactor?: number | bigint,
+
+    /**
+     * @deprecated Removed as it is deemed not necessary
+     */
+    blockSafetyFactor?: number
 };
 
 export type FromBTCWrapperOptions = ISwapWrapperOptions & {
@@ -210,13 +230,17 @@ export class FromBTCWrapper<
     private async preFetchClaimerBounty(
         signer: string,
         amountData: AmountData,
-        options: AllRequired<FromBTCOptions>,
+        options: {
+            feeSafetyFactorPPM: bigint,
+            blockSafetyFactor: bigint,
+            unsafeZeroWatchtowerFee: boolean
+        },
         abortController: AbortController
     ): Promise<{
         feePerBlock: bigint,
-        safetyFactor: number,
+        safetyFactor: bigint,
         startTimestamp: bigint,
-        addBlock: number,
+        addBlock: bigint,
         addFee: bigint
     } | undefined> {
         const startTimestamp = BigInt(Math.floor(Date.now()/1000));
@@ -226,7 +250,7 @@ export class FromBTCWrapper<
                 feePerBlock: 0n,
                 safetyFactor: options.blockSafetyFactor,
                 startTimestamp: startTimestamp,
-                addBlock: 0,
+                addBlock: 0n,
                 addFee: 0n
             }
         }
@@ -252,11 +276,11 @@ export class FromBTCWrapper<
             const currentBtcRelayBlock = btcRelayData.blockheight;
             const addBlock = Math.max(currentBtcBlock-currentBtcRelayBlock, 0);
             return {
-                feePerBlock: feePerBlock * options.feeSafetyFactor,
+                feePerBlock: feePerBlock * options.feeSafetyFactorPPM / 1_000_000n,
                 safetyFactor: options.blockSafetyFactor,
                 startTimestamp: startTimestamp,
-                addBlock,
-                addFee: claimFeeRate * options.feeSafetyFactor
+                addBlock: BigInt(addBlock),
+                addFee: claimFeeRate * options.feeSafetyFactorPPM / 1_000_000n
             }
         } catch (e) {
             abortController.abort(e);
@@ -275,18 +299,20 @@ export class FromBTCWrapper<
      */
     private getClaimerBounty(
         data: T["Data"],
-        options: AllRequired<FromBTCOptions>,
+        options: {
+            blockSafetyFactor: bigint
+        },
         claimerBounty: {
             feePerBlock: bigint,
-            safetyFactor: number,
+            safetyFactor: bigint,
             startTimestamp: bigint,
-            addBlock: number,
+            addBlock: bigint,
             addFee: bigint
         }
     ) : bigint {
         const tsDelta = data.getExpiry() - claimerBounty.startTimestamp;
-        const blocksDelta = tsDelta / BigInt(this._options.bitcoinBlocktime) * BigInt(options.blockSafetyFactor);
-        const totalBlock = blocksDelta + BigInt(claimerBounty.addBlock);
+        const blocksDelta = tsDelta / BigInt(this._options.bitcoinBlocktime) * options.blockSafetyFactor;
+        const totalBlock = blocksDelta + claimerBounty.addBlock;
         return claimerBounty.addFee + (totalBlock * claimerBounty.feePerBlock);
     }
 
@@ -312,14 +338,16 @@ export class FromBTCWrapper<
         resp: FromBTCResponseType,
         amountData: AmountData,
         lp: Intermediary,
-        options: AllRequired<FromBTCOptions>,
+        options: {
+            blockSafetyFactor: bigint
+        },
         data: T["Data"],
         sequence: bigint,
         claimerBounty: {
             feePerBlock: bigint,
-            safetyFactor: number,
+            safetyFactor: bigint,
             startTimestamp: bigint,
-            addBlock: number,
+            addBlock: bigint,
             addFee: bigint
         },
         depositToken: string
@@ -391,9 +419,16 @@ export class FromBTCWrapper<
         quote: Promise<FromBTCSwap<T>>,
         intermediary: Intermediary
     }[] {
-        const _options: AllRequired<FromBTCOptions> = {
-            blockSafetyFactor: options?.blockSafetyFactor ?? 1,
-            feeSafetyFactor: options?.feeSafetyFactor ?? 2n,
+        let feeSafetyFactorPPM: bigint = 1_500_000n;
+        if(typeof(options?.feeSafetyFactor)==="bigint") {
+            feeSafetyFactorPPM = options.feeSafetyFactor * 1_000_000n;
+        } else if(typeof(options?.feeSafetyFactor)==="number") {
+            feeSafetyFactorPPM = BigInt(Math.floor(options.feeSafetyFactor * 1_000_000));
+        }
+
+        const _options = {
+            blockSafetyFactor: options?.blockSafetyFactor!=null ? BigInt(options.blockSafetyFactor) : 1n,
+            feeSafetyFactorPPM,
             unsafeZeroWatchtowerFee: options?.unsafeZeroWatchtowerFee ?? false
         };
 

--- a/src/swaps/escrow_swaps/tobtc/IToBTCSwap.ts
+++ b/src/swaps/escrow_swaps/tobtc/IToBTCSwap.ts
@@ -423,7 +423,7 @@ export abstract class IToBTCSwap<
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true> {
+    getInput(): TokenAmount<SCToken<T["ChainId"]>, true> {
         return toTokenAmount(
             this._data.getAmount(), this.wrapper._tokens[this._data.getToken()],
             this.wrapper._prices, this.pricingInfo
@@ -433,7 +433,7 @@ export abstract class IToBTCSwap<
     /**
      * @inheritDoc
      */
-    getInputWithoutFee(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true> {
+    getInputWithoutFee(): TokenAmount<SCToken<T["ChainId"]>, true> {
         return toTokenAmount(
             this._data.getAmount() - (this.swapFee + this.networkFee),
             this.wrapper._tokens[this._data.getToken()], this.wrapper._prices, this.pricingInfo
@@ -445,8 +445,8 @@ export abstract class IToBTCSwap<
      */
     async hasEnoughBalance(): Promise<{
         enoughBalance: boolean,
-        balance: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>,
-        required: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>
+        balance: TokenAmount<SCToken<T["ChainId"]>, true>,
+        required: TokenAmount<SCToken<T["ChainId"]>, true>
     }> {
         const [balance, commitFee] = await Promise.all([
             this.wrapper._contract.getBalance(this._getInitiator(), this._data.getToken(), false),
@@ -467,8 +467,8 @@ export abstract class IToBTCSwap<
      */
     async hasEnoughForTxFees(): Promise<{
         enoughBalance: boolean,
-        balance: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>,
-        required: TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>
+        balance: TokenAmount<SCToken<T["ChainId"]>, true>,
+        required: TokenAmount<SCToken<T["ChainId"]>, true>
     }> {
         const [balance, commitFee] = await Promise.all([
             this.wrapper._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
@@ -823,7 +823,7 @@ export abstract class IToBTCSwap<
     /**
      * Get the estimated smart chain transaction fee of the refund transaction
      */
-    async getRefundNetworkFee(): Promise<TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true>> {
+    async getRefundNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>> {
         const swapContract: T["Contract"] = this.wrapper._contract;
         return toTokenAmount(
             await swapContract.getRefundFee(this._getInitiator(), this._data),

--- a/src/swaps/escrow_swaps/tobtc/IToBTCSwap.ts
+++ b/src/swaps/escrow_swaps/tobtc/IToBTCSwap.ts
@@ -593,7 +593,7 @@ export abstract class IToBTCSwap<
      * @throws {Error} When in invalid state (not {@link ToBTCSwapState.CREATED})
      */
     async txsCommit(skipChecks?: boolean): Promise<T["TX"][]> {
-        if(this._state!==ToBTCSwapState.CREATED) throw new Error("Must be in CREATED state!");
+        if(this._state!==ToBTCSwapState.CREATED && (!skipChecks || this._state!==ToBTCSwapState.QUOTE_SOFT_EXPIRED)) throw new Error("Must be in CREATED state!");
         if(this.signatureData==null) throw new Error("Init signature data not known, cannot commit!");
 
         if(!this.initiated) {

--- a/src/swaps/escrow_swaps/tobtc/IToBTCWrapper.ts
+++ b/src/swaps/escrow_swaps/tobtc/IToBTCWrapper.ts
@@ -90,7 +90,6 @@ export abstract class IToBTCWrapper<
     protected async processEventInitialize(swap: D["Swap"], event: InitializeEvent<T["Data"]>): Promise<boolean> {
         if(swap._state===ToBTCSwapState.CREATED || swap._state===ToBTCSwapState.QUOTE_SOFT_EXPIRED) {
             swap._state = ToBTCSwapState.COMMITED;
-            if(swap._commitTxId==null) swap._commitTxId = event.meta?.txId;
             return true;
         }
         return false;
@@ -108,7 +107,6 @@ export abstract class IToBTCWrapper<
                 this.logger.warn(`processEventClaim(): Failed to set payment result ${event.result}: `, e);
             });
             swap._state = ToBTCSwapState.CLAIMED;
-            if(swap._claimTxId==null) swap._claimTxId = event.meta?.txId;
             return true;
         }
         return false;
@@ -120,7 +118,6 @@ export abstract class IToBTCWrapper<
     protected processEventRefund(swap: D["Swap"], event: RefundEvent<T["Data"]>): Promise<boolean> {
         if(swap._state!==ToBTCSwapState.CLAIMED && swap._state!==ToBTCSwapState.REFUNDED) {
             swap._state = ToBTCSwapState.REFUNDED;
-            if(swap._refundTxId==null) swap._refundTxId = event.meta?.txId;
             return Promise.resolve(true);
         }
         return Promise.resolve(false);

--- a/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNSwap.ts
+++ b/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNSwap.ts
@@ -130,7 +130,7 @@ export class ToBTCLNSwap<T extends ChainType = ChainType> extends IToBTCSwap<T, 
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], BtcToken<true>> {
+    getOutput(): TokenAmount<BtcToken<true>> {
         if(this.pr==null || !this.pr.toLowerCase().startsWith("ln"))
             return toTokenAmount(null, this.outputToken, this.wrapper._prices, this.pricingInfo);
         const parsedPR = bolt11Decode(this.pr);

--- a/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.ts
+++ b/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.ts
@@ -21,15 +21,60 @@ import {sha256} from "@noble/hashes/sha2";
 import {AmountData} from "../../../../types/AmountData";
 import {LNURLPayParamsWithUrl} from "../../../../types/lnurl/LNURLPay";
 import {tryWithRetries} from "../../../../utils/RetryUtils";
-import {AllOptional, AllRequired} from "../../../../utils/TypeUtils";
+import {AllOptional} from "../../../../utils/TypeUtils";
 import {LightningInvoiceCreateService} from "../../../../types/wallets/LightningInvoiceCreateService";
 
 export type ToBTCLNOptions = {
+    /**
+     * HTLC expiration timeout in seconds to use when offering the HTLC to the LP. Larger expirations mean that more
+     *  lightning network payment paths can be considered (every hop in the lightning network payment adds additional
+     *  timeout requirement). On the other side, larger expiration also means that user's funds are locked for longer
+     *  in case of a non-cooperative LP.
+     *
+     * Uses 5 days as default.
+     */
     expirySeconds?: number,
-    maxFee?: bigint | Promise<bigint>,
-    expiryTimestamp?: bigint,
+    /**
+     * Maximum fee for routing the swap output payment through the lightning network. Higher fee percentages means that
+     *  more payment routes can be considered (every hop in the lightning network payment adds additional fee
+     *  requirements).
+     *
+     * The fee is express as percentage of the swap value, uses `0.2` by default which means the maximum
+     *  routing fee is capped at 0.2% of the swap value.
+     *
+     * The full fee also contains the base component (set by `maxRoutingBaseFee` option), the resulting maximum routing
+     *  fee rate is:
+     *
+     * `maxRoutingFee` = `maxRoutingBaseFee` sats + `value` * `maxRoutingFeePercentage`%
+     */
+    maxRoutingFeePercentage?: number,
+    /**
+     *
+     * Maximum base fee (in sats) for routing the swap output payment through the lightning network. Higher fee
+     *  percentages means that more payment routes can be considered (every hop in the lightning network payment adds additional fee
+     *  requirements).
+     *
+     * Uses 10 sats as a default.
+     *
+     * The full fee also contains the value percentage component (set by `maxRoutingFeePercentage` option), the
+     *  resulting maximum routing fee rate is:
+     *
+     * `maxRoutingFee` = `maxRoutingBaseFee` sats + (`value` * `maxRoutingFeePercentage`%)
+     */
+    maxRoutingBaseFee?: bigint,
+
+    /**
+     * @deprecated Use `maxRoutingFeePercentage` and express the routing fee in percentage instead!
+     */
     maxRoutingPPM?: bigint,
-    maxRoutingBaseFee?: bigint
+    /**
+     * @deprecated Adjust fee with `maxRoutingFeePercentage` & `maxRoutingBaseFee` params!
+     */
+    maxFee?: bigint | Promise<bigint>,
+    /**
+     * @deprecated Pass desired HTLC expiration timeout as `expirySeconds`
+     */
+    expiryTimestamp?: bigint
 }
 
 export type ToBTCLNWrapperOptions = ISwapWrapperOptions & {
@@ -67,7 +112,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
         super(
             chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer,
             {
-                paymentTimeoutSeconds: options?.paymentTimeoutSeconds ?? 4*24*60*60,
+                paymentTimeoutSeconds: options?.paymentTimeoutSeconds ?? 5*24*60*60,
                 lightningBaseFee: options?.lightningBaseFee ?? 10,
                 lightningFeePPM: options?.lightningFeePPM ?? 2000
             },
@@ -75,10 +120,12 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
         );
     }
 
-    private toRequiredSwapOptions(amountData: AmountData, options?: ToBTCLNOptions, pricePreFetchPromise?: Promise<bigint | undefined>, abortSignal?: AbortSignal): AllRequired<ToBTCLNOptions> {
+    private toRequiredSwapOptions(amountData: AmountData, options?: ToBTCLNOptions, pricePreFetchPromise?: Promise<bigint | undefined>, abortSignal?: AbortSignal) {
         const expirySeconds = options?.expirySeconds ?? this._options.paymentTimeoutSeconds;
         const maxRoutingBaseFee = options?.maxRoutingBaseFee ?? BigInt(this._options.lightningBaseFee);
-        const maxRoutingPPM = options?.maxRoutingPPM ?? BigInt(this._options.lightningFeePPM);
+        const maxRoutingPPM = options?.maxRoutingFeePercentage!=null
+            ? BigInt(Math.floor(options.maxRoutingFeePercentage * 10_000))
+            : options?.maxRoutingPPM ?? BigInt(this._options.lightningFeePPM);
 
         let maxFee: bigint | Promise<bigint>;
         if(options?.maxFee!=null) {
@@ -97,10 +144,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
         }
 
         return {
-            expirySeconds,
             expiryTimestamp: options?.expiryTimestamp ?? BigInt(Math.floor(Date.now()/1000)+expirySeconds),
-            maxRoutingBaseFee,
-            maxRoutingPPM,
             maxFee
         }
     }
@@ -149,7 +193,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
      * @param parsedPr Parsed bolt11 lightning invoice
      * @param token Smart chain token to be used in the swap
      * @param lp
-     * @param options Swap options as passed to the swap create function
+     * @param calculatedOptions Swap options computed from the swap create options
      * @param data Parsed swap data returned by the LP
      * @param requiredTotal Required total to be paid on the input (for exactIn swaps)
      *
@@ -163,11 +207,14 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
         parsedPr: PaymentRequestObject & {tagsObject: TagsObject},
         token: string,
         lp: Intermediary,
-        options: AllRequired<ToBTCLNOptions>,
+        calculatedOptions: {
+            maxFee: bigint | Promise<bigint>,
+            expiryTimestamp: bigint
+        },
         data: T["Data"],
         requiredTotal?: bigint
     ): Promise<void> {
-        if(resp.routingFeeSats > await options.maxFee) throw new IntermediaryError("Invalid max fee sats returned");
+        if(resp.routingFeeSats > await calculatedOptions.maxFee) throw new IntermediaryError("Invalid max fee sats returned");
 
         if(requiredTotal!=null && resp.total !== requiredTotal)
             throw new IntermediaryError("Invalid data returned - total amount");
@@ -178,7 +225,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
         if(
             data.getAmount() !== resp.total ||
             !Buffer.from(data.getClaimHash(), "hex").equals(claimHash) ||
-            data.getExpiry() !== options.expiryTimestamp ||
+            data.getExpiry() !== calculatedOptions.expiryTimestamp ||
             data.getType()!==ChainSwapType.HTLC ||
             !data.isPayIn() ||
             !data.isToken(token) ||
@@ -198,7 +245,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
      * @param lp Intermediary
      * @param pr bolt11 lightning network invoice
      * @param parsedPr Parsed bolt11 lightning network invoice
-     * @param options Options as passed to the swap create function
+     * @param calculatedOptions Swap options computed from the swap create options
      * @param preFetches
      * @param abort Abort signal or controller, if AbortController is passed it is used as-is, when AbortSignal is passed
      *  it is extended with extendAbortController and then used
@@ -212,7 +259,10 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
         lp: Intermediary,
         pr: string,
         parsedPr: PaymentRequestObject & {tagsObject: TagsObject},
-        options: AllRequired<ToBTCLNOptions>,
+        calculatedOptions: {
+            maxFee: bigint | Promise<bigint>,
+            expiryTimestamp: bigint
+        },
         preFetches: {
             feeRatePromise: Promise<string | undefined>,
             pricePreFetchPromise: Promise<bigint | undefined>,
@@ -232,8 +282,8 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
                 const {signDataPrefetch, response} = IntermediaryAPI.initToBTCLN(this.chainIdentifier, lp.url, {
                     offerer: signer,
                     pr,
-                    maxFee: await options.maxFee,
-                    expiryTimestamp: options.expiryTimestamp,
+                    maxFee: await calculatedOptions.maxFee,
+                    expiryTimestamp: calculatedOptions.expiryTimestamp,
                     token: amountData.token,
                     feeRate: throwIfUndefined(preFetches.feeRatePromise),
                     additionalParams
@@ -251,7 +301,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
             const data: T["Data"] = new this._swapDataDeserializer(resp.data);
             data.setOfferer(signer);
 
-            await this.verifyReturnedData(signer, resp, parsedPr, amountData.token, lp, options, data);
+            await this.verifyReturnedData(signer, resp, parsedPr, amountData.token, lp, calculatedOptions, data);
 
             const [pricingInfo, signatureExpiry, reputation] = await Promise.all([
                 this.verifyReturnedPrice(
@@ -309,7 +359,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
     async create(
         signer: string,
         recipient: string,
-        amountData: Omit<AmountData, "amount">,
+        amountData: Omit<AmountData, "amount"> & {exactIn: false},
         lps: Intermediary[],
         options?: ToBTCLNOptions,
         additionalParams?: Record<string, any>,
@@ -328,17 +378,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
         if(parsedPr.millisatoshis==null) throw new UserError("Must be an invoice with amount");
         const amountOut: bigint = (BigInt(parsedPr.millisatoshis) + 999n) / 1000n;
 
-        const expirySeconds = options?.expirySeconds ?? this._options.paymentTimeoutSeconds;
-        const maxRoutingBaseFee = options?.maxRoutingBaseFee ?? BigInt(this._options.lightningBaseFee);
-        const maxRoutingPPM = options?.maxRoutingPPM ?? BigInt(this._options.lightningFeePPM);
-
-        const _options: AllRequired<ToBTCLNOptions> = {
-            expirySeconds,
-            expiryTimestamp: options?.expiryTimestamp ?? BigInt(Math.floor(Date.now()/1000)+expirySeconds),
-            maxRoutingBaseFee,
-            maxRoutingPPM,
-            maxFee: options?.maxFee ?? this.calculateFeeForAmount(amountOut, maxRoutingBaseFee, maxRoutingPPM)
-        }
+        const _options = this.toRequiredSwapOptions({...amountData, amount: amountOut}, options);
 
         if(parsedPr.tagsObject.payment_hash==null) throw new Error("Provided lightning invoice doesn't contain payment hash field!");
         await this.checkPaymentHashWasPaid(parsedPr.tagsObject.payment_hash);
@@ -388,7 +428,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
      * @param lp Intermediary (LPs) to get the quote from
      * @param dummyPr Dummy minimum value bolt11 lightning invoice returned from the LNURL-pay, used to estimate
      *  network fees for an actual invoice
-     * @param options Optional additional quote options
+     * @param calculatedOptions Swap options computed from the swap create options
      * @param preFetches Optional existing pre-fetch promises for the swap (only used internally for LNURL swaps)
      * @param abortSignal Abort signal
      * @param additionalParams Additional params to be sent to the intermediary
@@ -401,7 +441,10 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
         invoiceCreateService: LightningInvoiceCreateService,
         lp: Intermediary,
         dummyPr: string,
-        options: AllRequired<ToBTCLNOptions> & {comment?: string},
+        calculatedOptions: {
+            maxFee: bigint | Promise<bigint>,
+            expiryTimestamp: bigint
+        },
         preFetches: {
             feeRatePromise: Promise<string | undefined>,
             pricePreFetchPromise: Promise<bigint | undefined>,
@@ -422,8 +465,8 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
                     offerer: signer,
                     pr: dummyPr,
                     amount: amountData.amount,
-                    maxFee: await options.maxFee,
-                    expiryTimestamp: options.expiryTimestamp,
+                    maxFee: await calculatedOptions.maxFee,
+                    expiryTimestamp: calculatedOptions.expiryTimestamp,
                     additionalParams
                 }, this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined);
 
@@ -462,7 +505,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
             const data: T["Data"] = new this._swapDataDeserializer(resp.data);
             data.setOfferer(signer);
 
-            await this.verifyReturnedData(signer, resp, parsedInvoice, amountData.token, lp, options, data, amountData.amount);
+            await this.verifyReturnedData(signer, resp, parsedInvoice, amountData.token, lp, calculatedOptions, data, amountData.amount);
 
             const [pricingInfo, signatureExpiry, reputation] = await Promise.all([
                 this.verifyReturnedPrice(
@@ -570,7 +613,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
 
                 const invoice = await invoiceCreateService.getInvoice(Number(amountData.amount), _abortController.signal);
 
-                return (await this.create(signer, invoice, amountData, lps, options, additionalParams, _abortController.signal, {
+                return (await this.create(signer, invoice, {...amountData, exactIn: false}, lps, options, additionalParams, _abortController.signal, {
                     feeRatePromise,
                     pricePreFetchPromise,
                     usdPricePrefetchPromise,

--- a/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.ts
+++ b/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.ts
@@ -289,8 +289,13 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
                     additionalParams
                 }, this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined);
 
+                let signDataPromise = preFetches.signDataPrefetchPromise;
+                if(signDataPromise==null) {
+                    signDataPromise = this.preFetchSignData(signDataPrefetch);
+                } else signDataPrefetch.catch(() => {});
+
                 return {
-                    signDataPromise: preFetches.signDataPrefetchPromise ?? this.preFetchSignData(signDataPrefetch),
+                    signDataPromise,
                     resp: await response
                 };
             }, undefined, e => e instanceof RequestError, abortController.signal);

--- a/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.ts
+++ b/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.ts
@@ -341,7 +341,6 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
                 pr,
                 exactIn: false
             } as IToBTCSwapInit<T["Data"]>);
-            await quote._save();
             return quote;
         } catch (e) {
             abortController.abort(e);
@@ -545,7 +544,6 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
                 pr: invoice,
                 exactIn: true
             } as IToBTCSwapInit<T["Data"]>);
-            await quote._save();
             return quote;
         } catch (e) {
             abortController.abort(e);

--- a/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.ts
+++ b/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.ts
@@ -112,6 +112,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
         super(
             chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer,
             {
+                ...options,
                 paymentTimeoutSeconds: options?.paymentTimeoutSeconds ?? 5*24*60*60,
                 lightningBaseFee: options?.lightningBaseFee ?? 10,
                 lightningFeePPM: options?.lightningFeePPM ?? 2000

--- a/src/swaps/escrow_swaps/tobtc/onchain/ToBTCSwap.ts
+++ b/src/swaps/escrow_swaps/tobtc/onchain/ToBTCSwap.ts
@@ -154,7 +154,7 @@ export class ToBTCSwap<T extends ChainType = ChainType> extends IToBTCSwap<T, To
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], BtcToken<false>> {
+    getOutput(): TokenAmount<BtcToken<false>> {
         return toTokenAmount(this.amount ?? null, this.outputToken, this.wrapper._prices, this.pricingInfo);
     }
 

--- a/src/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.ts
+++ b/src/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.ts
@@ -97,6 +97,7 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
         super(
             chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer,
             {
+                ...options,
                 bitcoinNetwork: options?.bitcoinNetwork ?? TEST_NETWORK,
                 safetyFactor: options?.safetyFactor ?? 2,
                 maxConfirmations: options?.maxConfirmations ?? 6,

--- a/src/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.ts
+++ b/src/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.ts
@@ -272,8 +272,13 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
                                 additionalParams
                             }, this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined);
 
+                            let signDataPromise = _signDataPromise;
+                            if(signDataPromise==null) {
+                                signDataPromise = this.preFetchSignData(signDataPrefetch);
+                            } else signDataPrefetch.catch(() => {});
+
                             return {
-                                signDataPromise: _signDataPromise ?? this.preFetchSignData(signDataPrefetch),
+                                signDataPromise,
                                 resp: await response
                             };
                         }, undefined, RequestError, abortController.signal);

--- a/src/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.ts
+++ b/src/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.ts
@@ -325,7 +325,6 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
                             requiredConfirmations: _options.confirmations,
                             nonce
                         } as ToBTCSwapInit<T["Data"]>);
-                        await quote._save();
                         return quote;
                     } catch (e) {
                         abortController.abort(e);

--- a/src/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.ts
+++ b/src/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.ts
@@ -25,11 +25,17 @@ import {UnifiedSwapStorage} from "../../../../storage/UnifiedSwapStorage";
 import {ISwap} from "../../../ISwap";
 import {AmountData} from "../../../../types/AmountData";
 import {tryWithRetries} from "../../../../utils/RetryUtils";
-import {AllOptional, AllRequired} from "../../../../utils/TypeUtils";
+import {AllOptional} from "../../../../utils/TypeUtils";
 import {ToBTCSwapState} from "../IToBTCSwap";
 
 export type ToBTCOptions = {
+    /**
+     * @deprecated Ignored by the LP anyway
+     */
     confirmationTarget?: number,
+    /**
+     * @deprecated Default 2 confirmations should be enough for any currently supported amount by atomiq
+     */
     confirmations?: number
 }
 
@@ -154,7 +160,10 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
         resp: ToBTCResponseType,
         amountData: AmountData,
         lp: Intermediary,
-        options: AllRequired<ToBTCOptions>,
+        options: {
+            confirmations: number,
+            confirmationTarget: number
+        },
         data: T["Data"],
         hash: string
     ): void {
@@ -220,7 +229,7 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
         intermediary: Intermediary
     }[] {
         if(!this.isInitialized) throw new Error("Not initialized, call init() first!");
-        const _options: AllRequired<ToBTCOptions> = {
+        const _options = {
             confirmationTarget: options?.confirmationTarget ?? 3,
             confirmations: options?.confirmations ?? 2
         };

--- a/src/swaps/spv_swaps/SpvFromBTCSwap.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCSwap.ts
@@ -193,6 +193,8 @@ export class SpvFromBTCSwap<T extends ChainType>
     extends ISwap<T, SpvFromBTCTypeDefinition<T>>
     implements IBTCWalletSwap, ISwapWithGasDrop<T>, IClaimableSwap<T, SpvFromBTCTypeDefinition<T>, SpvFromBTCSwapState> {
 
+    protected readonly currentVersion: number = 2;
+
     readonly TYPE: SwapType.SPV_VAULT_FROM_BTC = SwapType.SPV_VAULT_FROM_BTC;
 
     /**
@@ -239,6 +241,8 @@ export class SpvFromBTCSwap<T extends ChainType>
     private readonly executionFeeShare: bigint;
 
     private readonly gasPricingInfo?: PriceInfoType;
+
+    private posted?: boolean;
 
     /**
      * @internal
@@ -337,6 +341,7 @@ export class SpvFromBTCSwap<T extends ChainType>
             this._frontTxId = initOrObject.frontTxId;
             this.gasPricingInfo = deserializePriceInfoType(initOrObject.gasPricingInfo);
             this.btcTxConfirmedAt = initOrObject.btcTxConfirmedAt;
+            this.posted = initOrObject.posted;
             if(initOrObject.data!=null) this._data = new this.wrapper._spvWithdrawalDataDeserializer(initOrObject.data);
         }
         this.tryCalculateSwapFee();
@@ -347,7 +352,11 @@ export class SpvFromBTCSwap<T extends ChainType>
      * @inheritDoc
      * @internal
      */
-    protected upgradeVersion() { /*NOOP*/ }
+    protected upgradeVersion() {
+        if(this.version===1) {
+            this.posted = this.initiated;
+        }
+    }
 
     /**
      * @inheritDoc
@@ -973,6 +982,7 @@ export class SpvFromBTCSwap<T extends ChainType>
 
         this._data = data;
         this.initiated = true;
+        this.posted = true;
         await this._saveAndEmit(SpvFromBTCSwapState.SIGNED);
 
         try {
@@ -1186,7 +1196,7 @@ export class SpvFromBTCSwap<T extends ChainType>
         if(
             this._state!==SpvFromBTCSwapState.POSTED &&
             this._state!==SpvFromBTCSwapState.BROADCASTED &&
-            !(this._state===SpvFromBTCSwapState.QUOTE_SOFT_EXPIRED && this.initiated)
+            !(this._state===SpvFromBTCSwapState.QUOTE_SOFT_EXPIRED && this.posted)
         ) throw new Error("Must be in POSTED or BROADCASTED state!");
         if(this._data==null) throw new Error("Expected swap to have withdrawal data filled!");
 
@@ -1529,6 +1539,7 @@ export class SpvFromBTCSwap<T extends ChainType>
             executionFeeShare: this.executionFeeShare.toString(10),
             genesisSmartChainBlockHeight: this._genesisSmartChainBlockHeight,
             gasPricingInfo: serializePriceInfoType(this.gasPricingInfo),
+            posted: this.posted,
 
             senderAddress: this._senderAddress,
             claimTxId: this._claimTxId,
@@ -1704,7 +1715,7 @@ export class SpvFromBTCSwap<T extends ChainType>
             }
         }
 
-        if(this._state===SpvFromBTCSwapState.QUOTE_SOFT_EXPIRED && !this.initiated) {
+        if(this._state===SpvFromBTCSwapState.QUOTE_SOFT_EXPIRED && !this.posted) {
             if(this.expiry<Date.now()) {
                 this._state = SpvFromBTCSwapState.QUOTE_EXPIRED;
                 if(save) await this._saveAndEmit();

--- a/src/swaps/spv_swaps/SpvFromBTCSwap.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCSwap.ts
@@ -582,7 +582,7 @@ export class SpvFromBTCSwap<T extends ChainType>
      *
      * @internal
      */
-    protected getOutputWithoutFee(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true> {
+    protected getOutputWithoutFee(): TokenAmount<SCToken<T["ChainId"]>, true> {
         return toTokenAmount(
             (this.outputTotalSwap * (100_000n + this.callerFeeShare + this.frontingFeeShare + this.executionFeeShare) / 100_000n) + (this.swapFee ?? 0n),
             this.wrapper._tokens[this.outputSwapToken], this.wrapper._prices, this.pricingInfo
@@ -704,21 +704,21 @@ export class SpvFromBTCSwap<T extends ChainType>
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true> {
+    getOutput(): TokenAmount<SCToken<T["ChainId"]>, true> {
         return toTokenAmount(this.outputTotalSwap, this.wrapper._tokens[this.outputSwapToken], this.wrapper._prices, this.pricingInfo);
     }
 
     /**
      * @inheritDoc
      */
-    getGasDropOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true> {
+    getGasDropOutput(): TokenAmount<SCToken<T["ChainId"]>, true> {
         return toTokenAmount(this.outputTotalGas, this.wrapper._tokens[this.outputGasToken], this.wrapper._prices, this.gasPricingInfo);
     }
 
     /**
      * @inheritDoc
      */
-    getInputWithoutFee(): TokenAmount<T["ChainId"], BtcToken<false>, true> {
+    getInputWithoutFee(): TokenAmount<BtcToken<false>, true> {
         return toTokenAmount(this.getInputAmountWithoutFee(), BitcoinTokens.BTC, this.wrapper._prices, this.pricingInfo);
     }
 
@@ -732,7 +732,7 @@ export class SpvFromBTCSwap<T extends ChainType>
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], BtcToken<false>, true> {
+    getInput(): TokenAmount<BtcToken<false>, true> {
         return toTokenAmount(this.btcAmount, BitcoinTokens.BTC, this.wrapper._prices, this.pricingInfo);
     }
 
@@ -996,7 +996,7 @@ export class SpvFromBTCSwap<T extends ChainType>
     /**
      * @inheritDoc
      */
-    async estimateBitcoinFee(_bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<any, BtcToken<false>, true> | null> {
+    async estimateBitcoinFee(_bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<BtcToken<false>, true> | null> {
         const bitcoinWallet: IBitcoinWallet = toBitcoinWallet(_bitcoinWallet, this.wrapper._btcRpc, this.wrapper._options.bitcoinNetwork);
         const txFee = await bitcoinWallet.getFundedPsbtFee((await this.getPsbt()).psbt, feeRate);
         if(txFee==null) return null;

--- a/src/swaps/spv_swaps/SpvFromBTCSwap.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCSwap.ts
@@ -355,6 +355,7 @@ export class SpvFromBTCSwap<T extends ChainType>
     protected upgradeVersion() {
         if(this.version===1) {
             this.posted = this.initiated;
+            this.version = 2;
         }
     }
 

--- a/src/swaps/spv_swaps/SpvFromBTCSwap.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCSwap.ts
@@ -1571,6 +1571,8 @@ export class SpvFromBTCSwap<T extends ChainType>
         this._senderAddress = btcTx.inputAddresses[1];
     }
 
+    private btcTxLastChecked?: number;
+
     /**
      * @internal
      */
@@ -1578,6 +1580,7 @@ export class SpvFromBTCSwap<T extends ChainType>
         if(this._data?.btcTx==null) return false;
 
         //Check if bitcoin payment was confirmed
+        this.btcTxLastChecked = Date.now();
         const res = await this.getBitcoinPayment();
         if(res==null) {
             //Check inputs double-spent
@@ -1724,7 +1727,7 @@ export class SpvFromBTCSwap<T extends ChainType>
             }
         }
 
-        if(Math.floor(Date.now()/1000)%120===0) {
+        if(this.btcTxLastChecked==null || Date.now() - this.btcTxLastChecked > 120_000) {
             if (
                 this._state === SpvFromBTCSwapState.POSTED ||
                 this._state === SpvFromBTCSwapState.BROADCASTED

--- a/src/swaps/spv_swaps/SpvFromBTCSwap.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCSwap.ts
@@ -354,7 +354,7 @@ export class SpvFromBTCSwap<T extends ChainType>
      */
     protected upgradeVersion() {
         if(this.version===1) {
-            this.posted = this.initiated;
+            this.posted = this.initiated && this._data!=null;
             this.version = 2;
         }
     }

--- a/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
@@ -709,7 +709,6 @@ export class SpvFromBTCWrapper<
                             )
                         };
                         const quote = new SpvFromBTCSwap<T>(this, swapInit);
-                        await quote._save();
                         return quote;
                     } catch (e) {
                         abortController.abort(e);

--- a/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
@@ -32,13 +32,47 @@ import {ISwap} from "../ISwap";
 import {IClaimableSwapWrapper} from "../IClaimableSwapWrapper";
 import {AmountData} from "../../types/AmountData";
 import {tryWithRetries} from "../../utils/RetryUtils";
-import {AllOptional, AllRequired} from "../../utils/TypeUtils";
+import {AllOptional} from "../../utils/TypeUtils";
+import {fromHumanReadableString} from "../../utils/TokenUtils";
+import {UserError} from "../../errors/UserError";
 
 export type SpvFromBTCOptions = {
-    gasAmount?: bigint,
+    /**
+     * Optional additional native token to receive as an output of the swap (e.g. STRK on Starknet or cBTC on Citrea).
+     *
+     * When passed as a `bigint` it is specified in base units of the token and in `string` it is the human readable
+     *  decimal format.
+     */
+    gasAmount?: bigint | string,
+    /**
+     * The LP enforces a minimum bitcoin fee rate in sats/vB for the swap transaction. With this config you can optionally
+     *  limit how high of a minimum fee rate would you accept.
+     *
+     * By default the maximum allowed fee rate is calculated dynamically based on current bitcoin fee rate as:
+     *
+     * `maxAllowedBitcoinFeeRate` = 10 + `currentBitcoinFeeRate` * 1.5
+     */
+    maxAllowedBitcoinFeeRate?: number,
+    /**
+     * A flag to attach 0 watchtower fee to the swap, this would make the settlement unattractive for the watchtowers
+     *  and therefore automatic settlement for such swaps will not be possible, you will have to settle manually
+     *  with {@link FromBTCLNSwap.claim} or {@link FromBTCLNSwap.txsClaim} functions.
+     */
     unsafeZeroWatchtowerFee?: boolean,
+    /**
+     * A safety factor to use when estimating the watchtower fee to attach to the swap (this has to cover the gas fee
+     *  of watchtowers settling the swap). A higher multiple here would mean that a swap is more attractive for
+     *  watchtowers to settle automatically.
+     *
+     * Uses a `1.25` multiple by default (i.e. the current network fee is multiplied by 1.25 and then used to estimate
+     *  the settlement gas fee cost)
+     */
     feeSafetyFactor?: number,
-    maxAllowedNetworkFeeRate?: number
+
+    /**
+     * @deprecated Use `maxAllowedBitcoinFeeRate` instead!
+     */
+    maxAllowedNetworkFeeRate?: number,
 };
 
 export type SpvFromBTCWrapperOptions = ISwapWrapperOptions & {
@@ -275,7 +309,10 @@ export class SpvFromBTCWrapper<
      */
     private async preFetchCallerFeeShare(
         amountData: AmountData,
-        options: AllRequired<SpvFromBTCOptions>,
+        options: {
+            unsafeZeroWatchtowerFee: boolean,
+            feeSafetyFactor: number
+        },
         pricePrefetch: Promise<bigint | undefined>,
         nativeTokenPricePrefetch: Promise<bigint | undefined> | undefined,
         abortController: AbortController
@@ -355,7 +392,9 @@ export class SpvFromBTCWrapper<
         resp: SpvFromBTCPrepareResponseType,
         amountData: AmountData,
         lp: Intermediary,
-        options: SpvFromBTCOptions,
+        options: {
+            gasAmount: bigint
+        },
         callerFeeShare: bigint,
         bitcoinFeeRatePromise: Promise<number | undefined>,
         abortSignal: AbortSignal
@@ -438,7 +477,7 @@ export class SpvFromBTCWrapper<
                         throw new IntermediaryError("Invalid amount0 multiplier used, rawAmount diff too high");
                     if(resp.total !== adjustedAmount) throw new IntermediaryError("Invalid total returned");
                 }
-                if(options.gasAmount==null || options.gasAmount===0n) {
+                if(options.gasAmount===0n) {
                     if(resp.totalGas !== 0n) throw new IntermediaryError("Invalid gas total returned");
                 } else {
                     //Check the difference between amount adjusted due to scaling to raw amount
@@ -548,12 +587,15 @@ export class SpvFromBTCWrapper<
         quote: Promise<SpvFromBTCSwap<T>>,
         intermediary: Intermediary
     }[] {
-        const _options: AllRequired<SpvFromBTCOptions> = {
-            gasAmount: options?.gasAmount ?? 0n,
+        const _options = {
+            gasAmount: this.parseGasAmount(options?.gasAmount),
             unsafeZeroWatchtowerFee: options?.unsafeZeroWatchtowerFee ?? false,
             feeSafetyFactor: options?.feeSafetyFactor ?? 1.25,
-            maxAllowedNetworkFeeRate: options?.maxAllowedNetworkFeeRate ?? Infinity
+            maxAllowedBitcoinFeeRate: options?.maxAllowedBitcoinFeeRate ?? options?.maxAllowedNetworkFeeRate ?? Infinity
         };
+
+        if(amountData.token===this._chain.getNativeCurrencyAddress() && _options.gasAmount!==0n)
+            throw new UserError("Cannot specify `gasAmount` for swaps to a native token!");
 
         const _abortController = extendAbortController(abortSignal);
         const pricePrefetchPromise: Promise<bigint | undefined> = this.preFetchPrice(amountData, _abortController.signal);
@@ -564,8 +606,8 @@ export class SpvFromBTCWrapper<
             undefined :
             this.preFetchPrice({token: nativeTokenAddress}, _abortController.signal);
         const callerFeePrefetchPromise = this.preFetchCallerFeeShare(amountData, _options, pricePrefetchPromise, gasTokenPricePrefetchPromise, _abortController);
-        const bitcoinFeeRatePromise: Promise<number | undefined> = _options.maxAllowedNetworkFeeRate!=Infinity ?
-            Promise.resolve(_options.maxAllowedNetworkFeeRate) :
+        const bitcoinFeeRatePromise: Promise<number | undefined> = _options.maxAllowedBitcoinFeeRate!=Infinity ?
+            Promise.resolve(_options.maxAllowedBitcoinFeeRate) :
             this._btcRpc.getFeeRate().then(x => this._options.maxBtcFeeOffset + (x*this._options.maxBtcFeeMultiplier)).catch(e => {
                 _abortController.abort(e);
                 return undefined;

--- a/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
@@ -211,7 +211,6 @@ export class SpvFromBTCWrapper<
             swap._state===SpvFromBTCSwapState.QUOTE_SOFT_EXPIRED || swap._state===SpvFromBTCSwapState.BTC_TX_CONFIRMED
         ) {
             swap._state = SpvFromBTCSwapState.FRONTED;
-            swap._frontTxId = event.meta?.txId;
             await swap._setBitcoinTxId(event.btcTxId).catch(e => {
                 this.logger.warn("processEventFront(): Failed to set bitcoin txId: ", e);
             });
@@ -228,7 +227,6 @@ export class SpvFromBTCWrapper<
             swap._state===SpvFromBTCSwapState.BTC_TX_CONFIRMED
         ) {
             swap._state = SpvFromBTCSwapState.CLAIMED;
-            swap._claimTxId = event.meta?.txId;
             await swap._setBitcoinTxId(event.btcTxId).catch(e => {
                 this.logger.warn("processEventClaim(): Failed to set bitcoin txId: ", e);
             });

--- a/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
@@ -186,6 +186,7 @@ export class SpvFromBTCWrapper<
         super(
             chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens,
             {
+                ...options,
                 bitcoinNetwork: options?.bitcoinNetwork ?? TEST_NETWORK,
                 maxConfirmations: options?.maxConfirmations ?? 6,
                 bitcoinBlocktime: options?.bitcoinBlocktime ?? 10*60,

--- a/src/swaps/trusted/ln/LnForGasSwap.ts
+++ b/src/swaps/trusted/ln/LnForGasSwap.ts
@@ -318,7 +318,7 @@ export class LnForGasSwap<T extends ChainType = ChainType> extends ISwap<T, LnFo
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true> {
+    getOutput(): TokenAmount<SCToken<T["ChainId"]>, true> {
         return toTokenAmount(
             this.outputAmount, this.wrapper._tokens[this.wrapper._chain.getNativeCurrencyAddress()],
             this.wrapper._prices, this.pricingInfo
@@ -335,7 +335,7 @@ export class LnForGasSwap<T extends ChainType = ChainType> extends ISwap<T, LnFo
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], BtcToken<true>, true> {
+    getInput(): TokenAmount<BtcToken<true>, true> {
         const parsed = bolt11Decode(this.pr);
         const msats = parsed.millisatoshis;
         if(msats==null) throw new Error("Swap lightning invoice has no msat amount field!");
@@ -346,7 +346,7 @@ export class LnForGasSwap<T extends ChainType = ChainType> extends ISwap<T, LnFo
     /**
      * @inheritDoc
      */
-    getInputWithoutFee(): TokenAmount<T["ChainId"], BtcToken<true>, true> {
+    getInputWithoutFee(): TokenAmount<BtcToken<true>, true> {
         const parsed = bolt11Decode(this.pr);
         const msats = parsed.millisatoshis;
         if(msats==null) throw new Error("Swap lightning invoice has no msat amount field!");

--- a/src/swaps/trusted/ln/LnForGasWrapper.ts
+++ b/src/swaps/trusted/ln/LnForGasWrapper.ts
@@ -84,7 +84,6 @@ export class LnForGasWrapper<T extends ChainType> extends ISwapWrapper<T, LnForG
             exactIn: false
         };
         const quote = new LnForGasSwap(this, quoteInit);
-        await quote._save();
         return quote;
     }
 

--- a/src/swaps/trusted/onchain/OnchainForGasSwap.ts
+++ b/src/swaps/trusted/onchain/OnchainForGasSwap.ts
@@ -362,7 +362,7 @@ export class OnchainForGasSwap<T extends ChainType = ChainType> extends ISwap<T,
     /**
      * @inheritDoc
      */
-    getOutput(): TokenAmount<T["ChainId"], SCToken<T["ChainId"]>, true> {
+    getOutput(): TokenAmount<SCToken<T["ChainId"]>, true> {
         return toTokenAmount(
             this.outputAmount, this.wrapper._tokens[this.wrapper._chain.getNativeCurrencyAddress()],
             this.wrapper._prices, this.pricingInfo
@@ -379,14 +379,14 @@ export class OnchainForGasSwap<T extends ChainType = ChainType> extends ISwap<T,
     /**
      * @inheritDoc
      */
-    getInput(): TokenAmount<T["ChainId"], BtcToken<false>, true> {
+    getInput(): TokenAmount<BtcToken<false>, true> {
         return toTokenAmount(this.inputAmount, BitcoinTokens.BTC, this.wrapper._prices, this.pricingInfo);
     }
 
     /**
      * @inheritDoc
      */
-    getInputWithoutFee(): TokenAmount<T["ChainId"], BtcToken<false>, true> {
+    getInputWithoutFee(): TokenAmount<BtcToken<false>, true> {
         return toTokenAmount(
             this.inputAmount - (this.swapFeeBtc ?? 0n), BitcoinTokens.BTC,
             this.wrapper._prices, this.pricingInfo
@@ -526,7 +526,7 @@ export class OnchainForGasSwap<T extends ChainType = ChainType> extends ISwap<T,
     /**
      * @inheritDoc
      */
-    async estimateBitcoinFee(_bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<any, BtcToken<false>, true> | null> {
+    async estimateBitcoinFee(_bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number): Promise<TokenAmount<BtcToken<false>, true> | null> {
         const bitcoinWallet: IBitcoinWallet = toBitcoinWallet(_bitcoinWallet, this.wrapper._btcRpc, this.wrapper._options.bitcoinNetwork);
         const txFee = await bitcoinWallet.getTransactionFee(this.address, this.inputAmount, feeRate);
         if(txFee==null) return null;

--- a/src/swaps/trusted/onchain/OnchainForGasWrapper.ts
+++ b/src/swaps/trusted/onchain/OnchainForGasWrapper.ts
@@ -124,7 +124,6 @@ export class OnchainForGasWrapper<T extends ChainType> extends ISwapWrapper<T, O
             exactIn: false,
             token
         } as OnchainForGasSwapInit);
-        await quote._save();
         return quote;
     }
 

--- a/src/types/Token.ts
+++ b/src/types/Token.ts
@@ -4,21 +4,51 @@
  * @category Tokens
  */
 export type Token<ChainIdentifier extends string = string> = {
+    /**
+     * Chain identifier for the token's chain
+     */
     chainId: ChainIdentifier | "BITCOIN" | "LIGHTNING",
 
+    /**
+     * Ticker of the token
+     */
     ticker: string,
+    /**
+     * Full name of the token
+     */
     name: string,
+    /**
+     * Actual decimal places of the tokens
+     */
     decimals: number,
+    /**
+     * The decimal places that should be rendered and displayed to the user
+     */
     displayDecimals?: number,
 
+    /**
+     * Address of the token contract, or `""` for Bitcoin
+     */
     address: string,
 
     // legacy compatibility
+    /**
+     * Legacy chain identifier distinguishing between Smart Chain and Bitcoin tokens
+     */
     chain: "SC" | "BTC",
+    /**
+     * Legacy lightning flag, determines whether a Bitcoin token is an Lightning or on-chain one
+     */
     lightning?: boolean,
 
     // helpers
+    /**
+     * Equality check between tokens
+     */
     equals: (other: Token) => boolean,
+    /**
+     * Returns the
+     */
     toString: () => string
 };
 
@@ -51,7 +81,9 @@ export type BtcToken<L = boolean> = Token & {
 
     // legacy compatibility
     chain: "BTC",
-    lightning: L
+    lightning: L,
+
+    toString: () => L extends true ? "BTC-LN" : "BTC"
 };
 
 /**
@@ -111,6 +143,8 @@ export const BitcoinTokens: {
 export type SCToken<ChainIdentifier extends string = string> = Token<ChainIdentifier> & {
     chainId: ChainIdentifier,
     chain: "SC"
+
+    toString: () => `${ChainIdentifier}-${string}`
 };
 
 /**

--- a/src/types/Token.ts
+++ b/src/types/Token.ts
@@ -1,15 +1,57 @@
 /**
+ * Type for all token types (BTC or smart chain)
+ *
+ * @category Tokens
+ */
+export type Token<ChainIdentifier extends string = string> = {
+    chainId: ChainIdentifier | "BITCOIN" | "LIGHTNING",
+
+    ticker: string,
+    name: string,
+    decimals: number,
+    displayDecimals?: number,
+
+    address: string,
+
+    // legacy compatibility
+    chain: "SC" | "BTC",
+    lightning?: boolean,
+
+    // helpers
+    equals: (other: Token) => boolean,
+    toString: () => string
+};
+
+/**
+ * Type guard for a {@link Token} type, encompassing all tokens (BTC or smart chain)
+ *
+ * @category Tokens
+ */
+export function isToken(obj: any): obj is Token {
+    return typeof (obj) === "object" &&
+      (obj.chain === "SC" || obj.chain === "BTC") &&
+      typeof (obj.ticker) === "string" &&
+      typeof (obj.decimals) === "number" &&
+      typeof (obj.name) === "string";
+}
+
+/**
  * Bitcoin token type (BTC on on-chain or lightning)
  *
  * @category Tokens
  */
-export type BtcToken<L = boolean> = {
-    chain: "BTC",
-    lightning: L,
+export type BtcToken<L = boolean> = Token & {
+    chainId: L extends true ? "LIGHTNING" : "BITCOIN",
     ticker: "BTC",
-    decimals: 8,
     name: L extends true ? "Bitcoin (lightning L2)" : "Bitcoin (on-chain L1)",
-    displayDecimals?: number
+    decimals: 8,
+    displayDecimals: 8,
+
+    address: "",
+
+    // legacy compatibility
+    chain: "BTC",
+    lightning: L
 };
 
 /**
@@ -37,17 +79,27 @@ export const BitcoinTokens: {
 } = {
     BTC: {
         chain: "BTC",
+        chainId: "BITCOIN",
         lightning: false,
         ticker: "BTC",
         decimals: 8,
-        name: "Bitcoin (on-chain L1)"
+        displayDecimals: 8,
+        name: "Bitcoin (on-chain L1)",
+        address: "",
+        equals: (other: Token) => other.chainId==="BITCOIN" && other.ticker==="BTC",
+        toString: () => "BTC"
     },
     BTCLN: {
         chain: "BTC",
+        chainId: "LIGHTNING",
         lightning: true,
         ticker: "BTC",
         decimals: 8,
-        name: "Bitcoin (lightning L2)"
+        displayDecimals: 8,
+        name: "Bitcoin (lightning L2)",
+        address: "",
+        equals: (other: Token) => other.chainId==="LIGHTNING" && other.ticker==="BTC",
+        toString: () => "BTC-LN"
     }
 };
 
@@ -56,42 +108,22 @@ export const BitcoinTokens: {
  *
  * @category Tokens
  */
-export type SCToken<ChainIdentifier extends string = string> = {
-    chain: "SC",
+export type SCToken<ChainIdentifier extends string = string> = Token<ChainIdentifier> & {
     chainId: ChainIdentifier,
-    address: string,
-    ticker: string,
-    decimals: number,
-    displayDecimals?: number,
-    name: string
-}
+    chain: "SC"
+};
 
 /**
  * Type guard for {@link SCToken} (token on the smart chain)
  * @category Tokens
  */
-export function isSCToken(obj: any): obj is SCToken {
+export function isSCToken<ChainIdentifier extends string = string>(obj: any, chainIdentifier?: ChainIdentifier[]): obj is SCToken<ChainIdentifier> {
     return typeof (obj) === "object" &&
         obj.chain === "SC" &&
         typeof (obj.chainId) === "string" &&
+        (chainIdentifier==null || chainIdentifier.includes(obj.chainId)) &&
         typeof (obj.address) === "string" &&
         typeof (obj.ticker) === "string" &&
         typeof (obj.decimals) === "number" &&
         typeof (obj.name) === "string";
-}
-
-/**
- * Union type for all token types (BTC or smart chain)
- *
- * @category Tokens
- */
-export type Token<ChainIdentifier extends string = string> = BtcToken | SCToken<ChainIdentifier>;
-
-/**
- * Type guard for an union {@link Token} type, encompassing all tokens (BTC or smart chain)
- *
- * @category Tokens
- */
-export function isToken(obj: any): obj is Token {
-    return isBtcToken(obj) || isSCToken(obj);
 }

--- a/src/types/TokenAmount.ts
+++ b/src/types/TokenAmount.ts
@@ -9,8 +9,7 @@ import {toDecimal} from "../utils/Utils";
  * @category Tokens
  */
 export type TokenAmount<
-    ChainIdentifier extends string = string,
-    T extends Token<ChainIdentifier> = Token<ChainIdentifier>,
+    T extends Token = Token,
     Known extends boolean = boolean
 > = {
     /**
@@ -74,15 +73,14 @@ export type TokenAmount<
  * @internal
  */
 export function toTokenAmount<
-    ChainIdentifier extends string = string,
-    T extends Token<ChainIdentifier> = Token<ChainIdentifier>,
+    T extends Token = Token,
     Known extends boolean = boolean
 >(
     amount: Known extends true ? bigint : null,
     token: T,
     prices: ISwapPrice,
     pricingInfo?: PriceInfoType
-): TokenAmount<ChainIdentifier, T, Known> {
+): TokenAmount<T, Known> {
     if (amount == null) return {
         rawAmount: undefined,
         amount: "",
@@ -93,7 +91,7 @@ export function toTokenAmount<
         usdValue: () => Promise.resolve(NaN),
         toString: () => "??? " + token.ticker,
         isUnknown: true
-    } as TokenAmount<ChainIdentifier, T>;
+    } as TokenAmount<T>;
     const amountStr = toDecimal(amount, token.decimals, undefined, token.displayDecimals);
     const _amount = parseFloat(amountStr);
 
@@ -131,5 +129,5 @@ export function toTokenAmount<
         },
         toString: () => amountStr + " " + token.ticker,
         isUnknown: false
-    } as TokenAmount<ChainIdentifier, T>;
+    } as TokenAmount<T>;
 }

--- a/src/types/fees/Fee.ts
+++ b/src/types/fees/Fee.ts
@@ -16,11 +16,11 @@ export type Fee<
     /**
      * Fee value equivalent in source token
      */
-    amountInSrcToken: TokenAmount<ChainIdentifier, TSrc, true>,
+    amountInSrcToken: TokenAmount<TSrc, true>,
     /**
      * Fee value equivalent in destination token
      */
-    amountInDstToken: TokenAmount<ChainIdentifier, TDst, true>,
+    amountInDstToken: TokenAmount<TDst, true>,
     /**
      * Fetches the current USD value of the fee
      *
@@ -49,7 +49,7 @@ export type Fee<
      *  base_fee + amount * percentage_fee
      */
     composition?: {
-        base: TokenAmount<ChainIdentifier>,
+        base: TokenAmount,
         percentage: PercentagePPM
     }
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,7 +1,9 @@
 import {Buffer} from "buffer";
 import {randomBytes as randomBytesNoble} from "@noble/hashes/utils";
 import {sha256} from "@noble/hashes/sha2";
-import {BigIntBufferUtils} from "@atomiqlabs/base";
+import {BigIntBufferUtils, ChainType} from "@atomiqlabs/base";
+import {IFromBTCLNWrapper} from "../swaps/escrow_swaps/frombtc/IFromBTCLNWrapper";
+import {UserError} from "../errors/UserError";
 
 /**
  * Returns a promise that rejects if the passed promise resolves to `undefined` or `null`
@@ -179,4 +181,18 @@ export function toDecimal(amount: bigint, decimalCount: number, cut?: boolean, d
     if (displayDecimals === 0) return amountStr.substring(0, splitPoint);
     if (displayDecimals != null && cutTo > displayDecimals) cutTo = displayDecimals;
     return amountStr.substring(0, splitPoint) + "." + decimalPart.substring(0, cutTo);
+}
+
+export function parseHashValueExact32Bytes(value?: Buffer | string, variableName?: string): Buffer | undefined {
+    let hash: Buffer | undefined;
+    if(typeof(value)==="string") {
+        if(value.length!==64)
+            throw new UserError(`Invalid ${variableName} length, must be exactly 64 hexadecimal characters!`)
+        hash = Buffer.from(value, "hex");
+    } else {
+        hash = value;
+    }
+    if(hash!=null && hash.length!==32)
+        throw new UserError(`Invalid ${variableName} length, must be exactly 32 bytes!`);
+    return hash;
 }


### PR DESCRIPTION
General:
- Add SwapSide enum, instead of a simple boolean flag
- Fix README.md inconsistencies
- Accept broader signer argument types in some `txsClaim` variants

Swaps persistency:
- `saveUninitializedSwaps` swapper option now defaults to `true`
- Changed behavior of `saveUninitializedSwaps`, now doesn't set all swaps to initiated, but instead persists swaps with intiated flag set to `false`

Tokens and amounts:
- Unify `SCToken` and `BtcToken` types into a single `Token` type
- Improve correct narrow type inference in swapper
- Remove unecessary `TokenAmount` chain identifier generic parameter

Swap options:
- Deprecate some swap options
- Add typedoc coverage to the swap options
- Widen some parameter's types in swap options

Bug fixes:
- Skip broadcasting secret on initialize event when not known for Lightning -> Smart chain swaps
- De-couple `initiated` and `posted` flag in the new Bitcoin -> Smart chain swaps
- Fixed unhandled promise rejections when creating swaps
- Fixed unhandled promise rejections during tick and sync timer runs
- Fix inconsistent (wall-clock dependent) Bitcoin -> Smart chain swap (legacy and new variants) handling of btc transaction checks in tick function
- Fix `getInputWithoutFee()` returning unknown amount for Lightning -> Smart chain swaps (new variant)