### PR TITLE
Add support for versioned contracts

### DIFF
--- a/dist/events/UnifiedSwapEventListener.js
+++ b/dist/events/UnifiedSwapEventListener.js
@@ -47,9 +47,10 @@ class UnifiedSwapEventListener {
         const htlcCheckInitializeEvents = {};
         for (let event of events) {
             const escrowHash = chainEventToEscrowHash(event);
+            const eventVersion = event.contractVersion ?? "v1";
             if (escrowHash != null) {
                 const swap = swapsByEscrowHash[escrowHash];
-                if (swap != null) {
+                if (swap != null && (swap._contractVersion ?? "v1") === eventVersion) {
                     const obj = this.listeners[swap.getType()];
                     if (obj == null)
                         continue;
@@ -85,8 +86,9 @@ class UnifiedSwapEventListener {
         logger.debug("processEvents(): Additional HTLC swaps founds: ", swapsByClaimDataHash);
         for (let claimData in htlcCheckInitializeEvents) {
             const event = htlcCheckInitializeEvents[claimData];
+            const eventVersion = event.contractVersion ?? "v1";
             const swap = swapsByClaimDataHash[claimData];
-            if (swap != null) {
+            if (swap != null && (swap._contractVersion ?? "v1") === eventVersion) {
                 const obj = this.listeners[swap.getType()];
                 if (obj == null)
                     continue;

--- a/dist/intermediaries/Intermediary.d.ts
+++ b/dist/intermediaries/Intermediary.d.ts
@@ -51,6 +51,12 @@ export declare class Intermediary {
         [chainIdentifier: string]: string;
     };
     /**
+     * Contract versions of the intermediary on smart chains
+     */
+    readonly contractVersions: {
+        [chainIdentifier: string]: string;
+    };
+    /**
      * Swap protocol services offered by the intermediary
      */
     readonly services: ServicesType;
@@ -97,6 +103,8 @@ export declare class Intermediary {
         [chainIdentifier: string]: string;
     }, services: ServicesType, reputation?: {
         [chainIdentifier: string]: SingleChainReputationType;
+    }, contractVersions?: {
+        [chainIdentifier: string]: string;
     });
     /**
      * Returns the input/output swap limit for given swap type, chain and token
@@ -154,4 +162,17 @@ export declare class Intermediary {
      * @param chainIdentifier Chain identifier of the smart chain
      */
     getAddress(chainIdentifier: string): string;
+    /**
+     * Returns the contract version used by the intermediary for a given chain
+     *
+     * @param chainIdentifier
+     */
+    getContractVersion(chainIdentifier: string): string;
+    /**
+     * Returns the range of contract versions used by the LPs
+     *
+     * @param chainIdentifier
+     * @param lps
+     */
+    static getContractVersionsForLps(chainIdentifier: string, lps: Intermediary[]): string[];
 }

--- a/dist/intermediaries/Intermediary.js
+++ b/dist/intermediaries/Intermediary.js
@@ -9,7 +9,7 @@ const RetryUtils_1 = require("../utils/RetryUtils");
  * @category LPs
  */
 class Intermediary {
-    constructor(url, addresses, services, reputation = {}) {
+    constructor(url, addresses, services, reputation = {}, contractVersions = {}) {
         /**
          * Reputation of the intermediary on different smart chains, this is only fetched
          *  on-demand when creating a swap where reputation is checked
@@ -24,6 +24,7 @@ class Intermediary {
         this.addresses = addresses;
         this.services = services;
         this.reputation = reputation;
+        this.contractVersions = contractVersions;
         this.swapBounds = {};
         for (let _swapType in this.services) {
             const swapType = parseInt(_swapType);
@@ -137,6 +138,29 @@ class Intermediary {
      */
     getAddress(chainIdentifier) {
         return this.addresses[chainIdentifier];
+    }
+    /**
+     * Returns the contract version used by the intermediary for a given chain
+     *
+     * @param chainIdentifier
+     */
+    getContractVersion(chainIdentifier) {
+        return this.contractVersions[chainIdentifier] ?? "v1";
+    }
+    /**
+     * Returns the range of contract versions used by the LPs
+     *
+     * @param chainIdentifier
+     * @param lps
+     */
+    static getContractVersionsForLps(chainIdentifier, lps) {
+        const versions = [];
+        lps.forEach((lp) => {
+            const lpVersion = lp.getContractVersion(chainIdentifier);
+            if (!versions.includes(lpVersion))
+                versions.push(lpVersion);
+        });
+        return versions;
     }
 }
 exports.Intermediary = Intermediary;

--- a/dist/intermediaries/IntermediaryDiscovery.d.ts
+++ b/dist/intermediaries/IntermediaryDiscovery.d.ts
@@ -83,7 +83,11 @@ export declare class IntermediaryDiscovery extends EventEmitter {
      * Swap contracts for checking intermediary signatures
      */
     swapContracts: {
-        [key: string]: SwapContract;
+        [chainIdentifier: string]: {
+            [contractVersion: string]: {
+                swapContract: SwapContract;
+            };
+        };
     };
     /**
      * Registry URL used as a source for the list of intermediaries, this should be a link to a
@@ -105,7 +109,11 @@ export declare class IntermediaryDiscovery extends EventEmitter {
      */
     private overrideNodeUrls?;
     constructor(swapContracts: {
-        [key: string]: SwapContract;
+        [chainIdentifier: string]: {
+            [contractVersion: string]: {
+                swapContract: SwapContract;
+            };
+        };
     }, registryUrl?: string, nodeUrls?: string[], httpRequestTimeout?: number, maxWaitForOthersTimeout?: number);
     /**
      * Fetches the URLs of swap intermediaries from registry or from a pre-defined array of node urls

--- a/dist/intermediaries/IntermediaryDiscovery.d.ts
+++ b/dist/intermediaries/IntermediaryDiscovery.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import { Intermediary } from "./Intermediary";
 import { SwapType } from "../enums/SwapType";
-import { SwapContract } from "@atomiqlabs/base";
+import { SpvVaultContract, SwapContract } from "@atomiqlabs/base";
 import { EventEmitter } from "events";
 /**
  * Swap handler type mapping for intermediary communication
@@ -86,6 +86,7 @@ export declare class IntermediaryDiscovery extends EventEmitter {
         [chainIdentifier: string]: {
             [contractVersion: string]: {
                 swapContract: SwapContract;
+                spvVaultContract: SpvVaultContract;
             };
         };
     };
@@ -112,6 +113,7 @@ export declare class IntermediaryDiscovery extends EventEmitter {
         [chainIdentifier: string]: {
             [contractVersion: string]: {
                 swapContract: SwapContract;
+                spvVaultContract: SpvVaultContract;
             };
         };
     }, registryUrl?: string, nodeUrls?: string[], httpRequestTimeout?: number, maxWaitForOthersTimeout?: number);
@@ -190,6 +192,8 @@ export declare class IntermediaryDiscovery extends EventEmitter {
     getSwapMaximum(chainIdentifier: string, swapType: SwapType, tokenAddress: string): number | null;
     /**
      * Returns swap candidates for a specific swap type & token address
+     *
+     * @remark Also filters the LPs based on supported swap versions
      *
      * @param chainIdentifier Chain identifier of the smart chain
      * @param swapType Swap protocol type

--- a/dist/intermediaries/IntermediaryDiscovery.js
+++ b/dist/intermediaries/IntermediaryDiscovery.js
@@ -133,13 +133,21 @@ class IntermediaryDiscovery extends events_1.EventEmitter {
         abortSignal?.throwIfAborted();
         const promises = [];
         const addresses = {};
+        const contractVersions = {};
         for (let chain in response.chains) {
             if (this.swapContracts[chain] != null) {
+                const { signature, address, contractVersion } = response.chains[chain];
+                const _contractVersion = contractVersion ?? "v1";
+                const contract = this.swapContracts[chain][_contractVersion];
+                if (contract == null) {
+                    logger.warn("getNodeInfo(): Unknown chain contract version " + _contractVersion + " for " + chain + " reported by intermediary: " + url);
+                    continue;
+                }
                 promises.push((async () => {
-                    const { signature, address } = response.chains[chain];
                     try {
-                        await this.swapContracts[chain].isValidDataSignature(buffer_1.Buffer.from(response.envelope), signature, address);
+                        await contract.swapContract.isValidDataSignature(buffer_1.Buffer.from(response.envelope), signature, address);
                         addresses[chain] = address;
+                        contractVersions[chain] = _contractVersion;
                     }
                     catch (e) {
                         logger.warn("getNodeInfo(): Failed to verify " + chain + " signature for intermediary: " + url);
@@ -171,6 +179,7 @@ class IntermediaryDiscovery extends events_1.EventEmitter {
         }
         return {
             addresses,
+            contractVersions,
             info
         };
     }
@@ -188,7 +197,7 @@ class IntermediaryDiscovery extends events_1.EventEmitter {
             for (let key in nodeInfo.info.services) {
                 services[swapHandlerTypeToSwapType(key)] = nodeInfo.info.services[key];
             }
-            return new Intermediary_1.Intermediary(url, nodeInfo.addresses, services);
+            return new Intermediary_1.Intermediary(url, nodeInfo.addresses, services, undefined, nodeInfo.contractVersions);
         }
         catch (e) {
             logger.warn("fetchIntermediaries(): Intermediary " + url + ` is unreachable due to ${e.name ?? e.message} error, skipping...`);

--- a/dist/intermediaries/IntermediaryDiscovery.js
+++ b/dist/intermediaries/IntermediaryDiscovery.js
@@ -365,6 +365,8 @@ class IntermediaryDiscovery extends events_1.EventEmitter {
     /**
      * Returns swap candidates for a specific swap type & token address
      *
+     * @remark Also filters the LPs based on supported swap versions
+     *
      * @param chainIdentifier Chain identifier of the smart chain
      * @param swapType Swap protocol type
      * @param tokenAddress Token address
@@ -385,6 +387,13 @@ class IntermediaryDiscovery extends events_1.EventEmitter {
             if (swapService.chainTokens[chainIdentifier] == null)
                 return false;
             if (!swapService.chainTokens[chainIdentifier].includes(tokenAddress.toString()))
+                return false;
+            const contracts = this.swapContracts[chainIdentifier][e.getContractVersion(chainIdentifier) ?? "v1"];
+            if (contracts == null)
+                return false;
+            if (swapType === SwapType_1.SwapType.FROM_BTCLN_AUTO && !contracts.swapContract?.supportsInitWithoutClaimer)
+                return false;
+            if (swapType === SwapType_1.SwapType.SPV_VAULT_FROM_BTC && contracts.spvVaultContract == null)
                 return false;
             return true;
         });

--- a/dist/intermediaries/apis/IntermediaryAPI.d.ts
+++ b/dist/intermediaries/apis/IntermediaryAPI.d.ts
@@ -7,6 +7,7 @@ export type InfoHandlerResponse = {
         [chainIdentifier: string]: {
             address: string;
             signature: string;
+            contractVersion?: string;
         };
     };
 };

--- a/dist/swapper/Swapper.d.ts
+++ b/dist/swapper/Swapper.d.ts
@@ -159,14 +159,19 @@ type ChainSpecificData<T extends ChainType> = {
         [SwapType.FROM_BTCLN_AUTO]: FromBTCLNAutoWrapper<T>;
     };
     chainEvents: T["Events"];
-    swapContract: T["Contract"];
-    spvVaultContract: T["SpvVaultContract"];
     chainInterface: T["ChainInterface"];
-    btcRelay: BtcRelay<any, T["TX"], BtcBlock, T["Signer"]>;
-    synchronizer: RelaySynchronizer<any, T["TX"], BtcBlock>;
     unifiedChainEvents: UnifiedSwapEventListener<T>;
     unifiedSwapStorage: UnifiedSwapStorage<T>;
     reviver: (val: any) => ISwap<T>;
+    defaultVersion: string;
+    versionedContracts: {
+        [contractVersion: string]: {
+            swapContract: T["Contract"];
+            spvVaultContract: T["SpvVaultContract"];
+            btcRelay: BtcRelay<any, T["TX"], BtcBlock, T["Signer"]>;
+            synchronizer: RelaySynchronizer<any, T["TX"], BtcBlock>;
+        };
+    };
 };
 type MultiChainData<T extends MultiChain> = {
     [chainIdentifier in keyof T]: ChainSpecificData<T[chainIdentifier]>;

--- a/dist/swapper/Swapper.js
+++ b/dist/swapper/Swapper.js
@@ -91,30 +91,50 @@ class Swapper extends events_1.EventEmitter {
             this.emit("swapState", swap);
         };
         this._chains = (0, Utils_1.objectMap)(chainsData, (chainData, key) => {
-            const { swapContract, chainEvents, btcRelay, chainInterface, spvVaultContract, spvVaultWithdrawalDataConstructor, chainId } = chainData;
-            const synchronizer = bitcoinSynchronizer(btcRelay);
+            let { chainInterface, chainEvents, chainId, btcRelay, swapContract, swapDataConstructor, spvVaultContract, spvVaultWithdrawalDataConstructor, spvVaultDataConstructor, defaultVersion, versions } = chainData;
+            defaultVersion ??= "v1";
+            if (versions == null) {
+                versions = {
+                    [defaultVersion]: {
+                        btcRelay,
+                        swapContract,
+                        swapDataConstructor,
+                        spvVaultContract,
+                        spvVaultDataConstructor,
+                        spvVaultWithdrawalDataConstructor
+                    }
+                };
+            }
+            const versionedContracts = (0, Utils_1.objectMap)(versions, (value, key) => {
+                return {
+                    swapContract: value.swapContract,
+                    spvVaultContract: value.spvVaultContract,
+                    btcRelay: value.btcRelay,
+                    synchronizer: bitcoinSynchronizer(value.btcRelay)
+                };
+            });
             const storageHandler = swapStorage(storagePrefix + chainId);
             const unifiedSwapStorage = new UnifiedSwapStorage_1.UnifiedSwapStorage(storageHandler, this.options.noSwapCache);
             const unifiedChainEvents = new UnifiedSwapEventListener_1.UnifiedSwapEventListener(unifiedSwapStorage, chainEvents);
             const wrappers = {};
-            wrappers[SwapType_1.SwapType.TO_BTCLN] = new ToBTCLNWrapper_1.ToBTCLNWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, {
+            wrappers[SwapType_1.SwapType.TO_BTCLN] = new ToBTCLNWrapper_1.ToBTCLNWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, pricing, this._tokens[chainId], versions, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
                 saveUninitializedSwaps: this.options.saveUninitializedSwaps,
             });
-            wrappers[SwapType_1.SwapType.TO_BTC] = new ToBTCWrapper_1.ToBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, this._bitcoinRpc, {
+            wrappers[SwapType_1.SwapType.TO_BTC] = new ToBTCWrapper_1.ToBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, pricing, this._tokens[chainId], versions, this._bitcoinRpc, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
                 saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                 bitcoinNetwork: this._btcNetwork
             });
-            wrappers[SwapType_1.SwapType.FROM_BTCLN] = new FromBTCLNWrapper_1.FromBTCLNWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, lightningApi, {
+            wrappers[SwapType_1.SwapType.FROM_BTCLN] = new FromBTCLNWrapper_1.FromBTCLNWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, pricing, this._tokens[chainId], versions, lightningApi, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
                 saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                 unsafeSkipLnNodeCheck: this.bitcoinNetwork === base_1.BitcoinNetwork.TESTNET4 || this.bitcoinNetwork === base_1.BitcoinNetwork.REGTEST
             });
-            wrappers[SwapType_1.SwapType.FROM_BTC] = new FromBTCWrapper_1.FromBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, btcRelay, synchronizer, this._bitcoinRpc, {
+            wrappers[SwapType_1.SwapType.FROM_BTC] = new FromBTCWrapper_1.FromBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, pricing, this._tokens[chainId], versions, versionedContracts, this._bitcoinRpc, {
                 getRequestTimeout: this.options.getRequestTimeout,
                 postRequestTimeout: this.options.postRequestTimeout,
                 saveUninitializedSwaps: this.options.saveUninitializedSwaps,
@@ -131,16 +151,18 @@ class Swapper extends events_1.EventEmitter {
                 saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                 bitcoinNetwork: this._btcNetwork
             });
+            // This is gated on the default version of the contracts
             if (spvVaultContract != null) {
-                wrappers[SwapType_1.SwapType.SPV_VAULT_FROM_BTC] = new SpvFromBTCWrapper_1.SpvFromBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, spvVaultContract, pricing, this._tokens[chainId], spvVaultWithdrawalDataConstructor, btcRelay, synchronizer, bitcoinRpc, {
+                wrappers[SwapType_1.SwapType.SPV_VAULT_FROM_BTC] = new SpvFromBTCWrapper_1.SpvFromBTCWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, pricing, this._tokens[chainId], versions, versionedContracts, bitcoinRpc, {
                     getRequestTimeout: this.options.getRequestTimeout,
                     postRequestTimeout: this.options.postRequestTimeout,
                     saveUninitializedSwaps: this.options.saveUninitializedSwaps,
                     bitcoinNetwork: this._btcNetwork
                 });
             }
+            // This is gated on the default version of the contracts
             if (swapContract.supportsInitWithoutClaimer) {
-                wrappers[SwapType_1.SwapType.FROM_BTCLN_AUTO] = new FromBTCLNAutoWrapper_1.FromBTCLNAutoWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, swapContract, pricing, this._tokens[chainId], chainData.swapDataConstructor, lightningApi, this.messenger, {
+                wrappers[SwapType_1.SwapType.FROM_BTCLN_AUTO] = new FromBTCLNAutoWrapper_1.FromBTCLNAutoWrapper(key, unifiedSwapStorage, unifiedChainEvents, chainInterface, pricing, this._tokens[chainId], versions, lightningApi, this.messenger, {
                     getRequestTimeout: this.options.getRequestTimeout,
                     postRequestTimeout: this.options.postRequestTimeout,
                     saveUninitializedSwaps: this.options.saveUninitializedSwaps,
@@ -156,18 +178,16 @@ class Swapper extends events_1.EventEmitter {
             };
             return {
                 chainEvents,
-                spvVaultContract,
-                swapContract,
                 chainInterface,
-                btcRelay,
-                synchronizer,
                 wrappers,
                 unifiedChainEvents,
                 unifiedSwapStorage,
-                reviver
+                defaultVersion,
+                reviver,
+                versionedContracts
             };
         });
-        const contracts = (0, Utils_1.objectMap)(chainsData, (data) => data.swapContract);
+        const contracts = (0, Utils_1.objectMap)(chainsData, (data) => data.versions ?? { [data.defaultVersion ?? "v1"]: { swapContract: data.swapContract } });
         if (options.intermediaryUrl != null) {
             this.intermediaryDiscovery = new IntermediaryDiscovery_1.IntermediaryDiscovery(contracts, options.registryUrl, Array.isArray(options.intermediaryUrl) ? options.intermediaryUrl : [options.intermediaryUrl], options.getRequestTimeout);
         }
@@ -218,13 +238,15 @@ class Swapper extends events_1.EventEmitter {
         const chainPromises = [];
         for (let chainIdentifier in this._chains) {
             chainPromises.push((async () => {
-                const { chainInterface, swapContract, unifiedChainEvents, unifiedSwapStorage, wrappers, reviver } = this._chains[chainIdentifier];
+                const { chainInterface, versionedContracts, unifiedChainEvents, unifiedSwapStorage, wrappers, reviver } = this._chains[chainIdentifier];
                 const _chainInterface = chainInterface;
                 if (_chainInterface.verifyNetwork != null) {
                     await _chainInterface.verifyNetwork(this.bitcoinNetwork);
                 }
-                await swapContract.start();
-                this.logger.debug("init(): Intialized swap contract: " + chainIdentifier);
+                for (let contractVersion in versionedContracts) {
+                    await versionedContracts[contractVersion].swapContract.start();
+                    this.logger.debug("init(): Intialized swap contract: " + chainIdentifier + ` version: ${contractVersion}`);
+                }
                 await unifiedSwapStorage.init();
                 if (unifiedSwapStorage.storage instanceof IndexedDBUnifiedStorage_1.IndexedDBUnifiedStorage) {
                     //Try to migrate the data here
@@ -1173,15 +1195,35 @@ class Swapper extends events_1.EventEmitter {
      *  initiated after this blockheight
      */
     async recoverSwaps(chainId, signer, startBlockheight) {
-        const { spvVaultContract, swapContract, unifiedSwapStorage, reviver, wrappers } = this._chains[chainId];
-        if (swapContract.getHistoricalSwaps == null ||
-            (spvVaultContract != null && spvVaultContract.getHistoricalWithdrawalStates == null))
+        //TODO: Recover swaps from all the known contract versions
+        const { versionedContracts, unifiedSwapStorage, reviver, wrappers } = this._chains[chainId];
+        const recoveredSwaps = [];
+        let someVersionSupportsRecovery = false;
+        const recoveredEscrowStates = {};
+        const recoveredSpvStates = {};
+        for (let contractVersion in versionedContracts) {
+            const { swapContract, spvVaultContract } = versionedContracts[contractVersion];
+            if (swapContract.getHistoricalSwaps == null ||
+                (spvVaultContract != null && spvVaultContract.getHistoricalWithdrawalStates == null)) {
+                this.logger.warn(`recoverSwaps(): Swap data recovery not supported on ${chainId}, with contract version ${contractVersion}`);
+                continue;
+            }
+            someVersionSupportsRecovery = true;
+            const { swaps } = await swapContract.getHistoricalSwaps(signer, startBlockheight);
+            const spvVaultData = wrappers[SwapType_1.SwapType.SPV_VAULT_FROM_BTC] == null
+                ? undefined
+                : await spvVaultContract?.getHistoricalWithdrawalStates(signer, startBlockheight);
+            for (let key in swaps)
+                recoveredEscrowStates[key] = { ...swaps[key], contractVersion };
+            if (spvVaultData != null)
+                for (let key in spvVaultData.withdrawals)
+                    (recoveredSpvStates[contractVersion] ??= {})[key] = spvVaultData.withdrawals[key];
+        }
+        if (!someVersionSupportsRecovery)
             throw new Error(`Historical swap recovery is not supported for ${chainId}`);
-        const { swaps } = await swapContract.getHistoricalSwaps(signer, startBlockheight);
-        const spvVaultData = await spvVaultContract?.getHistoricalWithdrawalStates(signer, startBlockheight);
-        const escrowHashes = Object.keys(swaps);
-        if (spvVaultData != null)
-            Object.keys(spvVaultData.withdrawals).forEach(btcTxId => escrowHashes.push(btcTxId));
+        const escrowHashes = Object.keys(recoveredEscrowStates);
+        for (let contractVersion in recoveredSpvStates)
+            Object.keys(recoveredSpvStates[contractVersion]).forEach(btcTxId => escrowHashes.push(btcTxId));
         this.logger.debug(`recoverSwaps(): Loaded on-chain data for ${escrowHashes.length} swaps`);
         this.logger.debug(`recoverSwaps(): Fetching if swap escrowHashes are known: ${escrowHashes.join(", ")}`);
         const knownSwapsArray = await unifiedSwapStorage.query([[{ key: "escrowHash", value: escrowHashes }]], reviver);
@@ -1192,10 +1234,10 @@ class Swapper extends events_1.EventEmitter {
                 knownSwaps[escrowHash] = val;
         });
         this.logger.debug(`recoverSwaps(): Fetched known swaps escrowHashes: ${Object.keys(knownSwaps).join(", ")}`);
-        const recoveredSwaps = [];
-        for (let escrowHash in swaps) {
-            const { init, state } = swaps[escrowHash];
+        for (let escrowHash in recoveredEscrowStates) {
+            const { init, state, contractVersion } = recoveredEscrowStates[escrowHash];
             const knownSwap = knownSwaps[escrowHash];
+            const { swapContract } = versionedContracts[contractVersion];
             if (knownSwap == null) {
                 if (init == null) {
                     this.logger.warn(`recoverSwaps(escrow): Fetched ${escrowHash} swap state, but swap not found locally!`);
@@ -1204,6 +1246,10 @@ class Swapper extends events_1.EventEmitter {
             }
             else if (knownSwap instanceof IEscrowSwap_1.IEscrowSwap) {
                 this.logger.debug(`recoverSwaps(escrow): Forcibly updating ${escrowHash} swap: swap already known and in local storage!`);
+                if ((knownSwap._contractVersion ?? "v1") !== contractVersion) {
+                    this.logger.debug(`recoverSwaps(escrow): Skipping ${escrowHash} swap: swap uses contract version ${knownSwap._contractVersion ?? "v1"}, but state comes from ${contractVersion}!`);
+                    continue;
+                }
                 if (await knownSwap._forciblySetOnchainState(state)) {
                     await knownSwap._save();
                 }
@@ -1222,17 +1268,17 @@ class Swapper extends events_1.EventEmitter {
                     //To BTCLN
                     typeIdentified = true;
                     const lp = this.intermediaryDiscovery.intermediaries.find(val => val.supportsChain(chainId) && data.isClaimer(val.getAddress(chainId)));
-                    swap = await wrappers[SwapType_1.SwapType.TO_BTCLN].recoverFromSwapDataAndState(init, state, lp);
+                    swap = await wrappers[SwapType_1.SwapType.TO_BTCLN].recoverFromSwapDataAndState(init, state, contractVersion, lp);
                 }
                 else if (data.isClaimer(signer)) {
                     //From BTCLN
                     typeIdentified = true;
                     const lp = this.intermediaryDiscovery.intermediaries.find(val => val.supportsChain(chainId) && data.isOfferer(val.getAddress(chainId)));
-                    if (this.supportsSwapType(chainId, SwapType_1.SwapType.FROM_BTCLN_AUTO)) {
-                        swap = await wrappers[SwapType_1.SwapType.FROM_BTCLN_AUTO].recoverFromSwapDataAndState(init, state, lp);
+                    if (swapContract.supportsInitWithoutClaimer && wrappers[SwapType_1.SwapType.FROM_BTCLN_AUTO] != null) {
+                        swap = await wrappers[SwapType_1.SwapType.FROM_BTCLN_AUTO].recoverFromSwapDataAndState(init, state, contractVersion, lp);
                     }
                     else {
-                        swap = await wrappers[SwapType_1.SwapType.FROM_BTCLN].recoverFromSwapDataAndState(init, state, lp);
+                        swap = await wrappers[SwapType_1.SwapType.FROM_BTCLN].recoverFromSwapDataAndState(init, state, contractVersion, lp);
                     }
                 }
             }
@@ -1240,13 +1286,13 @@ class Swapper extends events_1.EventEmitter {
                 //To BTC
                 typeIdentified = true;
                 const lp = this.intermediaryDiscovery.intermediaries.find(val => val.supportsChain(chainId) && data.isClaimer(val.getAddress(chainId)));
-                swap = await wrappers[SwapType_1.SwapType.TO_BTC].recoverFromSwapDataAndState(init, state, lp);
+                swap = await wrappers[SwapType_1.SwapType.TO_BTC].recoverFromSwapDataAndState(init, state, contractVersion, lp);
             }
             else if (data.getType() === base_1.ChainSwapType.CHAIN) {
                 //From BTC
                 typeIdentified = true;
                 const lp = this.intermediaryDiscovery.intermediaries.find(val => val.supportsChain(chainId) && data.isOfferer(val.getAddress(chainId)));
-                swap = await wrappers[SwapType_1.SwapType.FROM_BTC].recoverFromSwapDataAndState(init, state, lp);
+                swap = await wrappers[SwapType_1.SwapType.FROM_BTC].recoverFromSwapDataAndState(init, state, contractVersion, lp);
             }
             if (swap != null) {
                 recoveredSwaps.push(swap);
@@ -1256,14 +1302,16 @@ class Swapper extends events_1.EventEmitter {
                     this.logger.debug(`recoverSwaps(escrow): Swap data type correctly identified but swap returned is null for swap ${escrowHash}`);
             }
         }
-        if (spvVaultContract != null && spvVaultData != null) {
-            const vaultsData = await spvVaultContract.getMultipleVaultData(Object.keys(spvVaultData.withdrawals)
+        for (let contractVersion in recoveredSpvStates) {
+            const { spvVaultContract } = versionedContracts[contractVersion];
+            const spvVaultData = recoveredSpvStates[contractVersion];
+            const vaultsData = await spvVaultContract.getMultipleVaultData(Object.keys(spvVaultData)
                 .map(btcTxId => ({
-                owner: spvVaultData.withdrawals[btcTxId].owner,
-                vaultId: spvVaultData.withdrawals[btcTxId].vaultId
+                owner: spvVaultData[btcTxId].owner,
+                vaultId: spvVaultData[btcTxId].vaultId
             })));
-            for (let btcTxId in spvVaultData.withdrawals) {
-                const state = spvVaultData.withdrawals[btcTxId];
+            for (let btcTxId in spvVaultData) {
+                const state = spvVaultData[btcTxId];
                 const knownSwap = knownSwaps[btcTxId];
                 if (knownSwap != null) {
                     if (knownSwap instanceof SpvFromBTCSwap_1.SpvFromBTCSwap) {
@@ -1280,7 +1328,7 @@ class Swapper extends events_1.EventEmitter {
                     }
                 }
                 const lp = this.intermediaryDiscovery.intermediaries.find(val => val.supportsChain(chainId) && state.owner.toLowerCase() === val.getAddress(chainId).toLowerCase());
-                const swap = await wrappers[SwapType_1.SwapType.SPV_VAULT_FROM_BTC].recoverFromState(state, vaultsData[state.owner]?.[state.vaultId.toString(10)], lp);
+                const swap = await wrappers[SwapType_1.SwapType.SPV_VAULT_FROM_BTC].recoverFromState(state, contractVersion, vaultsData[state.owner]?.[state.vaultId.toString(10)], lp);
                 if (swap != null) {
                     recoveredSwaps.push(swap);
                 }

--- a/dist/swapper/Swapper.js
+++ b/dist/swapper/Swapper.js
@@ -187,7 +187,7 @@ class Swapper extends events_1.EventEmitter {
                 versionedContracts
             };
         });
-        const contracts = (0, Utils_1.objectMap)(chainsData, (data) => data.versions ?? { [data.defaultVersion ?? "v1"]: { swapContract: data.swapContract } });
+        const contracts = (0, Utils_1.objectMap)(chainsData, (data) => data.versions ?? { [data.defaultVersion ?? "v1"]: { swapContract: data.swapContract, spvVaultContract: data.spvVaultContract } });
         if (options.intermediaryUrl != null) {
             this.intermediaryDiscovery = new IntermediaryDiscovery_1.IntermediaryDiscovery(contracts, options.registryUrl, Array.isArray(options.intermediaryUrl) ? options.intermediaryUrl : [options.intermediaryUrl], options.getRequestTimeout);
         }

--- a/dist/swapper/Swapper.js
+++ b/dist/swapper/Swapper.js
@@ -606,6 +606,8 @@ class Swapper extends events_1.EventEmitter {
     async createFromBTCSwapNew(chainIdentifier, recipient, tokenAddress, amount, exactOut = false, additionalParams = this.options.defaultAdditionalParameters, options) {
         if (this._chains[chainIdentifier] == null)
             throw new Error("Invalid chain identifier! Unknown chain: " + chainIdentifier);
+        if (this._chains[chainIdentifier].wrappers[SwapType_1.SwapType.SPV_VAULT_FROM_BTC] == null)
+            throw new Error("Chain " + chainIdentifier + " doesn't support new BTC swap protocol (spv vault swaps)!");
         if (!this._chains[chainIdentifier].chainInterface.isValidAddress(recipient, true))
             throw new Error("Invalid " + chainIdentifier + " address");
         recipient = this._chains[chainIdentifier].chainInterface.normalizeAddress(recipient);
@@ -706,6 +708,8 @@ class Swapper extends events_1.EventEmitter {
     async createFromBTCLNSwapNew(chainIdentifier, recipient, tokenAddress, amount, exactOut = false, additionalParams = this.options.defaultAdditionalParameters, options) {
         if (this._chains[chainIdentifier] == null)
             throw new Error("Invalid chain identifier! Unknown chain: " + chainIdentifier);
+        if (this._chains[chainIdentifier].wrappers[SwapType_1.SwapType.FROM_BTCLN_AUTO] == null)
+            throw new Error("Chain " + chainIdentifier + " doesn't support new lightning swap protocol (from btcln auto)!");
         if (!this._chains[chainIdentifier].chainInterface.isValidAddress(recipient, true))
             throw new Error("Invalid " + chainIdentifier + " address");
         recipient = this._chains[chainIdentifier].chainInterface.normalizeAddress(recipient);
@@ -732,6 +736,8 @@ class Swapper extends events_1.EventEmitter {
     async createFromBTCLNSwapNewViaLNURL(chainIdentifier, recipient, tokenAddress, lnurl, amount, exactOut = false, additionalParams = this.options.defaultAdditionalParameters, options) {
         if (this._chains[chainIdentifier] == null)
             throw new Error("Invalid chain identifier! Unknown chain: " + chainIdentifier);
+        if (this._chains[chainIdentifier].wrappers[SwapType_1.SwapType.FROM_BTCLN_AUTO] == null)
+            throw new Error("Chain " + chainIdentifier + " doesn't support new lightning swap protocol (from btcln auto)!");
         if (typeof (lnurl) === "string" && !this.Utils.isValidLNURL(lnurl))
             throw new Error("Invalid LNURL-withdraw link");
         if (!this._chains[chainIdentifier].chainInterface.isValidAddress(recipient, true))

--- a/dist/swapper/SwapperUtils.d.ts
+++ b/dist/swapper/SwapperUtils.d.ts
@@ -139,6 +139,12 @@ export declare class SwapperUtils<T extends MultiChain> {
      */
     getNativeToken<ChainIdentifier extends ChainIds<T>>(chainIdentifier: ChainIdentifier): SCToken<ChainIdentifier>;
     /**
+     * Returns whether when swapping to the provided token a gas drop can be requested
+     *
+     * @param token
+     */
+    destinationTokenSupportsGasDrop<ChainIdentifier extends ChainIds<T>>(token: SCToken<ChainIdentifier>): boolean;
+    /**
      * Returns a random signer for a given smart chain
      *
      * @param chainIdentifier

--- a/dist/swapper/SwapperUtils.js
+++ b/dist/swapper/SwapperUtils.js
@@ -337,7 +337,8 @@ class SwapperUtils {
     async getSpendableBalance(wallet, token, options) {
         if (this.root._chains[token.chainId] == null)
             throw new Error("Invalid chain identifier! Unknown chain: " + token.chainId);
-        const { swapContract, chainInterface } = this.root._chains[token.chainId];
+        const { defaultVersion, versionedContracts, chainInterface } = this.root._chains[token.chainId];
+        const { swapContract } = versionedContracts[defaultVersion];
         let signer;
         if (typeof (wallet) === "string") {
             signer = wallet;

--- a/dist/swapper/SwapperUtils.js
+++ b/dist/swapper/SwapperUtils.js
@@ -374,6 +374,19 @@ class SwapperUtils {
         return this.root._tokens[chainIdentifier][this.root._chains[chainIdentifier].chainInterface.getNativeCurrencyAddress()];
     }
     /**
+     * Returns whether when swapping to the provided token a gas drop can be requested
+     *
+     * @param token
+     */
+    destinationTokenSupportsGasDrop(token) {
+        if (this.root._chains[token.chainId] == null)
+            throw new Error("Invalid chain identifier! Unknown chain: " + token.chainId);
+        const { chainInterface } = this.root._chains[token.chainId];
+        if (chainInterface.shouldGetNativeTokenDrop != null)
+            return chainInterface.shouldGetNativeTokenDrop(token.address);
+        return chainInterface.getNativeCurrencyAddress() !== token.address;
+    }
+    /**
      * Returns a random signer for a given smart chain
      *
      * @param chainIdentifier

--- a/dist/swaps/ISwap.d.ts
+++ b/dist/swaps/ISwap.d.ts
@@ -25,6 +25,7 @@ export type ISwapInit = {
     swapFee: bigint;
     swapFeeBtc: bigint;
     exactIn: boolean;
+    contractVersion: string;
 };
 /**
  * Type guard to check if an object is an ISwapInit
@@ -119,6 +120,10 @@ export declare abstract class ISwap<T extends ChainType = ChainType, D extends S
      * @internal
      */
     _persisted: boolean;
+    /**
+     * @internal
+     */
+    _contractVersion?: string;
     /**
      * Event emitter emitting `"swapState"` event when swap's state changes
      */

--- a/dist/swaps/ISwap.js
+++ b/dist/swaps/ISwap.js
@@ -73,6 +73,7 @@ class ISwap {
             this.version = this.currentVersion;
             this.createdAt = Date.now();
             this._randomNonce = (0, Utils_1.randomBytes)(16).toString("hex");
+            this._contractVersion = swapInitOrObj.contractVersion;
         }
         else {
             this.expiry = swapInitOrObj.expiry;
@@ -97,6 +98,7 @@ class ISwap {
             this.exactIn = swapInitOrObj.exactIn;
             this.createdAt = swapInitOrObj.createdAt ?? swapInitOrObj.expiry;
             this._randomNonce = swapInitOrObj.randomNonce;
+            this._contractVersion = swapInitOrObj.contractVersion;
         }
         if (this.version !== this.currentVersion) {
             this.upgradeVersion();
@@ -328,7 +330,8 @@ class ISwap {
             initiated: this.initiated,
             exactIn: this.exactIn,
             createdAt: this.createdAt,
-            randomNonce: this._randomNonce
+            randomNonce: this._randomNonce,
+            contractVersion: this._contractVersion
         };
     }
     //////////////////////////////

--- a/dist/swaps/escrow_swaps/IEscrowSelfInitSwap.js
+++ b/dist/swaps/escrow_swaps/IEscrowSelfInitSwap.js
@@ -55,7 +55,7 @@ class IEscrowSelfInitSwap extends IEscrowSwap_1.IEscrowSwap {
         while (!expired) {
             await (0, TimeoutUtils_1.timeoutPromise)(intervalSeconds * 1000, abortSignal);
             try {
-                expired = await this.wrapper._contract.isInitAuthorizationExpired(this._data, this.signatureData);
+                expired = await this._contract.isInitAuthorizationExpired(this._data, this.signatureData);
             }
             catch (e) {
                 this.logger.error("watchdogWaitTillSignatureExpiry(): Error when checking signature expiry: ", e);
@@ -71,13 +71,13 @@ class IEscrowSelfInitSwap extends IEscrowSwap_1.IEscrowSwap {
      * @internal
      */
     getCommitFee() {
-        return this.wrapper._contract.getCommitFee(this._getInitiator(), this.getSwapData(), this.feeRate);
+        return this._contract.getCommitFee(this._getInitiator(), this.getSwapData(), this.feeRate);
     }
     /**
      * Returns the transaction fee paid on the smart chain side to initiate the escrow
      */
     async getSmartChainNetworkFee() {
-        const swapContract = this.wrapper._contract;
+        const swapContract = this._contract;
         return (0, TokenAmount_1.toTokenAmount)(await (swapContract.getRawCommitFee != null ?
             swapContract.getRawCommitFee(this._getInitiator(), this.getSwapData(), this.feeRate) :
             swapContract.getCommitFee(this._getInitiator(), this.getSwapData(), this.feeRate)), this.wrapper._getNativeToken(), this.wrapper._prices);
@@ -90,7 +90,7 @@ class IEscrowSelfInitSwap extends IEscrowSwap_1.IEscrowSwap {
     async _verifyQuoteDefinitelyExpired() {
         if (this._data == null || this.signatureData == null)
             throw new Error("data or signature data are null!");
-        return this.wrapper._contract.isInitAuthorizationExpired(this._data, this.signatureData);
+        return this._contract.isInitAuthorizationExpired(this._data, this.signatureData);
     }
     /**
      * Checks if the swap's quote is still valid
@@ -99,7 +99,7 @@ class IEscrowSelfInitSwap extends IEscrowSwap_1.IEscrowSwap {
         if (this._data == null || this.signatureData == null)
             throw new Error("data or signature data are null!");
         try {
-            await this.wrapper._contract.isValidInitAuthorization(this._getInitiator(), this._data, this.signatureData, this.feeRate);
+            await this._contract.isValidInitAuthorization(this._getInitiator(), this._data, this.signatureData, this.feeRate);
             return true;
         }
         catch (e) {

--- a/dist/swaps/escrow_swaps/IEscrowSwap.d.ts
+++ b/dist/swaps/escrow_swaps/IEscrowSwap.d.ts
@@ -31,6 +31,10 @@ export declare abstract class IEscrowSwap<T extends ChainType = ChainType, D ext
      * @internal
      */
     _claimTxId?: string;
+    /**
+     * @internal
+     */
+    protected _contract: T["Contract"];
     protected constructor(wrapper: D["Wrapper"], obj: any);
     protected constructor(wrapper: D["Wrapper"], swapInit: IEscrowSwapInit<T["Data"]>);
     /**

--- a/dist/swaps/escrow_swaps/IEscrowSwap.js
+++ b/dist/swaps/escrow_swaps/IEscrowSwap.js
@@ -24,11 +24,12 @@ class IEscrowSwap extends ISwap_1.ISwap {
         }
         else {
             if (swapInitOrObj.data != null)
-                this._data = new wrapper._swapDataDeserializer(swapInitOrObj.data);
+                this._data = new (wrapper._swapDataDeserializer(this._contractVersion))(swapInitOrObj.data);
             this._commitTxId = swapInitOrObj.commitTxId;
             this._claimTxId = swapInitOrObj.claimTxId;
             this._refundTxId = swapInitOrObj.refundTxId;
         }
+        this._contract = wrapper._contract(this._contractVersion);
     }
     //////////////////////////////
     //// Identifiers
@@ -114,7 +115,7 @@ class IEscrowSwap extends ISwap_1.ISwap {
         while (status?.type === base_1.SwapCommitStateType.NOT_COMMITED) {
             await (0, TimeoutUtils_1.timeoutPromise)(intervalSeconds * 1000, abortSignal);
             try {
-                status = await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data);
+                status = await this._contract.getCommitStatus(this._getInitiator(), this._data);
                 if (status?.type === base_1.SwapCommitStateType.NOT_COMMITED &&
                     await this._verifyQuoteDefinitelyExpired())
                     return false;
@@ -142,7 +143,7 @@ class IEscrowSwap extends ISwap_1.ISwap {
         while (status?.type === base_1.SwapCommitStateType.COMMITED || status?.type === base_1.SwapCommitStateType.REFUNDABLE) {
             await (0, TimeoutUtils_1.timeoutPromise)(intervalSeconds * 1000, abortSignal);
             try {
-                status = await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data);
+                status = await this._contract.getCommitStatus(this._getInitiator(), this._data);
             }
             catch (e) {
                 this.logger.error("watchdogWaitTillResult(): Error when fetching commit status: ", e);

--- a/dist/swaps/escrow_swaps/IEscrowSwapWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/IEscrowSwapWrapper.d.ts
@@ -20,23 +20,35 @@ export declare abstract class IEscrowSwapWrapper<T extends ChainType, D extends 
     /**
      * @internal
      */
-    readonly _contract: T["Contract"];
+    readonly _contract: (version?: string) => T["Contract"];
     /**
      * @internal
      */
-    readonly _swapDataDeserializer: new (data: any) => T["Data"];
-    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], contract: T["Contract"], prices: ISwapPrice, tokens: WrapperCtorTokens, swapDataDeserializer: new (data: any) => T["Data"], options: O, events?: EventEmitter<{
+    readonly _swapDataDeserializer: (version?: string) => new (data: any) => T["Data"];
+    readonly _versionedContracts: {
+        [version: string]: {
+            swapContract: T["Contract"];
+            swapDataConstructor: new (data: any) => T["Data"];
+        };
+    };
+    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], prices: ISwapPrice, tokens: WrapperCtorTokens, options: O, versionedContracts: {
+        [version: string]: {
+            swapContract: T["Contract"];
+            swapDataConstructor: new (data: any) => T["Data"];
+        };
+    }, events?: EventEmitter<{
         swapState: [ISwap];
     }>);
     /**
      * Pre-fetches signature verification data from the server's pre-sent promise, doesn't throw, instead returns null
      *
      * @param signDataPrefetch Promise that resolves when we receive "signDataPrefetch" from the LP in streaming mode
+     * @param contractVersion
      * @returns Pre-fetched signature verification data or null if failed
      *
      * @internal
      */
-    protected preFetchSignData(signDataPrefetch: Promise<any | null>): Promise<T["PreFetchVerification"] | undefined>;
+    protected preFetchSignData(signDataPrefetch: Promise<any | null>, contractVersion: string): Promise<T["PreFetchVerification"] | undefined>;
     /**
      * Verifies swap initialization signature returned by the intermediary
      *
@@ -45,13 +57,14 @@ export declare abstract class IEscrowSwapWrapper<T extends ChainType, D extends 
      * @param signature Response of the intermediary
      * @param feeRatePromise Pre-fetched fee rate promise
      * @param preFetchSignatureVerificationData Pre-fetched signature verification data
+     * @param contractVersion
      * @param abortSignal
      * @returns Swap initialization signature expiry
      * @throws {SignatureVerificationError} when swap init signature is invalid
      *
      * @internal
      */
-    protected verifyReturnedSignature(initiator: string, data: T["Data"], signature: SignatureData, feeRatePromise: Promise<any>, preFetchSignatureVerificationData: Promise<any>, abortSignal?: AbortSignal): Promise<number>;
+    protected verifyReturnedSignature(initiator: string, data: T["Data"], signature: SignatureData, feeRatePromise: Promise<any>, preFetchSignatureVerificationData: Promise<any>, contractVersion: string, abortSignal?: AbortSignal): Promise<number>;
     /**
      * Processes InitializeEvent for a given swap
      * @param swap
@@ -111,5 +124,5 @@ export declare abstract class IEscrowSwapWrapper<T extends ChainType, D extends 
             blockTime: number;
             blockHeight: number;
         }>;
-    }, state: SwapCommitState, lp?: Intermediary): Promise<D["Swap"] | null>;
+    }, state: SwapCommitState, contractVersion: string, lp?: Intermediary): Promise<D["Swap"] | null>;
 }

--- a/dist/swaps/escrow_swaps/IEscrowSwapWrapper.js
+++ b/dist/swaps/escrow_swaps/IEscrowSwapWrapper.js
@@ -9,21 +9,43 @@ const base_1 = require("@atomiqlabs/base");
  * @category Swaps/Abstract
  */
 class IEscrowSwapWrapper extends ISwapWrapper_1.ISwapWrapper {
-    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, options, events) {
+    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, options, versionedContracts, events) {
         super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, options, events);
-        this._swapDataDeserializer = swapDataDeserializer;
-        this._contract = contract;
+        /**
+         * @internal
+         */
+        this._contract = (version) => {
+            const _version = version ?? "v1";
+            const data = this._versionedContracts[_version];
+            if (data == null)
+                throw new Error(`Invalid contract version ${_version} requested`);
+            return data.swapContract;
+        };
+        /**
+         * @internal
+         */
+        this._swapDataDeserializer = (version) => {
+            const _version = version ?? "v1";
+            const data = this._versionedContracts[_version];
+            if (data == null)
+                throw new Error(`Invalid contract version ${_version} requested`);
+            return data.swapDataConstructor;
+        };
+        //TODO: Properly populate in constructor
+        this._versionedContracts = {};
+        this._versionedContracts = versionedContracts;
     }
     /**
      * Pre-fetches signature verification data from the server's pre-sent promise, doesn't throw, instead returns null
      *
      * @param signDataPrefetch Promise that resolves when we receive "signDataPrefetch" from the LP in streaming mode
+     * @param contractVersion
      * @returns Pre-fetched signature verification data or null if failed
      *
      * @internal
      */
-    preFetchSignData(signDataPrefetch) {
-        if (this._contract.preFetchForInitSignatureVerification == null) {
+    preFetchSignData(signDataPrefetch, contractVersion) {
+        if (this._contract(contractVersion).preFetchForInitSignatureVerification == null) {
             // Catch promise rejections, should they happen
             signDataPrefetch.catch(() => { });
             return Promise.resolve(undefined);
@@ -31,7 +53,7 @@ class IEscrowSwapWrapper extends ISwapWrapper_1.ISwapWrapper {
         return signDataPrefetch.then(obj => {
             if (obj == null)
                 return undefined;
-            return this._contract.preFetchForInitSignatureVerification(obj);
+            return this._contract(contractVersion).preFetchForInitSignatureVerification(obj);
         }).catch(e => {
             this.logger.error("preFetchSignData(): Error: ", e);
         });
@@ -44,16 +66,17 @@ class IEscrowSwapWrapper extends ISwapWrapper_1.ISwapWrapper {
      * @param signature Response of the intermediary
      * @param feeRatePromise Pre-fetched fee rate promise
      * @param preFetchSignatureVerificationData Pre-fetched signature verification data
+     * @param contractVersion
      * @param abortSignal
      * @returns Swap initialization signature expiry
      * @throws {SignatureVerificationError} when swap init signature is invalid
      *
      * @internal
      */
-    async verifyReturnedSignature(initiator, data, signature, feeRatePromise, preFetchSignatureVerificationData, abortSignal) {
+    async verifyReturnedSignature(initiator, data, signature, feeRatePromise, preFetchSignatureVerificationData, contractVersion, abortSignal) {
         const [feeRate, preFetchedSignatureData] = await Promise.all([feeRatePromise, preFetchSignatureVerificationData]);
-        await this._contract.isValidInitAuthorization(initiator, data, signature, feeRate, preFetchedSignatureData);
-        return await this._contract.getInitAuthorizationExpiry(data, signature, preFetchedSignatureData);
+        await this._contract(contractVersion).isValidInitAuthorization(initiator, data, signature, feeRate, preFetchedSignatureData);
+        return await this._contract(contractVersion).getInitAuthorizationExpiry(data, signature, preFetchedSignatureData);
     }
     /**
      * Processes a single SC on-chain event
@@ -100,7 +123,7 @@ class IEscrowSwapWrapper extends ISwapWrapper_1.ISwapWrapper {
         const changedSwaps = [];
         const removeSwaps = [];
         const swapExpiredStatus = {};
-        const checkStatusSwaps = [];
+        const checkStatusSwaps = {};
         for (let pastSwap of pastSwaps) {
             if (pastSwap._shouldFetchExpiryStatus()) {
                 //Check expiry
@@ -109,19 +132,29 @@ class IEscrowSwapWrapper extends ISwapWrapper_1.ISwapWrapper {
             if (pastSwap._shouldFetchOnchainState()) {
                 //Add to swaps for which status should be checked
                 if (pastSwap._data != null)
-                    checkStatusSwaps.push(pastSwap);
+                    (checkStatusSwaps[pastSwap._contractVersion ?? "v1"] ??= []).push(pastSwap);
             }
         }
-        const swapStatuses = await this._contract.getCommitStatuses(checkStatusSwaps.map(val => ({ signer: val._getInitiator(), swapData: val._data })));
-        for (let pastSwap of checkStatusSwaps) {
-            const escrowHash = pastSwap.getEscrowHash();
-            const shouldSave = await pastSwap._sync(false, swapExpiredStatus[pastSwap.getId()], escrowHash == null ? undefined : swapStatuses[escrowHash]);
-            if (shouldSave) {
-                if (pastSwap.isQuoteExpired()) {
-                    removeSwaps.push(pastSwap);
-                }
-                else {
-                    changedSwaps.push(pastSwap);
+        for (let version in checkStatusSwaps) {
+            if (this._versionedContracts[version] == null) {
+                this.logger.warn(`_checkPastSwaps(): No contract was found for ${this.chainIdentifier} version ${version}! Skipping these swaps!`);
+                continue;
+            }
+            const _checkStatusSwap = checkStatusSwaps[version];
+            const swapStatuses = await this._contract(version).getCommitStatuses(_checkStatusSwap.map(val => ({
+                signer: val._getInitiator(),
+                swapData: val._data
+            })));
+            for (let pastSwap of _checkStatusSwap) {
+                const escrowHash = pastSwap.getEscrowHash();
+                const shouldSave = await pastSwap._sync(false, swapExpiredStatus[pastSwap.getId()], escrowHash == null ? undefined : swapStatuses[escrowHash]);
+                if (shouldSave) {
+                    if (pastSwap.isQuoteExpired()) {
+                        removeSwaps.push(pastSwap);
+                    }
+                    else {
+                        changedSwaps.push(pastSwap);
+                    }
                 }
             }
         }

--- a/dist/swaps/escrow_swaps/frombtc/IFromBTCLNWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/IFromBTCLNWrapper.d.ts
@@ -29,15 +29,19 @@ export declare abstract class IFromBTCLNWrapper<T extends ChainType, D extends I
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Swap pricing handler
      * @param tokens
-     * @param swapDataDeserializer Deserializer for SwapData
+     * @param versionedContracts
      * @param lnApi
      * @param options
      * @param events Instance to use for emitting events
      */
-    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], contract: T["Contract"], prices: ISwapPrice, tokens: WrapperCtorTokens, swapDataDeserializer: new (data: any) => T["Data"], lnApi: LightningNetworkApi, options: O, events?: EventEmitter<{
+    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], prices: ISwapPrice, tokens: WrapperCtorTokens, versionedContracts: {
+        [version: string]: {
+            swapContract: T["Contract"];
+            swapDataConstructor: new (data: any) => T["Data"];
+        };
+    }, lnApi: LightningNetworkApi, options: O, events?: EventEmitter<{
         swapState: [IEscrowSwap];
     }>);
     /**

--- a/dist/swaps/escrow_swaps/frombtc/IFromBTCLNWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/IFromBTCLNWrapper.js
@@ -19,16 +19,15 @@ class IFromBTCLNWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Swap pricing handler
      * @param tokens
-     * @param swapDataDeserializer Deserializer for SwapData
+     * @param versionedContracts
      * @param lnApi
      * @param options
      * @param events Instance to use for emitting events
      */
-    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, lnApi, options, events) {
-        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, options, events);
+    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, versionedContracts, lnApi, options, events) {
+        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, options, versionedContracts, events);
         this.lnApi = lnApi;
     }
     /**

--- a/dist/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.js
+++ b/dist/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.js
@@ -128,7 +128,7 @@ class IFromBTCSelfInitSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
      */
     async hasEnoughForTxFees() {
         const [balance, commitFee] = await Promise.all([
-            this.wrapper._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
+            this._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
             this.getCommitFee()
         ]);
         const totalFee = commitFee + this.getSwapData().getTotalDeposit();
@@ -174,7 +174,7 @@ class IFromBTCSelfInitSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
             this.initiated = true;
             await this._saveAndEmit();
         }
-        return await this.wrapper._contract.txsInit(this._getInitiator(), this._data, this.signatureData, skipChecks, this.feeRate).catch(e => Promise.reject(e instanceof base_1.SignatureVerificationError ? new Error("Request timed out") : e));
+        return await this._contract.txsInit(this._getInitiator(), this._data, this.signatureData, skipChecks, this.feeRate).catch(e => Promise.reject(e instanceof base_1.SignatureVerificationError ? new Error("Request timed out") : e));
     }
     //////////////////////////////
     //// Claim
@@ -183,7 +183,7 @@ class IFromBTCSelfInitSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
      *  smart chain
      */
     async getClaimNetworkFee() {
-        const swapContract = this.wrapper._contract;
+        const swapContract = this._contract;
         return (0, TokenAmount_1.toTokenAmount)(await swapContract.getClaimFee(this._getInitiator(), this.getSwapData()), this.wrapper._getNativeToken(), this.wrapper._prices);
     }
 }

--- a/dist/swaps/escrow_swaps/frombtc/IFromBTCWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/IFromBTCWrapper.d.ts
@@ -27,11 +27,16 @@ export declare abstract class IFromBTCWrapper<T extends ChainType, D extends IFr
      * @param claimHash optional claim hash of the swap or null
      * @param abortController
      *
+     * @param contractVersions
      * @returns Fee rate
      *
      * @internal
      */
-    protected preFetchFeeRate(signer: string, amountData: AmountData, claimHash: string | undefined, abortController: AbortController): Promise<string | undefined>;
+    protected preFetchFeeRate(signer: string, amountData: AmountData, claimHash: {
+        [contractVersion: string]: string;
+    } | undefined, abortController: AbortController, contractVersions: string[]): {
+        [contractVersion: string]: Promise<string | undefined>;
+    };
     /**
      * Pre-fetches intermediary (LP) available smart chain liquidity
      *
@@ -39,11 +44,12 @@ export declare abstract class IFromBTCWrapper<T extends ChainType, D extends IFr
      * @param lp Intermediary
      * @param abortController
      *
+     * @param contractVersion
      * @returns Intermediary's liquidity balance
      *
      * @internal
      */
-    protected preFetchIntermediaryLiquidity(amountData: AmountData, lp: Intermediary, abortController: AbortController): Promise<bigint | undefined>;
+    protected preFetchIntermediaryLiquidity(amountData: AmountData, lp: Intermediary, abortController: AbortController, contractVersion: string): Promise<bigint | undefined>;
     /**
      * Verifies whether the intermediary (LP) has enough available liquidity such that we can initiate the swap
      *

--- a/dist/swaps/escrow_swaps/frombtc/IFromBTCWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/IFromBTCWrapper.js
@@ -29,16 +29,19 @@ class IFromBTCWrapper extends IEscrowSwapWrapper_1.IEscrowSwapWrapper {
      * @param claimHash optional claim hash of the swap or null
      * @param abortController
      *
+     * @param contractVersions
      * @returns Fee rate
      *
      * @internal
      */
-    preFetchFeeRate(signer, amountData, claimHash, abortController) {
-        return this._contract.getInitFeeRate(this._chain.randomAddress(), signer, amountData.token, claimHash)
-            .catch(e => {
-            this.logger.warn("preFetchFeeRate(): Error: ", e);
-            abortController.abort(e);
-            return undefined;
+    preFetchFeeRate(signer, amountData, claimHash, abortController, contractVersions) {
+        return (0, Utils_1.mapArrayToObject)(contractVersions, (contractVersion) => {
+            return this._contract(contractVersion).getInitFeeRate(this._chain.randomAddress(), signer, amountData.token, claimHash?.[contractVersion])
+                .catch(e => {
+                this.logger.warn("preFetchFeeRate(): Error: ", e);
+                abortController.abort(e);
+                return undefined;
+            });
         });
     }
     /**
@@ -48,12 +51,13 @@ class IFromBTCWrapper extends IEscrowSwapWrapper_1.IEscrowSwapWrapper {
      * @param lp Intermediary
      * @param abortController
      *
+     * @param contractVersion
      * @returns Intermediary's liquidity balance
      *
      * @internal
      */
-    preFetchIntermediaryLiquidity(amountData, lp, abortController) {
-        return lp.getLiquidity(this.chainIdentifier, this._contract, amountData.token.toString(), abortController.signal).catch(e => {
+    preFetchIntermediaryLiquidity(amountData, lp, abortController, contractVersion) {
+        return lp.getLiquidity(this.chainIdentifier, this._contract(contractVersion), amountData.token.toString(), abortController.signal).catch(e => {
             this.logger.warn("preFetchIntermediaryLiquidity(): Error: ", e);
             abortController.abort(e);
             return undefined;

--- a/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.js
@@ -394,11 +394,11 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
      */
     async hasEnoughForTxFees() {
         const [balance, feeRate] = await Promise.all([
-            this.wrapper._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
-            this.feeRate != null ? Promise.resolve(this.feeRate) : this.wrapper._contract.getInitFeeRate(this.getSwapData().getOfferer(), this.getSwapData().getClaimer(), this.getSwapData().getToken(), this.getSwapData().getClaimHash())
+            this._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
+            this.feeRate != null ? Promise.resolve(this.feeRate) : this._contract.getInitFeeRate(this.getSwapData().getOfferer(), this.getSwapData().getClaimer(), this.getSwapData().getToken(), this.getSwapData().getClaimHash())
         ]);
-        const commitFee = await this.wrapper._contract.getCommitFee(this._getInitiator(), this.getSwapData(), feeRate);
-        const claimFee = await this.wrapper._contract.getClaimFee(this._getInitiator(), this.getSwapData(), feeRate);
+        const commitFee = await this._contract.getCommitFee(this._getInitiator(), this.getSwapData(), feeRate);
+        const claimFee = await this._contract.getClaimFee(this._getInitiator(), this.getSwapData(), feeRate);
         const totalFee = commitFee + claimFee + this.getSwapData().getTotalDeposit();
         return {
             enoughBalance: balance >= totalFee,
@@ -408,7 +408,7 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
     }
     isValidSecretPreimage(secret) {
         const paymentHash = buffer_1.Buffer.from((0, sha2_1.sha256)(buffer_1.Buffer.from(secret, "hex")));
-        const claimHash = this.wrapper._contract.getHashForHtlc(paymentHash).toString("hex");
+        const claimHash = this._contract.getHashForHtlc(paymentHash).toString("hex");
         return this.getSwapData().getClaimHash() === claimHash;
     }
     /**
@@ -602,10 +602,10 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
         const resp = await IntermediaryAPI_1.IntermediaryAPI.getPaymentAuthorization(this.url, paymentHash.toString("hex"));
         switch (resp.code) {
             case IntermediaryAPI_1.PaymentAuthorizationResponseCodes.AUTH_DATA:
-                const data = new this.wrapper._swapDataDeserializer(resp.data.data);
+                const data = new (this.wrapper._swapDataDeserializer(this._contractVersion))(resp.data.data);
                 try {
                     await this.checkIntermediaryReturnedAuthData(this._getInitiator(), data, resp.data);
-                    this.expiry = await this.wrapper._contract.getInitAuthorizationExpiry(data, resp.data);
+                    this.expiry = await this._contract.getInitAuthorizationExpiry(data, resp.data);
                     this._state = FromBTCLNSwapState.PR_PAID;
                     this._data = data;
                     this.signatureData = {
@@ -666,8 +666,8 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
         if (data.hasSuccessAction())
             throw new IntermediaryError_1.IntermediaryError("Invalid has success action");
         await Promise.all([
-            this.wrapper._contract.isValidInitAuthorization(this._getInitiator(), data, signature, this.feeRate),
-            this.wrapper._contract.getCommitStatus(data.getClaimer(), data)
+            this._contract.isValidInitAuthorization(this._getInitiator(), data, signature, this.feeRate),
+            this._contract.getCommitStatus(data.getClaimer(), data)
                 .then(status => {
                 if (status?.type !== base_1.SwapCommitStateType.NOT_COMMITED)
                     throw new Error("Swap already committed on-chain!");
@@ -730,9 +730,9 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
         abortController.signal.throwIfAborted();
         if (resp.code === IntermediaryAPI_1.PaymentAuthorizationResponseCodes.AUTH_DATA) {
             const sigData = resp.data;
-            const swapData = new this.wrapper._swapDataDeserializer(resp.data.data);
+            const swapData = new (this.wrapper._swapDataDeserializer(this._contractVersion))(resp.data.data);
             await this.checkIntermediaryReturnedAuthData(this._getInitiator(), swapData, sigData);
-            this.expiry = await this.wrapper._contract.getInitAuthorizationExpiry(swapData, sigData);
+            this.expiry = await this._contract.getInitAuthorizationExpiry(swapData, sigData);
             if (onPaymentReceived != null)
                 onPaymentReceived(this.getInputTxId());
             if (this._state === FromBTCLNSwapState.PR_CREATED || this._state === FromBTCLNSwapState.QUOTE_SOFT_EXPIRED) {
@@ -840,7 +840,7 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
             throw new Error("Swap secret pre-image not known and not provided, please provide the swap secret pre-image as an argument");
         if (!this.isValidSecretPreimage(useSecret))
             throw new Error("Invalid swap secret pre-image provided!");
-        return this.wrapper._contract.txsClaimWithSecret(address ?? this._getInitiator(), this._data, useSecret, true, true);
+        return this._contract.txsClaimWithSecret(address ?? this._getInitiator(), this._data, useSecret, true, true);
     }
     /**
      * @inheritDoc
@@ -950,7 +950,7 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
      *  to settle the swap on the smart chain destination side.
      */
     async getCommitAndClaimNetworkFee() {
-        const swapContract = this.wrapper._contract;
+        const swapContract = this._contract;
         const feeRate = this.feeRate ?? await swapContract.getInitFeeRate(this.getSwapData().getOfferer(), this.getSwapData().getClaimer(), this.getSwapData().getToken(), this.getSwapData().getClaimHash());
         const commitFee = await (swapContract.getRawCommitFee != null ?
             swapContract.getRawCommitFee(this._getInitiator(), this.getSwapData(), feeRate) :
@@ -966,7 +966,7 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
      *  call {@link commit} first and then {@link claim}.
      */
     canCommitAndClaimInOneShot() {
-        return this.wrapper._contract.initAndClaimWithSecret != null;
+        return this._contract.initAndClaimWithSecret != null;
     }
     /**
      * Returns transactions for both commit & claim operation together, such that they can be signed all at once by
@@ -995,7 +995,7 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
         if (!this.isValidSecretPreimage(useSecret))
             throw new Error("Invalid swap secret pre-image provided!");
         const initTxs = await this.txsCommit(skipChecks);
-        const claimTxs = await this.wrapper._contract.txsClaimWithSecret(this._getInitiator(), this._data, useSecret, true, true, undefined, true);
+        const claimTxs = await this._contract.txsClaimWithSecret(this._getInitiator(), this._data, useSecret, true, true, undefined, true);
         return initTxs.concat(claimTxs);
     }
     /**
@@ -1125,7 +1125,7 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
                 quoteExpired = quoteDefinitelyExpired ?? await this._verifyQuoteDefinitelyExpired();
             }
             //Check if it's already successfully paid
-            commitStatus ??= await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data);
+            commitStatus ??= await this._contract.getCommitStatus(this._getInitiator(), this._data);
             if (commitStatus != null && await this._forciblySetOnchainState(commitStatus))
                 return true;
             //Set the state on expiry here
@@ -1191,7 +1191,7 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
         if (await this.syncStateFromChain(quoteDefinitelyExpired, commitStatus))
             changed = true;
         if (this._state === FromBTCLNSwapState.CLAIM_COMMITED) {
-            const expired = await this.wrapper._contract.isExpired(this._getInitiator(), this._data);
+            const expired = await this._contract.isExpired(this._getInitiator(), this._data);
             if (expired) {
                 this._state = FromBTCLNSwapState.EXPIRED;
                 changed = true;
@@ -1259,7 +1259,7 @@ class FromBTCLNSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
                 }
                 break;
             case FromBTCLNSwapState.CLAIM_COMMITED:
-                const expired = await this.wrapper._contract.isExpired(this._getInitiator(), this._data);
+                const expired = await this._contract.isExpired(this._getInitiator(), this._data);
                 if (expired) {
                     this._state = FromBTCLNSwapState.EXPIRED;
                     if (save)

--- a/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.d.ts
@@ -79,15 +79,19 @@ export declare class FromBTCLNWrapper<T extends ChainType> extends IFromBTCLNWra
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Swap pricing handler
      * @param tokens
-     * @param swapDataDeserializer Deserializer for SwapData
+     * @param versionedContracts
      * @param lnApi
      * @param options
      * @param events Instance to use for emitting events
      */
-    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], contract: T["Contract"], prices: ISwapPrice, tokens: WrapperCtorTokens, swapDataDeserializer: new (data: any) => T["Data"], lnApi: LightningNetworkApi, options?: AllOptional<FromBTCLNWrapperOptions>, events?: EventEmitter<{
+    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], prices: ISwapPrice, tokens: WrapperCtorTokens, versionedContracts: {
+        [version: string]: {
+            swapContract: T["Contract"];
+            swapDataConstructor: new (data: any) => T["Data"];
+        };
+    }, lnApi: LightningNetworkApi, options?: AllOptional<FromBTCLNWrapperOptions>, events?: EventEmitter<{
         swapState: [ISwap];
     }>);
     /**
@@ -136,8 +140,10 @@ export declare class FromBTCLNWrapper<T extends ChainType> extends IFromBTCLNWra
      */
     create(recipient: string, amountData: AmountData, lps: Intermediary[], options?: FromBTCLNOptions, additionalParams?: Record<string, any>, abortSignal?: AbortSignal, preFetches?: {
         usdPricePrefetchPromise: Promise<number | undefined>;
-        pricePrefetchPromise?: Promise<bigint | undefined>;
-        feeRatePromise?: Promise<string | undefined>;
+        pricePrefetchPromise: Promise<bigint | undefined>;
+        feeRatePromise: {
+            [contractVersion: string]: Promise<string | undefined>;
+        };
     }): {
         quote: Promise<FromBTCLNSwap<T>>;
         intermediary: Intermediary;
@@ -180,5 +186,5 @@ export declare class FromBTCLNWrapper<T extends ChainType> extends IFromBTCLNWra
             blockTime: number;
             blockHeight: number;
         }>;
-    }, state: SwapCommitState, lp?: Intermediary): Promise<FromBTCLNSwap<T> | null>;
+    }, state: SwapCommitState, contractVersion: string, lp?: Intermediary): Promise<FromBTCLNSwap<T> | null>;
 }

--- a/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.js
@@ -4,6 +4,7 @@ exports.FromBTCLNWrapper = void 0;
 const FromBTCLNSwap_1 = require("./FromBTCLNSwap");
 const bolt11_1 = require("@atomiqlabs/bolt11");
 const base_1 = require("@atomiqlabs/base");
+const Intermediary_1 = require("../../../../intermediaries/Intermediary");
 const buffer_1 = require("buffer");
 const UserError_1 = require("../../../../errors/UserError");
 const IntermediaryError_1 = require("../../../../errors/IntermediaryError");
@@ -26,16 +27,15 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Swap pricing handler
      * @param tokens
-     * @param swapDataDeserializer Deserializer for SwapData
+     * @param versionedContracts
      * @param lnApi
      * @param options
      * @param events Instance to use for emitting events
      */
-    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, lnApi, options, events) {
-        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, lnApi, {
+    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, versionedContracts, lnApi, options, events) {
+        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, versionedContracts, lnApi, {
             ...options,
             safetyFactor: options?.safetyFactor ?? 2,
             bitcoinBlocktime: options?.bitcoinBlocktime ?? 10 * 60,
@@ -164,6 +164,7 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
         };
         if (_options.description != null && buffer_1.Buffer.byteLength(_options.description, "utf8") > 500)
             throw new UserError_1.UserError("Invalid description length");
+        const lpVersions = Intermediary_1.Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
         let secret;
         let paymentHash;
         if (_options.paymentHash != null) {
@@ -172,13 +173,15 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
         else {
             ({ secret, paymentHash } = this.getSecretAndHash());
         }
-        const claimHash = this._contract.getHashForHtlc(paymentHash);
+        const _hash = (0, Utils_1.mapArrayToObject)(lpVersions, (contractVersion) => {
+            return this._contract(contractVersion).getHashForHtlc(paymentHash).toString("hex");
+        });
         const nativeTokenAddress = this._chain.getNativeCurrencyAddress();
         const _abortController = (0, Utils_1.extendAbortController)(abortSignal);
-        const _preFetches = {
-            pricePrefetchPromise: preFetches?.pricePrefetchPromise ?? this.preFetchPrice(amountData, _abortController.signal),
-            feeRatePromise: preFetches?.feeRatePromise ?? this.preFetchFeeRate(recipient, amountData, claimHash.toString("hex"), _abortController),
-            usdPricePrefetchPromise: preFetches?.usdPricePrefetchPromise ?? this.preFetchUsdPrice(_abortController.signal),
+        const _preFetches = preFetches ?? {
+            pricePrefetchPromise: this.preFetchPrice(amountData, _abortController.signal),
+            feeRatePromise: this.preFetchFeeRate(recipient, amountData, _hash, _abortController, lpVersions),
+            usdPricePrefetchPromise: this.preFetchUsdPrice(_abortController.signal),
         };
         return lps.map(lp => {
             return {
@@ -186,8 +189,9 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                 quote: (async () => {
                     if (lp.services[SwapType_1.SwapType.FROM_BTCLN] == null)
                         throw new Error("LP service for processing from btcln swaps not found!");
+                    const version = lp.getContractVersion(this.chainIdentifier);
                     const abortController = (0, Utils_1.extendAbortController)(_abortController.signal);
-                    const liquidityPromise = this.preFetchIntermediaryLiquidity(amountData, lp, abortController);
+                    const liquidityPromise = this.preFetchIntermediaryLiquidity(amountData, lp, abortController, version);
                     const { lnCapacityPromise, resp } = await (0, RetryUtils_1.tryWithRetries)(async (retryCount) => {
                         const { lnPublicKey, response } = IntermediaryAPI_1.IntermediaryAPI.initFromBTCLN(this.chainIdentifier, lp.url, nativeTokenAddress, {
                             paymentHash,
@@ -197,7 +201,7 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                             description: _options.description,
                             descriptionHash: _options.descriptionHash,
                             exactOut: !amountData.exactIn,
-                            feeRate: (0, Utils_1.throwIfUndefined)(_preFetches.feeRatePromise),
+                            feeRate: (0, Utils_1.throwIfUndefined)(_preFetches.feeRatePromise[version]),
                             additionalParams
                         }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
                         let lnCapacityPromise;
@@ -231,11 +235,12 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                             expiry: decodedPr.timeExpireDate * 1000,
                             swapFee: resp.swapFee,
                             swapFeeBtc,
-                            feeRate: (await _preFetches.feeRatePromise),
-                            initialSwapData: await this._contract.createSwapData(base_1.ChainSwapType.HTLC, lp.getAddress(this.chainIdentifier), recipient, amountData.token, resp.total, claimHash.toString("hex"), this.getRandomSequence(), BigInt(Math.floor(Date.now() / 1000)), false, true, resp.securityDeposit, 0n, nativeTokenAddress),
+                            feeRate: (await _preFetches.feeRatePromise[version]),
+                            initialSwapData: await this._contract(version).createSwapData(base_1.ChainSwapType.HTLC, lp.getAddress(this.chainIdentifier), recipient, amountData.token, resp.total, _hash[version], this.getRandomSequence(), BigInt(Math.floor(Date.now() / 1000)), false, true, resp.securityDeposit, 0n, nativeTokenAddress),
                             pr: resp.pr,
                             secret: secret?.toString("hex"),
-                            exactIn: amountData.exactIn ?? true
+                            exactIn: amountData.exactIn ?? true,
+                            contractVersion: version
                         });
                         return quote;
                     }
@@ -271,11 +276,12 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
             descriptionHash: (0, Utils_1.parseHashValueExact32Bytes)(options?.descriptionHash, "description hash"),
             unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? this._options.unsafeSkipLnNodeCheck
         };
+        const lpVersions = Intermediary_1.Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
         const abortController = (0, Utils_1.extendAbortController)(abortSignal);
         const preFetches = {
             pricePrefetchPromise: this.preFetchPrice(amountData, abortController.signal),
             usdPricePrefetchPromise: this.preFetchUsdPrice(abortController.signal),
-            feeRatePromise: this.preFetchFeeRate(recipient, amountData, undefined, abortController)
+            feeRatePromise: this.preFetchFeeRate(recipient, amountData, undefined, abortController, lpVersions)
         };
         try {
             const exactOutAmountPromise = !amountData.exactIn ? preFetches.pricePrefetchPromise.then(price => this._prices.getToBtcSwapAmount(this.chainIdentifier, amountData.amount, amountData.token, abortController.signal, price)).catch(e => {
@@ -326,7 +332,7 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
     async _checkPastSwaps(pastSwaps) {
         const changedSwapSet = new Set();
         const swapExpiredStatus = {};
-        const checkStatusSwaps = [];
+        const checkStatusSwaps = {};
         await Promise.all(pastSwaps.map(async (pastSwap) => {
             if (pastSwap._shouldCheckIntermediary()) {
                 try {
@@ -346,14 +352,21 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
             if (pastSwap._shouldFetchOnchainState()) {
                 //Add to swaps for which status should be checked
                 if (pastSwap._data != null)
-                    checkStatusSwaps.push(pastSwap);
+                    (checkStatusSwaps[pastSwap._contractVersion ?? "v1"] ??= []).push(pastSwap);
             }
         }));
-        const swapStatuses = await this._contract.getCommitStatuses(checkStatusSwaps.map(val => ({ signer: val._getInitiator(), swapData: val._data })));
-        for (let pastSwap of checkStatusSwaps) {
-            const shouldSave = await pastSwap._sync(false, swapExpiredStatus[pastSwap.getId()], swapStatuses[pastSwap.getEscrowHash()], true);
-            if (shouldSave) {
-                changedSwapSet.add(pastSwap);
+        for (let version in checkStatusSwaps) {
+            if (this._versionedContracts[version] == null) {
+                this.logger.warn(`_checkPastSwaps(): No contract was found for ${this.chainIdentifier} version ${version}! Skipping these swaps!`);
+                continue;
+            }
+            const _checkStatusSwap = checkStatusSwaps[version];
+            const swapStatuses = await this._contract(version).getCommitStatuses(_checkStatusSwap.map(val => ({ signer: val._getInitiator(), swapData: val._data })));
+            for (let pastSwap of _checkStatusSwap) {
+                const shouldSave = await pastSwap._sync(false, swapExpiredStatus[pastSwap.getId()], swapStatuses[pastSwap.getEscrowHash()], true);
+                if (shouldSave) {
+                    changedSwapSet.add(pastSwap);
+                }
             }
         }
         const changedSwaps = [];
@@ -375,7 +388,7 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
      * @inheritDoc
      * @internal
      */
-    async recoverFromSwapDataAndState(init, state, lp) {
+    async recoverFromSwapDataAndState(init, state, contractVersion, lp) {
         const data = init.data;
         let paymentHash = data.getHTLCHashHint();
         let secret;
@@ -402,7 +415,8 @@ class FromBTCLNWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
             data,
             pr: paymentHash ?? undefined,
             secret,
-            exactIn: false
+            exactIn: false,
+            contractVersion
         };
         const swap = new FromBTCLNSwap_1.FromBTCLNSwap(this, swapInit);
         swap._commitTxId = await init.getInitTxId();

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.js
@@ -576,7 +576,7 @@ class FromBTCLNAutoSwap extends IEscrowSwap_1.IEscrowSwap {
     }
     isValidSecretPreimage(secret) {
         const paymentHash = buffer_1.Buffer.from((0, sha2_1.sha256)(buffer_1.Buffer.from(secret, "hex")));
-        const claimHash = this.wrapper._contract.getHashForHtlc(paymentHash).toString("hex");
+        const claimHash = this._contract.getHashForHtlc(paymentHash).toString("hex");
         return this.getSwapData().getClaimHash() === claimHash;
     }
     /**
@@ -737,7 +737,7 @@ class FromBTCLNAutoSwap extends IEscrowSwap_1.IEscrowSwap {
         const resp = await IntermediaryAPI_1.IntermediaryAPI.getInvoiceStatus(this.url, paymentHash.toString("hex"));
         switch (resp.code) {
             case IntermediaryAPI_1.InvoiceStatusResponseCodes.PAID:
-                const data = new this.wrapper._swapDataDeserializer(resp.data.data);
+                const data = new (this.wrapper._swapDataDeserializer(this._contractVersion))(resp.data.data);
                 if (this._state === FromBTCLNAutoSwapState.PR_CREATED || this._state === FromBTCLNAutoSwapState.QUOTE_SOFT_EXPIRED)
                     try {
                         await this._saveRealSwapData(data, save);
@@ -809,7 +809,7 @@ class FromBTCLNAutoSwap extends IEscrowSwap_1.IEscrowSwap {
             throw new IntermediaryError_1.IntermediaryError("Invalid deposit token used!");
         if (data.hasSuccessAction())
             throw new IntermediaryError_1.IntermediaryError("Invalid has success action");
-        if (await this.wrapper._contract.isExpired(this._getInitiator(), data))
+        if (await this.wrapper._contract(this._contractVersion).isExpired(this._getInitiator(), data))
             throw new IntermediaryError_1.IntermediaryError("Not enough time to claim!");
         if (this.wrapper._getHtlcTimeout(data) <= (Date.now() / 1000))
             throw new IntermediaryError_1.IntermediaryError("HTLC expires too soon!");
@@ -880,7 +880,7 @@ class FromBTCLNAutoSwap extends IEscrowSwap_1.IEscrowSwap {
                     this.lnurlFailSignal.signal.removeEventListener("abort", lnurlFailListener);
                     abortController.signal.throwIfAborted();
                     if (resp.code === IntermediaryAPI_1.InvoiceStatusResponseCodes.PAID) {
-                        const swapData = new this.wrapper._swapDataDeserializer(resp.data.data);
+                        const swapData = new (this.wrapper._swapDataDeserializer(this._contractVersion))(resp.data.data);
                         return await this._saveRealSwapData(swapData, true);
                     }
                     if (this._state === FromBTCLNAutoSwapState.PR_CREATED || this._state === FromBTCLNAutoSwapState.QUOTE_SOFT_EXPIRED) {
@@ -984,7 +984,7 @@ class FromBTCLNAutoSwap extends IEscrowSwap_1.IEscrowSwap {
             throw new Error("Swap secret pre-image not known and not provided, please provide the swap secret pre-image as an argument");
         if (!this.isValidSecretPreimage(useSecret))
             throw new Error("Invalid swap secret pre-image provided!");
-        return await this.wrapper._contract.txsClaimWithSecret(address ?? this._getInitiator(), this._data, useSecret, true, true);
+        return await this._contract.txsClaimWithSecret(address ?? this._getInitiator(), this._data, useSecret, true, true);
     }
     /**
      * @inheritDoc
@@ -1176,7 +1176,7 @@ class FromBTCLNAutoSwap extends IEscrowSwap_1.IEscrowSwap {
                 quoteExpired = quoteDefinitelyExpired ?? await this._verifyQuoteDefinitelyExpired();
             }
             //Check if it's already successfully paid
-            commitStatus ??= await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data);
+            commitStatus ??= await this._contract.getCommitStatus(this._getInitiator(), this._data);
             if (commitStatus != null && await this._forciblySetOnchainState(commitStatus))
                 return true;
             if (this._state === FromBTCLNAutoSwapState.PR_PAID) {
@@ -1239,7 +1239,7 @@ class FromBTCLNAutoSwap extends IEscrowSwap_1.IEscrowSwap {
         if (await this.syncStateFromChain(quoteDefinitelyExpired, commitStatus))
             changed = true;
         if (this._state === FromBTCLNAutoSwapState.CLAIM_COMMITED) {
-            const expired = await this.wrapper._contract.isExpired(this._getInitiator(), this._data);
+            const expired = await this._contract.isExpired(this._getInitiator(), this._data);
             if (expired) {
                 this._state = FromBTCLNAutoSwapState.EXPIRED;
                 changed = true;
@@ -1308,7 +1308,7 @@ class FromBTCLNAutoSwap extends IEscrowSwap_1.IEscrowSwap {
         if (!this.isValidSecretPreimage(useSecret))
             throw new Error("Invalid swap secret pre-image provided!");
         if (!noCheckExpiry) {
-            if (await this.wrapper._contract.isExpired(this._getInitiator(), this._data))
+            if (await this._contract.isExpired(this._getInitiator(), this._data))
                 throw new Error("On-chain HTLC already expired!");
         }
         await this.wrapper._messenger.broadcast(new base_1.SwapClaimWitnessMessage(this._data, useSecret));
@@ -1337,7 +1337,7 @@ class FromBTCLNAutoSwap extends IEscrowSwap_1.IEscrowSwap {
                 break;
             case FromBTCLNAutoSwapState.PR_PAID:
             case FromBTCLNAutoSwapState.CLAIM_COMMITED:
-                const expired = await this.wrapper._contract.isExpired(this._getInitiator(), this._data);
+                const expired = await this._contract.isExpired(this._getInitiator(), this._data);
                 if (expired) {
                     this._state = FromBTCLNAutoSwapState.EXPIRED;
                     if (save)

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.d.ts
@@ -108,16 +108,20 @@ export declare class FromBTCLNAutoWrapper<T extends ChainType> extends IFromBTCL
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Swap pricing handler
      * @param tokens
-     * @param swapDataDeserializer Deserializer for SwapData
+     * @param versionedContracts
      * @param lnApi
      * @param messenger
      * @param options
      * @param events Instance to use for emitting events
      */
-    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], contract: T["Contract"], prices: ISwapPrice, tokens: WrapperCtorTokens, swapDataDeserializer: new (data: any) => T["Data"], lnApi: LightningNetworkApi, messenger: Messenger, options?: AllOptional<FromBTCLNAutoWrapperOptions>, events?: EventEmitter<{
+    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], prices: ISwapPrice, tokens: WrapperCtorTokens, versionedContracts: {
+        [version: string]: {
+            swapContract: T["Contract"];
+            swapDataConstructor: new (data: any) => T["Data"];
+        };
+    }, lnApi: LightningNetworkApi, messenger: Messenger, options?: AllOptional<FromBTCLNAutoWrapperOptions>, events?: EventEmitter<{
         swapState: [ISwap];
     }>);
     /**
@@ -144,6 +148,7 @@ export declare class FromBTCLNAutoWrapper<T extends ChainType> extends IFromBTCL
      * @param options Options as passed to the swap creation function
      * @param abortController
      *
+     * @param contractVersions
      * @private
      */
     private preFetchClaimerBounty;
@@ -178,10 +183,12 @@ export declare class FromBTCLNAutoWrapper<T extends ChainType> extends IFromBTCL
      * @param preFetches Optional pre-fetches for speeding up the quoting process (mainly used internally)
      */
     create(recipient: string, amountData: AmountData, lps: Intermediary[], options?: FromBTCLNAutoOptions, additionalParams?: Record<string, any>, abortSignal?: AbortSignal, preFetches?: {
-        pricePrefetchPromise?: Promise<bigint | undefined>;
-        usdPricePrefetchPromise?: Promise<number | undefined>;
+        pricePrefetchPromise: Promise<bigint | undefined>;
+        usdPricePrefetchPromise: Promise<number | undefined>;
+        claimerBountyPrefetch: {
+            [contractVersion: string]: Promise<bigint | undefined>;
+        };
         gasTokenPricePrefetchPromise?: Promise<bigint | undefined>;
-        claimerBountyPrefetch?: Promise<bigint | undefined>;
     }): {
         quote: Promise<FromBTCLNAutoSwap<T>>;
         intermediary: Intermediary;
@@ -224,5 +231,5 @@ export declare class FromBTCLNAutoWrapper<T extends ChainType> extends IFromBTCL
             blockTime: number;
             blockHeight: number;
         }>;
-    }, state: SwapCommitState, lp?: Intermediary): Promise<FromBTCLNAutoSwap<T> | null>;
+    }, state: SwapCommitState, contractVersion: string, lp?: Intermediary): Promise<FromBTCLNAutoSwap<T> | null>;
 }

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.FromBTCLNAutoWrapper = void 0;
 const bolt11_1 = require("@atomiqlabs/bolt11");
 const base_1 = require("@atomiqlabs/base");
+const Intermediary_1 = require("../../../../intermediaries/Intermediary");
 const buffer_1 = require("buffer");
 const UserError_1 = require("../../../../errors/UserError");
 const IntermediaryError_1 = require("../../../../errors/IntermediaryError");
@@ -28,17 +29,16 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Swap pricing handler
      * @param tokens
-     * @param swapDataDeserializer Deserializer for SwapData
+     * @param versionedContracts
      * @param lnApi
      * @param messenger
      * @param options
      * @param events Instance to use for emitting events
      */
-    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, lnApi, messenger, options, events) {
-        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, lnApi, {
+    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, versionedContracts, lnApi, messenger, options, events) {
+        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, versionedContracts, lnApi, {
             ...options,
             safetyFactor: options?.safetyFactor ?? 2,
             bitcoinBlocktime: options?.bitcoinBlocktime ?? 10 * 60,
@@ -142,20 +142,23 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
      * @param options Options as passed to the swap creation function
      * @param abortController
      *
+     * @param contractVersions
      * @private
      */
-    async preFetchClaimerBounty(signer, amountData, options, abortController) {
-        if (options.unsafeZeroWatchtowerFee)
-            return 0n;
-        const dummyAmount = BigInt(Math.floor(Math.random() * 0x1000000));
-        const dummySwapData = await this._contract.createSwapData(base_1.ChainSwapType.HTLC, this._chain.randomAddress(), signer, amountData.token, dummyAmount, this._contract.getHashForHtlc((0, Utils_1.randomBytes)(32)).toString("hex"), this.getRandomSequence(), BigInt(Math.floor(Date.now() / 1000)), false, true, BigInt(Math.floor(Math.random() * 0x10000)), BigInt(Math.floor(Math.random() * 0x10000)));
-        try {
-            const result = await this._contract.getClaimFee(this._chain.randomAddress(), dummySwapData);
-            return result * BigInt(Math.floor(options.feeSafetyFactor * 1000000)) / 1000000n;
-        }
-        catch (e) {
-            abortController.abort(e);
-        }
+    preFetchClaimerBounty(signer, amountData, options, abortController, contractVersions) {
+        return (0, Utils_1.mapArrayToObject)(contractVersions, async (contractVersion) => {
+            if (options.unsafeZeroWatchtowerFee)
+                return 0n;
+            const dummyAmount = BigInt(Math.floor(Math.random() * 0x1000000));
+            const dummySwapData = await this._contract(contractVersion).createSwapData(base_1.ChainSwapType.HTLC, this._chain.randomAddress(), signer, amountData.token, dummyAmount, this._contract(contractVersion).getHashForHtlc((0, Utils_1.randomBytes)(32)).toString("hex"), this.getRandomSequence(), BigInt(Math.floor(Date.now() / 1000)), false, true, BigInt(Math.floor(Math.random() * 0x10000)), BigInt(Math.floor(Math.random() * 0x10000)));
+            try {
+                const result = await this._contract(contractVersion).getClaimFee(this._chain.randomAddress(), dummySwapData);
+                return result * BigInt(Math.floor(options.feeSafetyFactor * 1000000)) / 1000000n;
+            }
+            catch (e) {
+                abortController.abort(e);
+            }
+        });
     }
     /**
      * Verifies response returned from intermediary
@@ -232,6 +235,7 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
             throw new UserError_1.UserError("Cannot specify `gasAmount` for swaps to a native token!");
         if (_options.description != null && buffer_1.Buffer.byteLength(_options.description, "utf8") > 500)
             throw new UserError_1.UserError("Invalid description length");
+        const lpVersions = Intermediary_1.Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
         let secret;
         let paymentHash;
         if (_options?.paymentHash != null) {
@@ -240,16 +244,17 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
         else {
             ({ secret, paymentHash } = this.getSecretAndHash());
         }
-        const claimHash = this._contract.getHashForHtlc(paymentHash);
+        const _hash = (0, Utils_1.mapArrayToObject)(lpVersions, (contractVersion) => {
+            return this._contract(contractVersion).getHashForHtlc(paymentHash).toString("hex");
+        });
         const nativeTokenAddress = this._chain.getNativeCurrencyAddress();
         const _abortController = (0, Utils_1.extendAbortController)(abortSignal);
-        preFetches ??= {};
-        const _preFetches = {
-            pricePrefetchPromise: preFetches?.pricePrefetchPromise ?? this.preFetchPrice(amountData, _abortController.signal),
-            usdPricePrefetchPromise: preFetches?.usdPricePrefetchPromise ?? this.preFetchUsdPrice(_abortController.signal),
-            claimerBountyPrefetch: preFetches?.claimerBountyPrefetch ?? this.preFetchClaimerBounty(recipient, amountData, _options, _abortController),
+        const _preFetches = preFetches ?? {
+            pricePrefetchPromise: this.preFetchPrice(amountData, _abortController.signal),
+            usdPricePrefetchPromise: this.preFetchUsdPrice(_abortController.signal),
+            claimerBountyPrefetch: this.preFetchClaimerBounty(recipient, amountData, _options, _abortController, lpVersions),
             gasTokenPricePrefetchPromise: _options.gasAmount !== 0n || !_options.unsafeZeroWatchtowerFee ?
-                (preFetches.gasTokenPricePrefetchPromise ??= this.preFetchPrice({ token: nativeTokenAddress }, _abortController.signal)) :
+                this.preFetchPrice({ token: nativeTokenAddress }, _abortController.signal) :
                 undefined
         };
         return lps.map(lp => {
@@ -258,8 +263,9 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                 quote: (async () => {
                     if (lp.services[SwapType_1.SwapType.FROM_BTCLN_AUTO] == null)
                         throw new Error("LP service for processing from btcln auto swaps not found!");
+                    const version = lp.getContractVersion(this.chainIdentifier);
                     const abortController = (0, Utils_1.extendAbortController)(_abortController.signal);
-                    const liquidityPromise = this.preFetchIntermediaryLiquidity(amountData, lp, abortController);
+                    const liquidityPromise = this.preFetchIntermediaryLiquidity(amountData, lp, abortController, version);
                     const { lnCapacityPromise, resp } = await (0, RetryUtils_1.tryWithRetries)(async (retryCount) => {
                         const { lnPublicKey, response } = IntermediaryAPI_1.IntermediaryAPI.initFromBTCLNAuto(this.chainIdentifier, lp.url, {
                             paymentHash,
@@ -272,7 +278,7 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                             additionalParams,
                             gasToken: this._chain.getNativeCurrencyAddress(),
                             gasAmount: _options.gasAmount,
-                            claimerBounty: (0, Utils_1.throwIfUndefined)(_preFetches.claimerBountyPrefetch)
+                            claimerBounty: (0, Utils_1.throwIfUndefined)(_preFetches.claimerBountyPrefetch[version])
                         }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
                         let lnCapacityPromise;
                         if (!_options.unsafeSkipLnNodeCheck) {
@@ -291,7 +297,7 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                     if (decodedPr.timeExpireDate == null)
                         throw new IntermediaryError_1.IntermediaryError("Invalid returned swap invoice, no expiry date field");
                     const amountIn = (BigInt(decodedPr.millisatoshis) + 999n) / 1000n;
-                    const claimerBounty = (await _preFetches.claimerBountyPrefetch);
+                    const claimerBounty = (await _preFetches.claimerBountyPrefetch[version]);
                     try {
                         this.verifyReturnedData(resp, amountData, lp, _options, decodedPr, paymentHash, claimerBounty);
                         const [pricingInfo, gasPricingInfo] = await Promise.all([
@@ -312,10 +318,11 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
                             btcAmountGas: resp.btcAmountGas,
                             btcAmountSwap: resp.btcAmountSwap,
                             gasPricingInfo,
-                            initialSwapData: await this._contract.createSwapData(base_1.ChainSwapType.HTLC, lp.getAddress(this.chainIdentifier), recipient, amountData.token, resp.total, claimHash.toString("hex"), this.getRandomSequence(), BigInt(Math.floor(Date.now() / 1000)), false, true, _options.gasAmount + resp.claimerBounty, resp.claimerBounty, nativeTokenAddress),
+                            initialSwapData: await this._contract(version).createSwapData(base_1.ChainSwapType.HTLC, lp.getAddress(this.chainIdentifier), recipient, amountData.token, resp.total, _hash[version], this.getRandomSequence(), BigInt(Math.floor(Date.now() / 1000)), false, true, _options.gasAmount + resp.claimerBounty, resp.claimerBounty, nativeTokenAddress),
                             pr: resp.pr,
                             secret: secret?.toString("hex"),
-                            exactIn: amountData.exactIn ?? true
+                            exactIn: amountData.exactIn ?? true,
+                            contractVersion: version
                         };
                         const quote = new FromBTCLNAutoSwap_1.FromBTCLNAutoSwap(this, swapInit);
                         return quote;
@@ -356,6 +363,7 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
             description: options?.description,
             descriptionHash: (0, Utils_1.parseHashValueExact32Bytes)(options?.descriptionHash, "description hash")
         };
+        const lpVersions = Intermediary_1.Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
         const abortController = (0, Utils_1.extendAbortController)(abortSignal);
         const preFetches = {
             pricePrefetchPromise: this.preFetchPrice(amountData, abortController.signal),
@@ -363,7 +371,7 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
             gasTokenPricePrefetchPromise: _options.gasAmount !== 0n || !_options.unsafeZeroWatchtowerFee ?
                 this.preFetchPrice({ token: this._chain.getNativeCurrencyAddress() }, abortController.signal) :
                 undefined,
-            claimerBountyPrefetch: this.preFetchClaimerBounty(recipient, amountData, _options, abortController)
+            claimerBountyPrefetch: this.preFetchClaimerBounty(recipient, amountData, _options, abortController, lpVersions)
         };
         try {
             const exactOutAmountPromise = !amountData.exactIn ? preFetches.pricePrefetchPromise.then(price => this._prices.getToBtcSwapAmount(this.chainIdentifier, amountData.amount, amountData.token, abortController.signal, price)).catch(e => {
@@ -414,7 +422,7 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
     async _checkPastSwaps(pastSwaps) {
         const changedSwapSet = new Set();
         const swapExpiredStatus = {};
-        const checkStatusSwaps = [];
+        const checkStatusSwaps = {};
         await Promise.all(pastSwaps.map(async (pastSwap) => {
             if (pastSwap._shouldCheckIntermediary()) {
                 try {
@@ -434,14 +442,21 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
             if (pastSwap._shouldFetchOnchainState()) {
                 //Add to swaps for which status should be checked
                 if (pastSwap._data != null)
-                    checkStatusSwaps.push(pastSwap);
+                    (checkStatusSwaps[pastSwap._contractVersion ?? "v1"] ??= []).push(pastSwap);
             }
         }));
-        const swapStatuses = await this._contract.getCommitStatuses(checkStatusSwaps.map(val => ({ signer: val._getInitiator(), swapData: val._data })));
-        for (let pastSwap of checkStatusSwaps) {
-            const shouldSave = await pastSwap._sync(false, swapExpiredStatus[pastSwap.getId()], swapStatuses[pastSwap.getEscrowHash()], true);
-            if (shouldSave) {
-                changedSwapSet.add(pastSwap);
+        for (let version in checkStatusSwaps) {
+            if (this._versionedContracts[version] == null) {
+                this.logger.warn(`_checkPastSwaps(): No contract was found for ${this.chainIdentifier} version ${version}! Skipping these swaps!`);
+                continue;
+            }
+            const _checkStatusSwap = checkStatusSwaps[version];
+            const swapStatuses = await this._contract(version).getCommitStatuses(_checkStatusSwap.map(val => ({ signer: val._getInitiator(), swapData: val._data })));
+            for (let pastSwap of _checkStatusSwap) {
+                const shouldSave = await pastSwap._sync(false, swapExpiredStatus[pastSwap.getId()], swapStatuses[pastSwap.getEscrowHash()], true);
+                if (shouldSave) {
+                    changedSwapSet.add(pastSwap);
+                }
             }
         }
         const changedSwaps = [];
@@ -462,7 +477,7 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
     /**
      * @inheritDoc
      */
-    async recoverFromSwapDataAndState(init, state, lp) {
+    async recoverFromSwapDataAndState(init, state, contractVersion, lp) {
         const data = init.data;
         let paymentHash = data.getHTLCHashHint();
         let secret;
@@ -489,7 +504,8 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
             data,
             pr: paymentHash ?? undefined,
             secret,
-            exactIn: false
+            exactIn: false,
+            contractVersion
         };
         const swap = new FromBTCLNAutoSwap_1.FromBTCLNAutoSwap(this, swapInit);
         swap._commitTxId = await init.getInitTxId();

--- a/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.js
@@ -231,7 +231,10 @@ class FromBTCLNAutoWrapper extends IFromBTCLNWrapper_1.IFromBTCLNWrapper {
             description: options?.description,
             descriptionHash: (0, Utils_1.parseHashValueExact32Bytes)(options?.descriptionHash, "description hash")
         };
-        if (amountData.token === this._chain.getNativeCurrencyAddress() && _options.gasAmount !== 0n)
+        if (_options.gasAmount !== 0n &&
+            (this._chain.shouldGetNativeTokenDrop != null
+                ? !this._chain.shouldGetNativeTokenDrop(amountData.token)
+                : amountData.token === this._chain.getNativeCurrencyAddress()))
             throw new UserError_1.UserError("Cannot specify `gasAmount` for swaps to a native token!");
         if (_options.description != null && buffer_1.Buffer.byteLength(_options.description, "utf8") > 500)
             throw new UserError_1.UserError("Invalid description length");

--- a/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.js
+++ b/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.js
@@ -305,7 +305,7 @@ class FromBTCSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
     inferRequiredConfirmationsCount(btcTx, vout) {
         const txOut = btcTx.outs[vout];
         for (let i = 1; i <= 20; i++) {
-            const computedClaimHash = this.wrapper._contract.getHashForOnchain(buffer_1.Buffer.from(txOut.scriptPubKey.hex, "hex"), BigInt(txOut.value), i);
+            const computedClaimHash = this._contract.getHashForOnchain(buffer_1.Buffer.from(txOut.scriptPubKey.hex, "hex"), BigInt(txOut.value), i);
             if (computedClaimHash.toString("hex") === this._data.getClaimHash()) {
                 return i;
             }
@@ -815,13 +815,13 @@ class FromBTCSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
             throw new Error("Cannot create claim transaction, because required confirmations are not known and cannot be infered! This can happen after a swap is recovered.");
         if (tx.blockhash == null || tx.confirmations == null || tx.blockheight == null || tx.confirmations < this.requiredConfirmations)
             throw new Error("Bitcoin transaction not confirmed yet!");
-        return await this.wrapper._contract.txsClaimWithTxData(signer ?? this._getInitiator(), this._data, {
+        return await this._contract.txsClaimWithTxData(signer ?? this._getInitiator(), this._data, {
             blockhash: tx.blockhash,
             confirmations: tx.confirmations,
             txid: tx.txid,
             hex: tx.hex,
             height: tx.blockheight
-        }, this.requiredConfirmations, this.vout, undefined, this.wrapper._synchronizer, true);
+        }, this.requiredConfirmations, this.vout, undefined, this.wrapper._synchronizer(this._contractVersion), true);
     }
     /**
      * Settles the swap by claiming the funds on the destination chain if the swap requires manual settlement, you can
@@ -855,7 +855,7 @@ class FromBTCSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
                 this.logger.info("claim(): Transaction state is CLAIM_CLAIMED, swap was successfully claimed by the watchtower");
                 return this._claimTxId;
             }
-            const status = await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data);
+            const status = await this._contract.getCommitStatus(this._getInitiator(), this._data);
             if (status?.type === base_1.SwapCommitStateType.PAID) {
                 this.logger.info("claim(): Transaction commit status is PAID, swap was successfully claimed by the watchtower");
                 if (this._claimTxId == null)
@@ -973,7 +973,7 @@ class FromBTCSwap extends IFromBTCSelfInitSwap_1.IFromBTCSelfInitSwap {
             if (this._state === FromBTCSwapState.PR_CREATED || this._state === FromBTCSwapState.QUOTE_SOFT_EXPIRED) {
                 quoteExpired = quoteDefinitelyExpired ?? await this._verifyQuoteDefinitelyExpired(); //Make sure we check for expiry here, to prevent race conditions
             }
-            const status = commitStatus ?? await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data);
+            const status = commitStatus ?? await this._contract.getCommitStatus(this._getInitiator(), this._data);
             if (status != null && await this._forciblySetOnchainState(status))
                 return true;
             if (this._state === FromBTCSwapState.PR_CREATED || this._state === FromBTCSwapState.QUOTE_SOFT_EXPIRED) {

--- a/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.d.ts
@@ -74,28 +74,38 @@ export declare class FromBTCWrapper<T extends ChainType> extends IFromBTCWrapper
     /**
      * @internal
      */
-    readonly _synchronizer: RelaySynchronizer<any, T["TX"], any>;
+    readonly _synchronizer: (version?: string) => RelaySynchronizer<any, T["TX"], any>;
     /**
      * @internal
      */
     readonly _btcRpc: BitcoinRpcWithAddressIndex<any>;
     private readonly btcRelay;
+    private readonly versionedBtcRelay;
+    private readonly versionedSynchronizer;
     /**
      * @param chainIdentifier
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Pricing to use
      * @param tokens
-     * @param swapDataDeserializer Deserializer for SwapData
-     * @param btcRelay
-     * @param synchronizer Btc relay synchronizer
+     * @param versionedContracts
+     * @param versionedSynchronizer
      * @param btcRpc Bitcoin RPC which also supports getting transactions by txoHash
      * @param options
      * @param events Instance to use for emitting events
      */
-    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], contract: T["Contract"], prices: ISwapPrice, tokens: WrapperCtorTokens, swapDataDeserializer: new (data: any) => T["Data"], btcRelay: BtcRelay<any, T["TX"], any>, synchronizer: RelaySynchronizer<any, T["TX"], any>, btcRpc: BitcoinRpcWithAddressIndex<any>, options?: AllOptional<FromBTCWrapperOptions>, events?: EventEmitter<{
+    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], prices: ISwapPrice, tokens: WrapperCtorTokens, versionedContracts: {
+        [version: string]: {
+            swapContract: T["Contract"];
+            swapDataConstructor: new (data: any) => T["Data"];
+            btcRelay: BtcRelay<any, T["TX"], any>;
+        };
+    }, versionedSynchronizer: {
+        [version: string]: {
+            synchronizer: RelaySynchronizer<any, T["TX"], any>;
+        };
+    }, btcRpc: BitcoinRpcWithAddressIndex<any>, options?: AllOptional<FromBTCWrapperOptions>, events?: EventEmitter<{
         swapState: [ISwap];
     }>);
     /**
@@ -130,6 +140,7 @@ export declare class FromBTCWrapper<T extends ChainType> extends IFromBTCWrapper
      * @param amountData
      * @param options Options as passed to the swap creation function
      * @param abortController
+     * @param contractVersion
      *
      * @private
      */
@@ -187,5 +198,5 @@ export declare class FromBTCWrapper<T extends ChainType> extends IFromBTCWrapper
             blockTime: number;
             blockHeight: number;
         }>;
-    }, state: SwapCommitState, lp?: Intermediary): Promise<FromBTCSwap<T> | null>;
+    }, state: SwapCommitState, contractVersion: string, lp?: Intermediary): Promise<FromBTCSwap<T> | null>;
 }

--- a/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.js
+++ b/dist/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.js
@@ -4,6 +4,7 @@ exports.FromBTCWrapper = void 0;
 const IFromBTCWrapper_1 = require("../IFromBTCWrapper");
 const FromBTCSwap_1 = require("./FromBTCSwap");
 const base_1 = require("@atomiqlabs/base");
+const Intermediary_1 = require("../../../../intermediaries/Intermediary");
 const buffer_1 = require("buffer");
 const IntermediaryError_1 = require("../../../../errors/IntermediaryError");
 const SwapType_1 = require("../../../../enums/SwapType");
@@ -25,18 +26,16 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Pricing to use
      * @param tokens
-     * @param swapDataDeserializer Deserializer for SwapData
-     * @param btcRelay
-     * @param synchronizer Btc relay synchronizer
+     * @param versionedContracts
+     * @param versionedSynchronizer
      * @param btcRpc Bitcoin RPC which also supports getting transactions by txoHash
      * @param options
      * @param events Instance to use for emitting events
      */
-    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, btcRelay, synchronizer, btcRpc, options, events) {
-        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, {
+    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, versionedContracts, versionedSynchronizer, btcRpc, options, events) {
+        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, {
             ...options,
             bitcoinNetwork: options?.bitcoinNetwork ?? utils_1.TEST_NETWORK,
             safetyFactor: options?.safetyFactor ?? 2,
@@ -44,7 +43,7 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
             maxConfirmations: options?.maxConfirmations ?? 6,
             minSendWindow: options?.minSendWindow ?? 30 * 60,
             bitcoinBlocktime: options?.bitcoinBlocktime ?? 10 * 60
-        }, events);
+        }, versionedContracts, events);
         this.TYPE = SwapType_1.SwapType.FROM_BTC;
         /**
          * @internal
@@ -68,9 +67,28 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
          * @internal
          */
         this._swapDeserializer = FromBTCSwap_1.FromBTCSwap;
-        this.btcRelay = btcRelay;
-        this._synchronizer = synchronizer;
+        /**
+         * @internal
+         */
+        this._synchronizer = (version) => {
+            const _version = version ?? "v1";
+            const data = this.versionedSynchronizer[_version];
+            if (data == null)
+                throw new Error(`Invalid contract version ${_version} requested`);
+            return data.synchronizer;
+        };
+        this.btcRelay = (version) => {
+            const _version = version ?? "v1";
+            const data = this.versionedBtcRelay[_version];
+            if (data == null)
+                throw new Error(`Invalid contract version ${_version} requested`);
+            return data.btcRelay;
+        };
+        this.versionedBtcRelay = {};
+        this.versionedSynchronizer = {};
         this._btcRpc = btcRpc;
+        this.versionedBtcRelay = versionedContracts;
+        this.versionedSynchronizer = versionedSynchronizer;
     }
     /**
      * @inheritDoc
@@ -128,10 +146,11 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
      * @param amountData
      * @param options Options as passed to the swap creation function
      * @param abortController
+     * @param contractVersion
      *
      * @private
      */
-    async preFetchClaimerBounty(signer, amountData, options, abortController) {
+    async preFetchClaimerBounty(signer, amountData, options, abortController, contractVersion) {
         const startTimestamp = BigInt(Math.floor(Date.now() / 1000));
         if (options.unsafeZeroWatchtowerFee) {
             return {
@@ -143,13 +162,13 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
             };
         }
         const dummyAmount = BigInt(Math.floor(Math.random() * 0x1000000));
-        const dummySwapData = await this._contract.createSwapData(base_1.ChainSwapType.CHAIN, signer, signer, amountData.token, dummyAmount, this._contract.getHashForOnchain((0, Utils_1.randomBytes)(20), dummyAmount, 3).toString("hex"), this.getRandomSequence(), startTimestamp, false, true, BigInt(Math.floor(Math.random() * 0x10000)), BigInt(Math.floor(Math.random() * 0x10000)));
+        const dummySwapData = await this._contract(contractVersion).createSwapData(base_1.ChainSwapType.CHAIN, signer, signer, amountData.token, dummyAmount, this._contract(contractVersion).getHashForOnchain((0, Utils_1.randomBytes)(20), dummyAmount, 3).toString("hex"), this.getRandomSequence(), startTimestamp, false, true, BigInt(Math.floor(Math.random() * 0x10000)), BigInt(Math.floor(Math.random() * 0x10000)));
         try {
             const [feePerBlock, btcRelayData, currentBtcBlock, claimFeeRate] = await Promise.all([
-                this.btcRelay.getFeePerBlock(),
-                this.btcRelay.getTipData(),
+                this.btcRelay(contractVersion).getFeePerBlock(),
+                this.btcRelay(contractVersion).getTipData(),
                 this._btcRpc.getTipHeight(),
-                this._contract.getClaimFee(signer, dummySwapData)
+                this._contract(contractVersion).getClaimFee(signer, dummySwapData)
             ]);
             if (btcRelayData == null)
                 throw new Error("Btc relay not initialized!");
@@ -231,9 +250,10 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
         if ((expiry - currentTimestamp) < BigInt(this._options.minSendWindow)) {
             throw new IntermediaryError_1.IntermediaryError("Send window too low");
         }
+        const version = lp.getContractVersion(this.chainIdentifier);
         const lockingScript = (0, BitcoinUtils_1.toOutputScript)(this._options.bitcoinNetwork, resp.btcAddress);
-        const desiredExtraData = this._contract.getExtraData(lockingScript, resp.amount, requiredConfirmations);
-        const desiredClaimHash = this._contract.getHashForOnchain(lockingScript, resp.amount, requiredConfirmations);
+        const desiredExtraData = this._contract(version).getExtraData(lockingScript, resp.amount, requiredConfirmations);
+        const desiredClaimHash = this._contract(version).getHashForOnchain(lockingScript, resp.amount, requiredConfirmations);
         if (!desiredClaimHash.equals(buffer_1.Buffer.from(data.getClaimHash(), "hex"))) {
             throw new IntermediaryError_1.IntermediaryError("Invalid claim hash returned!");
         }
@@ -261,6 +281,7 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
         else if (typeof (options?.feeSafetyFactor) === "number") {
             feeSafetyFactorPPM = BigInt(Math.floor(options.feeSafetyFactor * 1000000));
         }
+        const lpVersions = Intermediary_1.Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
         const _options = {
             blockSafetyFactor: options?.blockSafetyFactor != null ? BigInt(options.blockSafetyFactor) : 1n,
             feeSafetyFactorPPM,
@@ -270,20 +291,25 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
         const _abortController = (0, Utils_1.extendAbortController)(abortSignal);
         const pricePrefetchPromise = this.preFetchPrice(amountData, _abortController.signal);
         const usdPricePrefetchPromise = this.preFetchUsdPrice(_abortController.signal);
-        const claimerBountyPrefetchPromise = this.preFetchClaimerBounty(recipient, amountData, _options, _abortController);
+        const claimerBountyPrefetchPromise = (0, Utils_1.mapArrayToObject)(lpVersions, (contractVersion) => {
+            return this.preFetchClaimerBounty(recipient, amountData, _options, _abortController, contractVersion);
+        });
         const nativeTokenAddress = this._chain.getNativeCurrencyAddress();
-        const feeRatePromise = this.preFetchFeeRate(recipient, amountData, undefined, _abortController);
-        const _signDataPromise = this._contract.preFetchBlockDataForSignatures == null ?
-            this.preFetchSignData(Promise.resolve(true)) :
-            undefined;
+        const feeRatePromise = this.preFetchFeeRate(recipient, amountData, undefined, _abortController, lpVersions);
+        const _signDataPromise = (0, Utils_1.mapArrayToObject)(lpVersions, (contractVersion) => {
+            return this._contract(contractVersion).preFetchBlockDataForSignatures == null ?
+                this.preFetchSignData(Promise.resolve(true), contractVersion) :
+                undefined;
+        });
         return lps.map(lp => {
             return {
                 intermediary: lp,
                 quote: (async () => {
                     if (lp.services[SwapType_1.SwapType.FROM_BTC] == null)
                         throw new Error("LP service for processing from btc swaps not found!");
+                    const version = lp.getContractVersion(this.chainIdentifier);
                     const abortController = (0, Utils_1.extendAbortController)(_abortController.signal);
-                    const liquidityPromise = this.preFetchIntermediaryLiquidity(amountData, lp, abortController);
+                    const liquidityPromise = this.preFetchIntermediaryLiquidity(amountData, lp, abortController, version);
                     try {
                         const { signDataPromise, resp } = await (0, RetryUtils_1.tryWithRetries)(async (retryCount) => {
                             const { signDataPrefetch, response } = IntermediaryAPI_1.IntermediaryAPI.initFromBTC(this.chainIdentifier, lp.url, nativeTokenAddress, {
@@ -292,13 +318,13 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
                                 token: amountData.token.toString(),
                                 exactOut: !amountData.exactIn,
                                 sequence,
-                                claimerBounty: (0, Utils_1.throwIfUndefined)(claimerBountyPrefetchPromise),
-                                feeRate: (0, Utils_1.throwIfUndefined)(feeRatePromise),
+                                claimerBounty: (0, Utils_1.throwIfUndefined)(claimerBountyPrefetchPromise[version]),
+                                feeRate: (0, Utils_1.throwIfUndefined)(feeRatePromise[version]),
                                 additionalParams
                             }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
-                            let signDataPromise = _signDataPromise;
+                            let signDataPromise = _signDataPromise[version];
                             if (signDataPromise == null) {
-                                signDataPromise = this.preFetchSignData(signDataPrefetch);
+                                signDataPromise = this.preFetchSignData(signDataPrefetch, version);
                             }
                             else
                                 signDataPrefetch.catch(() => { });
@@ -307,14 +333,14 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
                                 resp: await response
                             };
                         }, undefined, e => e instanceof RequestError_1.RequestError, abortController.signal);
-                        const data = new this._swapDataDeserializer(resp.data);
+                        const data = new (this._swapDataDeserializer(version))(resp.data);
                         data.setClaimer(recipient);
                         const swapFeeBtc = resp.swapFee * resp.amount / (data.getAmount() + resp.swapFee);
-                        this.verifyReturnedData(recipient, resp, amountData, lp, _options, data, sequence, (await claimerBountyPrefetchPromise), nativeTokenAddress);
+                        this.verifyReturnedData(recipient, resp, amountData, lp, _options, data, sequence, (await claimerBountyPrefetchPromise[version]), nativeTokenAddress);
                         const [pricingInfo, signatureExpiry] = await Promise.all([
                             //Get intermediary's liquidity
                             this.verifyReturnedPrice(lp.services[SwapType_1.SwapType.FROM_BTC], false, resp.amount, resp.total, amountData.token, { swapFeeBtc }, pricePrefetchPromise, usdPricePrefetchPromise, abortController.signal),
-                            this.verifyReturnedSignature(recipient, data, resp, feeRatePromise, signDataPromise, abortController.signal),
+                            this.verifyReturnedSignature(recipient, data, resp, feeRatePromise[version], signDataPromise, version, abortController.signal),
                             this.verifyIntermediaryLiquidity(data.getAmount(), (0, Utils_1.throwIfUndefined)(liquidityPromise)),
                         ]);
                         const quote = new FromBTCSwap_1.FromBTCSwap(this, {
@@ -323,13 +349,14 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
                             expiry: signatureExpiry,
                             swapFee: resp.swapFee,
                             swapFeeBtc,
-                            feeRate: (await feeRatePromise),
+                            feeRate: (await feeRatePromise[version]),
                             signatureData: resp,
                             data,
                             address: resp.btcAddress,
                             amount: resp.amount,
                             exactIn: amountData.exactIn ?? true,
-                            requiredConfirmations: resp.confirmations
+                            requiredConfirmations: resp.confirmations,
+                            contractVersion: version
                         });
                         return quote;
                     }
@@ -344,7 +371,7 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
     /**
      * @inheritDoc
      */
-    async recoverFromSwapDataAndState(init, state, lp) {
+    async recoverFromSwapDataAndState(init, state, contractVersion, lp) {
         const data = init.data;
         const swapInit = {
             pricingInfo: {
@@ -362,7 +389,8 @@ class FromBTCWrapper extends IFromBTCWrapper_1.IFromBTCWrapper {
             feeRate: "",
             signatureData: undefined,
             data,
-            exactIn: false
+            exactIn: false,
+            contractVersion
         };
         const swap = new FromBTCSwap_1.FromBTCSwap(this, swapInit);
         swap._commitTxId = await init.getInitTxId();

--- a/dist/swaps/escrow_swaps/tobtc/IToBTCSwap.js
+++ b/dist/swaps/escrow_swaps/tobtc/IToBTCSwap.js
@@ -333,7 +333,7 @@ class IToBTCSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
      */
     async hasEnoughBalance() {
         const [balance, commitFee] = await Promise.all([
-            this.wrapper._contract.getBalance(this._getInitiator(), this._data.getToken(), false),
+            this._contract.getBalance(this._getInitiator(), this._data.getToken(), false),
             this._data.getToken() === this.wrapper._chain.getNativeCurrencyAddress() ? this.getCommitFee() : Promise.resolve(null)
         ]);
         let required = this._data.getAmount();
@@ -351,7 +351,7 @@ class IToBTCSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
      */
     async hasEnoughForTxFees() {
         const [balance, commitFee] = await Promise.all([
-            this.wrapper._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
+            this._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
             this.getCommitFee()
         ]);
         return {
@@ -461,7 +461,7 @@ class IToBTCSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
             this.initiated = true;
             await this._saveAndEmit();
         }
-        return await this.wrapper._contract.txsInit(this._getInitiator(), this._data, this.signatureData, skipChecks, this.feeRate).catch(e => Promise.reject(e instanceof base_1.SignatureVerificationError ? new Error("Request timed out") : e));
+        return await this._contract.txsInit(this._getInitiator(), this._data, this.signatureData, skipChecks, this.feeRate).catch(e => Promise.reject(e instanceof base_1.SignatureVerificationError ? new Error("Request timed out") : e));
     }
     /**
      * @inheritDoc
@@ -583,7 +583,7 @@ class IToBTCSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
                 }
                 return processed;
             case IntermediaryAPI_1.RefundAuthorizationResponseCodes.REFUND_DATA:
-                await this.wrapper._contract.isValidRefundAuthorization(this._data, resp.data);
+                await this._contract.isValidRefundAuthorization(this._data, resp.data);
                 this._state = ToBTCSwapState.REFUNDABLE;
                 if (save)
                     await this._saveAndEmit();
@@ -649,11 +649,11 @@ class IToBTCSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
                 return true;
             case IntermediaryAPI_1.RefundAuthorizationResponseCodes.REFUND_DATA:
                 const resultData = result.data;
-                await this.wrapper._contract.isValidRefundAuthorization(this._data, resultData);
+                await this._contract.isValidRefundAuthorization(this._data, resultData);
                 await this._saveAndEmit(ToBTCSwapState.REFUNDABLE);
                 return false;
             case IntermediaryAPI_1.RefundAuthorizationResponseCodes.EXPIRED:
-                if (await this.wrapper._contract.isExpired(this._getInitiator(), this._data))
+                if (await this._contract.isExpired(this._getInitiator(), this._data))
                     throw new Error("Swap expired");
                 throw new IntermediaryError_1.IntermediaryError("Swap expired");
             case IntermediaryAPI_1.RefundAuthorizationResponseCodes.NOT_FOUND:
@@ -669,7 +669,7 @@ class IToBTCSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
      * Get the estimated smart chain transaction fee of the refund transaction
      */
     async getRefundNetworkFee() {
-        const swapContract = this.wrapper._contract;
+        const swapContract = this._contract;
         return (0, TokenAmount_1.toTokenAmount)(await swapContract.getRefundFee(this._getInitiator(), this._data), this.wrapper._getNativeToken(), this.wrapper._prices);
     }
     /**
@@ -697,15 +697,15 @@ class IToBTCSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
         else {
             signer = this._getInitiator();
         }
-        if (await this.wrapper._contract.isExpired(this._getInitiator(), this._data)) {
-            return await this.wrapper._contract.txsRefund(signer, this._data, true, true);
+        if (await this._contract.isExpired(this._getInitiator(), this._data)) {
+            return await this._contract.txsRefund(signer, this._data, true, true);
         }
         else {
             if (this.url == null)
                 throw new Error("LP URL not known, cannot get cooperative refund message, wait till expiry to refund!");
             const res = await IntermediaryAPI_1.IntermediaryAPI.getRefundAuthorization(this.url, this.getLpIdentifier(), this._data.getSequence());
             if (res.code === IntermediaryAPI_1.RefundAuthorizationResponseCodes.REFUND_DATA) {
-                return await this.wrapper._contract.txsRefundWithAuthorization(signer, this._data, res.data, true, true);
+                return await this._contract.txsRefundWithAuthorization(signer, this._data, res.data, true, true);
             }
             throw new IntermediaryError_1.IntermediaryError("Invalid intermediary cooperative message returned");
         }
@@ -800,7 +800,7 @@ class IToBTCSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
                 //Check if quote is still valid
                 quoteExpired = quoteDefinitelyExpired ?? await this._verifyQuoteDefinitelyExpired();
             }
-            commitStatus ??= await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data);
+            commitStatus ??= await this._contract.getCommitStatus(this._getInitiator(), this._data);
             if (commitStatus != null && await this._forciblySetOnchainState(commitStatus))
                 return true;
             if ((this._state === ToBTCSwapState.CREATED || this._state === ToBTCSwapState.QUOTE_SOFT_EXPIRED)) {
@@ -909,7 +909,7 @@ class IToBTCSwap extends IEscrowSelfInitSwap_1.IEscrowSelfInitSwap {
                 break;
             case ToBTCSwapState.COMMITED:
             case ToBTCSwapState.SOFT_CLAIMED:
-                const expired = await this.wrapper._contract.isExpired(this._getInitiator(), this._data);
+                const expired = await this._contract.isExpired(this._getInitiator(), this._data);
                 if (expired) {
                     this._state = ToBTCSwapState.REFUNDABLE;
                     if (save)

--- a/dist/swaps/escrow_swaps/tobtc/IToBTCWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/tobtc/IToBTCWrapper.d.ts
@@ -29,12 +29,13 @@ export declare abstract class IToBTCWrapper<T extends ChainType, D extends IToBT
      * @param amountData
      * @param lp Intermediary
      * @param abortController
+     * @param contractVersion
      * @returns Intermediary's reputation or null if failed
      * @throws {IntermediaryError} If the intermediary vault doesn't exist
      *
      * @internal
      */
-    protected preFetchIntermediaryReputation(amountData: Omit<AmountData, "amount">, lp: Intermediary, abortController: AbortController): Promise<SingleChainReputationType | undefined>;
+    protected preFetchIntermediaryReputation(amountData: Omit<AmountData, "amount">, lp: Intermediary, abortController: AbortController, contractVersion: string): Promise<SingleChainReputationType | undefined>;
     /**
      * Pre-fetches feeRate for a given swap
      *
@@ -42,11 +43,16 @@ export declare abstract class IToBTCWrapper<T extends ChainType, D extends IToBT
      * @param amountData
      * @param claimHash optional hash of the swap or null
      * @param abortController
+     * @param contractVersions
      * @returns Fee rate
      *
      * @internal
      */
-    protected preFetchFeeRate(signer: string, amountData: Omit<AmountData, "amount">, claimHash: string | undefined, abortController: AbortController): Promise<string | undefined>;
+    protected preFetchFeeRate(signer: string, amountData: Omit<AmountData, "amount">, claimHash: {
+        [contractVersion: string]: string;
+    } | undefined, abortController: AbortController, contractVersions: string[]): {
+        [contractVersion: string]: Promise<string | undefined>;
+    };
     /**
      * @internal
      */

--- a/dist/swaps/escrow_swaps/tobtc/IToBTCWrapper.js
+++ b/dist/swaps/escrow_swaps/tobtc/IToBTCWrapper.js
@@ -4,6 +4,7 @@ exports.IToBTCWrapper = void 0;
 const IToBTCSwap_1 = require("./IToBTCSwap");
 const IntermediaryError_1 = require("../../../errors/IntermediaryError");
 const IEscrowSwapWrapper_1 = require("../IEscrowSwapWrapper");
+const Utils_1 = require("../../../utils/Utils");
 /**
  * Base class for wrappers of escrow-based Smart chain -> Bitcoin (on-chain & lightning) swaps
  *
@@ -37,13 +38,14 @@ class IToBTCWrapper extends IEscrowSwapWrapper_1.IEscrowSwapWrapper {
      * @param amountData
      * @param lp Intermediary
      * @param abortController
+     * @param contractVersion
      * @returns Intermediary's reputation or null if failed
      * @throws {IntermediaryError} If the intermediary vault doesn't exist
      *
      * @internal
      */
-    preFetchIntermediaryReputation(amountData, lp, abortController) {
-        return lp.getReputation(this.chainIdentifier, this._contract, [amountData.token.toString()], abortController.signal).then(res => {
+    preFetchIntermediaryReputation(amountData, lp, abortController, contractVersion) {
+        return lp.getReputation(this.chainIdentifier, this._contract(contractVersion), [amountData.token.toString()], abortController.signal).then(res => {
             if (res == null)
                 throw new IntermediaryError_1.IntermediaryError("Invalid data returned - invalid LP vault");
             return res;
@@ -60,16 +62,19 @@ class IToBTCWrapper extends IEscrowSwapWrapper_1.IEscrowSwapWrapper {
      * @param amountData
      * @param claimHash optional hash of the swap or null
      * @param abortController
+     * @param contractVersions
      * @returns Fee rate
      *
      * @internal
      */
-    preFetchFeeRate(signer, amountData, claimHash, abortController) {
-        return this._contract.getInitPayInFeeRate(signer, this._chain.randomAddress(), amountData.token, claimHash)
-            .catch(e => {
-            this.logger.warn("preFetchFeeRate(): Error: ", e);
-            abortController.abort(e);
-            return undefined;
+    preFetchFeeRate(signer, amountData, claimHash, abortController, contractVersions) {
+        return (0, Utils_1.mapArrayToObject)(contractVersions, (contractVersion) => {
+            return this._contract(contractVersion).getInitPayInFeeRate(signer, this._chain.randomAddress(), amountData.token, claimHash?.[contractVersion])
+                .catch(e => {
+                this.logger.warn("preFetchFeeRate(): Error: ", e);
+                abortController.abort(e);
+                return undefined;
+            });
         });
     }
     /**

--- a/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNSwap.js
+++ b/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNSwap.js
@@ -78,7 +78,7 @@ class ToBTCLNSwap extends IToBTCSwap_1.IToBTCSwap {
         const secretBuffer = buffer_1.Buffer.from(result.secret, "hex");
         const hash = buffer_1.Buffer.from((0, sha2_1.sha256)(secretBuffer));
         if (check) {
-            const claimHash = this.wrapper._contract.getHashForHtlc(hash);
+            const claimHash = this._contract.getHashForHtlc(hash);
             const expectedClaimHash = buffer_1.Buffer.from(this.getClaimHash(), "hex");
             if (!claimHash.equals(expectedClaimHash))
                 throw new IntermediaryError_1.IntermediaryError("Invalid payment secret returned");

--- a/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.d.ts
@@ -82,7 +82,12 @@ export declare class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T
      * @internal
      */
     readonly _swapDeserializer: typeof ToBTCLNSwap;
-    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], contract: T["Contract"], prices: ISwapPrice, tokens: WrapperCtorTokens, swapDataDeserializer: new (data: any) => T["Data"], options?: AllOptional<ToBTCLNWrapperOptions>, events?: EventEmitter<{
+    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], prices: ISwapPrice, tokens: WrapperCtorTokens, versionedContracts: {
+        [version: string]: {
+            swapContract: T["Contract"];
+            swapDataConstructor: new (data: any) => T["Data"];
+        };
+    }, options?: AllOptional<ToBTCLNWrapperOptions>, events?: EventEmitter<{
         swapState: [ISwap];
     }>);
     private toRequiredSwapOptions;
@@ -157,10 +162,14 @@ export declare class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T
     create(signer: string, recipient: string, amountData: Omit<AmountData, "amount"> & {
         exactIn: false;
     }, lps: Intermediary[], options?: ToBTCLNOptions, additionalParams?: Record<string, any>, abortSignal?: AbortSignal, preFetches?: {
-        feeRatePromise: Promise<string | undefined>;
+        feeRatePromise: {
+            [contractVersion: string]: Promise<string | undefined>;
+        };
         pricePreFetchPromise: Promise<bigint | undefined>;
         usdPricePrefetchPromise: Promise<number | undefined>;
-        signDataPrefetchPromise?: Promise<T["PreFetchVerification"] | undefined>;
+        signDataPrefetchPromise?: {
+            [contractVersion: string]: Promise<T["PreFetchVerification"] | undefined> | undefined;
+        };
     }): Promise<{
         quote: Promise<ToBTCLNSwap<T>>;
         intermediary: Intermediary;
@@ -238,5 +247,5 @@ export declare class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T
             blockTime: number;
             blockHeight: number;
         }>;
-    }, state: SwapCommitState, lp?: Intermediary): Promise<ToBTCLNSwap<T> | null>;
+    }, state: SwapCommitState, contractVersion: string, lp?: Intermediary): Promise<ToBTCLNSwap<T> | null>;
 }

--- a/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.js
+++ b/dist/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.js
@@ -6,6 +6,7 @@ const ToBTCLNSwap_1 = require("./ToBTCLNSwap");
 const IToBTCWrapper_1 = require("../IToBTCWrapper");
 const UserError_1 = require("../../../../errors/UserError");
 const base_1 = require("@atomiqlabs/base");
+const Intermediary_1 = require("../../../../intermediaries/Intermediary");
 const IntermediaryError_1 = require("../../../../errors/IntermediaryError");
 const SwapType_1 = require("../../../../enums/SwapType");
 const Utils_1 = require("../../../../utils/Utils");
@@ -21,13 +22,13 @@ const RetryUtils_1 = require("../../../../utils/RetryUtils");
  * @category Swaps/Smart chain → Lightning
  */
 class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
-    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, options, events) {
-        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, {
+    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, versionedContracts, options, events) {
+        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, {
             ...options,
             paymentTimeoutSeconds: options?.paymentTimeoutSeconds ?? 5 * 24 * 60 * 60,
             lightningBaseFee: options?.lightningBaseFee ?? 10,
             lightningFeePPM: options?.lightningFeePPM ?? 2000
-        }, events);
+        }, versionedContracts, events);
         this.TYPE = SwapType_1.SwapType.TO_BTCLN;
         /**
          * @internal
@@ -116,7 +117,7 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
             throw new IntermediaryError_1.IntermediaryError("Invalid data returned - total amount");
         if (parsedPr.tagsObject.payment_hash == null)
             throw new Error("Swap invoice doesn't contain payment hash field!");
-        const claimHash = this._contract.getHashForHtlc(Buffer.from(parsedPr.tagsObject.payment_hash, "hex"));
+        const claimHash = this._contract(lp.getContractVersion(this.chainIdentifier)).getHashForHtlc(Buffer.from(parsedPr.tagsObject.payment_hash, "hex"));
         if (data.getAmount() !== resp.total ||
             !Buffer.from(data.getClaimHash(), "hex").equals(claimHash) ||
             data.getExpiry() !== calculatedOptions.expiryTimestamp ||
@@ -148,8 +149,9 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
     async getIntermediaryQuote(signer, amountData, lp, pr, parsedPr, calculatedOptions, preFetches, abort, additionalParams) {
         if (lp.services[SwapType_1.SwapType.TO_BTCLN] == null)
             throw new Error("LP service for processing to btcln swaps not found!");
+        const version = lp.getContractVersion(this.chainIdentifier);
         const abortController = abort instanceof AbortController ? abort : (0, Utils_1.extendAbortController)(abort);
-        const reputationPromise = this.preFetchIntermediaryReputation(amountData, lp, abortController);
+        const reputationPromise = this.preFetchIntermediaryReputation(amountData, lp, abortController, version);
         try {
             const { signDataPromise, resp } = await (0, RetryUtils_1.tryWithRetries)(async (retryCount) => {
                 const { signDataPrefetch, response } = IntermediaryAPI_1.IntermediaryAPI.initToBTCLN(this.chainIdentifier, lp.url, {
@@ -158,12 +160,12 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                     maxFee: await calculatedOptions.maxFee,
                     expiryTimestamp: calculatedOptions.expiryTimestamp,
                     token: amountData.token,
-                    feeRate: (0, Utils_1.throwIfUndefined)(preFetches.feeRatePromise),
+                    feeRate: (0, Utils_1.throwIfUndefined)(preFetches.feeRatePromise[version]),
                     additionalParams
                 }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
-                let signDataPromise = preFetches.signDataPrefetchPromise;
+                let signDataPromise = preFetches.signDataPrefetchPromise?.[version];
                 if (signDataPromise == null) {
-                    signDataPromise = this.preFetchSignData(signDataPrefetch);
+                    signDataPromise = this.preFetchSignData(signDataPrefetch, version);
                 }
                 else
                     signDataPrefetch.catch(() => { });
@@ -176,13 +178,13 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                 throw new Error("Swap invoice doesn't have msat amount field!");
             const amountOut = (BigInt(parsedPr.millisatoshis) + 999n) / 1000n;
             const totalFee = resp.swapFee + resp.maxFee;
-            const data = new this._swapDataDeserializer(resp.data);
+            const data = new (this._swapDataDeserializer(version))(resp.data);
             data.setOfferer(signer);
             await this.verifyReturnedData(signer, resp, parsedPr, amountData.token, lp, calculatedOptions, data);
             const swapFeeBtc = resp.swapFee * amountOut / (data.getAmount() - totalFee);
             const [pricingInfo, signatureExpiry, reputation] = await Promise.all([
                 this.verifyReturnedPrice(lp.services[SwapType_1.SwapType.TO_BTCLN], true, amountOut, data.getAmount(), amountData.token, { networkFee: resp.maxFee, swapFeeBtc }, preFetches.pricePreFetchPromise, preFetches.usdPricePrefetchPromise, abortController.signal),
-                this.verifyReturnedSignature(signer, data, resp, preFetches.feeRatePromise, signDataPromise, abortController.signal),
+                this.verifyReturnedSignature(signer, data, resp, preFetches.feeRatePromise[version], signDataPromise, version, abortController.signal),
                 reputationPromise
             ]);
             abortController.signal.throwIfAborted();
@@ -194,14 +196,15 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                 expiry: signatureExpiry,
                 swapFee: resp.swapFee,
                 swapFeeBtc,
-                feeRate: (await preFetches.feeRatePromise),
+                feeRate: (await preFetches.feeRatePromise[version]),
                 signatureData: resp,
                 data,
                 networkFee: resp.maxFee,
                 networkFeeBtc: resp.routingFeeSats,
                 confidence: resp.confidence,
                 pr,
-                exactIn: false
+                exactIn: false,
+                contractVersion: version
             });
             return quote;
         }
@@ -228,17 +231,24 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
         if (parsedPr.millisatoshis == null)
             throw new UserError_1.UserError("Must be an invoice with amount");
         const amountOut = (BigInt(parsedPr.millisatoshis) + 999n) / 1000n;
+        const lpVersions = Intermediary_1.Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
         const _options = this.toRequiredSwapOptions({ ...amountData, amount: amountOut }, options);
         if (parsedPr.tagsObject.payment_hash == null)
             throw new Error("Provided lightning invoice doesn't contain payment hash field!");
         await this.checkPaymentHashWasPaid(parsedPr.tagsObject.payment_hash);
-        const claimHash = this._contract.getHashForHtlc(Buffer.from(parsedPr.tagsObject.payment_hash, "hex"));
+        const _hash = (0, Utils_1.mapArrayToObject)(lpVersions, (contractVersion) => {
+            return this._contract(contractVersion).getHashForHtlc(Buffer.from(parsedPr.tagsObject.payment_hash, "hex")).toString("hex");
+        });
         const _abortController = (0, Utils_1.extendAbortController)(abortSignal);
         const _preFetches = preFetches ?? {
             pricePreFetchPromise: this.preFetchPrice(amountData, _abortController.signal),
-            feeRatePromise: this.preFetchFeeRate(signer, amountData, claimHash.toString("hex"), _abortController),
+            feeRatePromise: this.preFetchFeeRate(signer, amountData, _hash, _abortController, lpVersions),
             usdPricePrefetchPromise: this.preFetchUsdPrice(_abortController.signal),
-            signDataPrefetchPromise: this._contract.preFetchBlockDataForSignatures == null ? this.preFetchSignData(Promise.resolve(true)) : undefined
+            signDataPrefetchPromise: (0, Utils_1.mapArrayToObject)(lpVersions, (contractVersion) => {
+                return this._contract(contractVersion).preFetchBlockDataForSignatures == null ?
+                    this.preFetchSignData(Promise.resolve(true), contractVersion) :
+                    undefined;
+            })
         };
         return lps.map(lp => {
             return {
@@ -285,8 +295,9 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
     async getIntermediaryQuoteExactIn(signer, amountData, invoiceCreateService, lp, dummyPr, calculatedOptions, preFetches, abortSignal, additionalParams) {
         if (lp.services[SwapType_1.SwapType.TO_BTCLN] == null)
             throw new Error("LP service for processing to btcln swaps not found!");
+        const version = lp.getContractVersion(this.chainIdentifier);
         const abortController = (0, Utils_1.extendAbortController)(abortSignal);
-        const reputationPromise = this.preFetchIntermediaryReputation(amountData, lp, abortController);
+        const reputationPromise = this.preFetchIntermediaryReputation(amountData, lp, abortController, version);
         try {
             const { signDataPromise, prepareResp } = await (0, RetryUtils_1.tryWithRetries)(async (retryCount) => {
                 const { signDataPrefetch, response } = IntermediaryAPI_1.IntermediaryAPI.prepareToBTCLNExactIn(this.chainIdentifier, lp.url, {
@@ -299,7 +310,7 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                     additionalParams
                 }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
                 return {
-                    signDataPromise: this.preFetchSignData(signDataPrefetch),
+                    signDataPromise: this.preFetchSignData(signDataPrefetch, version),
                     prepareResp: await response
                 };
             }, undefined, e => e instanceof RequestError_1.RequestError, abortController.signal);
@@ -318,20 +329,20 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
             const resp = await (0, RetryUtils_1.tryWithRetries)((retryCount) => IntermediaryAPI_1.IntermediaryAPI.initToBTCLNExactIn(lp.url, {
                 pr: invoice,
                 reqId: prepareResp.reqId,
-                feeRate: (0, Utils_1.throwIfUndefined)(preFetches.feeRatePromise),
+                feeRate: (0, Utils_1.throwIfUndefined)(preFetches.feeRatePromise[version]),
                 additionalParams
             }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined), undefined, RequestError_1.RequestError, abortController.signal);
             if (parsedInvoice.millisatoshis == null)
                 throw new Error("Swap invoice doesn't have msat amount field!");
             const amountOut = (BigInt(parsedInvoice.millisatoshis) + 999n) / 1000n;
             const totalFee = resp.swapFee + resp.maxFee;
-            const data = new this._swapDataDeserializer(resp.data);
+            const data = new (this._swapDataDeserializer(version))(resp.data);
             data.setOfferer(signer);
             await this.verifyReturnedData(signer, resp, parsedInvoice, amountData.token, lp, calculatedOptions, data, amountData.amount);
             const swapFeeBtc = resp.swapFee * amountOut / (data.getAmount() - totalFee);
             const [pricingInfo, signatureExpiry, reputation] = await Promise.all([
                 this.verifyReturnedPrice(lp.services[SwapType_1.SwapType.TO_BTCLN], true, prepareResp.amount, data.getAmount(), amountData.token, { networkFee: resp.maxFee, swapFeeBtc }, preFetches.pricePreFetchPromise, preFetches.usdPricePrefetchPromise, abortSignal),
-                this.verifyReturnedSignature(signer, data, resp, preFetches.feeRatePromise, signDataPromise, abortController.signal),
+                this.verifyReturnedSignature(signer, data, resp, preFetches.feeRatePromise[version], signDataPromise, version, abortController.signal),
                 reputationPromise
             ]);
             abortController.signal.throwIfAborted();
@@ -343,14 +354,15 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                 expiry: signatureExpiry,
                 swapFee: resp.swapFee,
                 swapFeeBtc,
-                feeRate: (await preFetches.feeRatePromise),
+                feeRate: (await preFetches.feeRatePromise[version]),
                 signatureData: resp,
                 data,
                 networkFee: resp.maxFee,
                 networkFeeBtc: resp.routingFeeSats,
                 confidence: resp.confidence,
                 pr: invoice,
-                exactIn: true
+                exactIn: true,
+                contractVersion: version
             });
             return quote;
         }
@@ -375,13 +387,16 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
     async createViaInvoiceCreateService(signer, invoiceCreateServicePromise, amountData, lps, options, additionalParams, abortSignal) {
         if (!this.isInitialized)
             throw new Error("Not initialized, call init() first!");
+        const lpVersions = Intermediary_1.Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
         const _abortController = (0, Utils_1.extendAbortController)(abortSignal);
         const pricePreFetchPromise = this.preFetchPrice(amountData, _abortController.signal);
         const usdPricePrefetchPromise = this.preFetchUsdPrice(_abortController.signal);
-        const feeRatePromise = this.preFetchFeeRate(signer, amountData, undefined, _abortController);
-        const signDataPrefetchPromise = this._contract.preFetchBlockDataForSignatures == null ?
-            this.preFetchSignData(Promise.resolve(true)) :
-            undefined;
+        const feeRatePromise = this.preFetchFeeRate(signer, amountData, undefined, _abortController, lpVersions);
+        const signDataPrefetchPromise = (0, Utils_1.mapArrayToObject)(lpVersions, (contractVersion) => {
+            return this._contract(contractVersion).preFetchBlockDataForSignatures == null ?
+                this.preFetchSignData(Promise.resolve(true), contractVersion) :
+                undefined;
+        });
         const _options = this.toRequiredSwapOptions(amountData, options, pricePreFetchPromise, _abortController.signal);
         try {
             const invoiceCreateService = await invoiceCreateServicePromise;
@@ -476,7 +491,7 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
     /**
      * @inheritDoc
      */
-    async recoverFromSwapDataAndState(init, state, lp) {
+    async recoverFromSwapDataAndState(init, state, contractVersion, lp) {
         const data = init.data;
         let paymentHash = data.getHTLCHashHint();
         let secret;
@@ -504,7 +519,8 @@ class ToBTCLNWrapper extends IToBTCWrapper_1.IToBTCWrapper {
             networkFeeBtc: 0n,
             confidence: 0,
             pr: paymentHash ?? undefined,
-            exactIn: false
+            exactIn: false,
+            contractVersion
         };
         const swap = new ToBTCLNSwap_1.ToBTCLNSwap(this, swapInit);
         swap._commitTxId = await init.getInitTxId();

--- a/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCSwap.js
+++ b/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCSwap.js
@@ -73,11 +73,11 @@ class ToBTCSwap extends IToBTCSwap_1.IToBTCSwap {
             let requiredConfirmations = this.requiredConfirmations;
             const foundVout = btcTx.outs.find(vout => {
                 if (requiredConfirmations != null) {
-                    return this._data.getClaimHash() === this.wrapper._contract.getHashForOnchain(buffer_1.Buffer.from(vout.scriptPubKey.hex, "hex"), BigInt(vout.value), requiredConfirmations, nonce).toString("hex");
+                    return this._data.getClaimHash() === this._contract.getHashForOnchain(buffer_1.Buffer.from(vout.scriptPubKey.hex, "hex"), BigInt(vout.value), requiredConfirmations, nonce).toString("hex");
                 }
                 else {
                     for (let i = 1; i <= 20; i++) {
-                        if (this._data.getClaimHash() === this.wrapper._contract.getHashForOnchain(buffer_1.Buffer.from(vout.scriptPubKey.hex, "hex"), BigInt(vout.value), i, nonce).toString("hex")) {
+                        if (this._data.getClaimHash() === this._contract.getHashForOnchain(buffer_1.Buffer.from(vout.scriptPubKey.hex, "hex"), BigInt(vout.value), i, nonce).toString("hex")) {
                             requiredConfirmations = i;
                             return true;
                         }

--- a/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.d.ts
+++ b/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.d.ts
@@ -52,15 +52,19 @@ export declare class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, 
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents Smart chain on-chain event listener
      * @param chain
-     * @param contract Chain specific swap contract
+     * @param versionedContracts Chain specific versioned contracts
      * @param prices Swap pricing handler
      * @param tokens
-     * @param swapDataDeserializer Deserializer for chain specific SwapData
      * @param btcRpc Bitcoin RPC api
      * @param options
      * @param events Instance to use for emitting events
      */
-    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], contract: T["Contract"], prices: ISwapPrice, tokens: WrapperCtorTokens, swapDataDeserializer: new (data: any) => T["Data"], btcRpc: BitcoinRpc<any>, options?: AllOptional<ToBTCWrapperOptions>, events?: EventEmitter<{
+    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], prices: ISwapPrice, tokens: WrapperCtorTokens, versionedContracts: {
+        [version: string]: {
+            swapContract: T["Contract"];
+            swapDataConstructor: new (data: any) => T["Data"];
+        };
+    }, btcRpc: BitcoinRpc<any>, options?: AllOptional<ToBTCWrapperOptions>, events?: EventEmitter<{
         swapState: [ISwap];
     }>);
     /**
@@ -124,5 +128,5 @@ export declare class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, 
             blockTime: number;
             blockHeight: number;
         }>;
-    }, state: SwapCommitState, lp?: Intermediary): Promise<ToBTCSwap<T> | null>;
+    }, state: SwapCommitState, contractVersion: string, lp?: Intermediary): Promise<ToBTCSwap<T> | null>;
 }

--- a/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.js
+++ b/dist/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.js
@@ -4,6 +4,7 @@ exports.ToBTCWrapper = void 0;
 const ToBTCSwap_1 = require("./ToBTCSwap");
 const IToBTCWrapper_1 = require("../IToBTCWrapper");
 const base_1 = require("@atomiqlabs/base");
+const Intermediary_1 = require("../../../../intermediaries/Intermediary");
 const UserError_1 = require("../../../../errors/UserError");
 const IntermediaryError_1 = require("../../../../errors/IntermediaryError");
 const SwapType_1 = require("../../../../enums/SwapType");
@@ -25,16 +26,15 @@ class ToBTCWrapper extends IToBTCWrapper_1.IToBTCWrapper {
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents Smart chain on-chain event listener
      * @param chain
-     * @param contract Chain specific swap contract
+     * @param versionedContracts Chain specific versioned contracts
      * @param prices Swap pricing handler
      * @param tokens
-     * @param swapDataDeserializer Deserializer for chain specific SwapData
      * @param btcRpc Bitcoin RPC api
      * @param options
      * @param events Instance to use for emitting events
      */
-    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, btcRpc, options, events) {
-        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, {
+    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, versionedContracts, btcRpc, options, events) {
+        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, {
             ...options,
             bitcoinNetwork: options?.bitcoinNetwork ?? utils_1.TEST_NETWORK,
             safetyFactor: options?.safetyFactor ?? 2,
@@ -42,7 +42,7 @@ class ToBTCWrapper extends IToBTCWrapper_1.IToBTCWrapper {
             bitcoinBlocktime: options?.bitcoinBlocktime ?? (60 * 10),
             maxExpectedOnchainSendSafetyFactor: options?.maxExpectedOnchainSendSafetyFactor ?? 4,
             maxExpectedOnchainSendGracePeriodBlocks: options?.maxExpectedOnchainSendGracePeriodBlocks ?? 12,
-        }, events);
+        }, versionedContracts, events);
         this.TYPE = SwapType_1.SwapType.TO_BTC;
         /**
          * @internal
@@ -146,26 +146,32 @@ class ToBTCWrapper extends IToBTCWrapper_1.IToBTCWrapper {
             confirmationTarget: options?.confirmationTarget ?? 3,
             confirmations: options?.confirmations ?? 2
         };
+        const lpVersions = Intermediary_1.Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
         const nonce = this.getRandomNonce();
         const outputScript = this.btcAddressToOutputScript(recipient);
         const _hash = !amountData.exactIn ?
-            this._contract.getHashForOnchain(outputScript, amountData.amount, _options.confirmations, nonce).toString("hex") :
+            (0, Utils_1.mapArrayToObject)(lpVersions, (contractVersion) => {
+                return this._contract(contractVersion).getHashForOnchain(outputScript, amountData.amount, _options.confirmations, nonce).toString("hex");
+            }) :
             undefined;
         const _abortController = (0, Utils_1.extendAbortController)(abortSignal);
         const pricePreFetchPromise = this.preFetchPrice(amountData, _abortController.signal);
         const usdPricePrefetchPromise = this.preFetchUsdPrice(_abortController.signal);
-        const feeRatePromise = this.preFetchFeeRate(signer, amountData, _hash, _abortController);
-        const _signDataPromise = this._contract.preFetchBlockDataForSignatures == null ?
-            this.preFetchSignData(Promise.resolve(true)) :
-            undefined;
+        const feeRatePromise = this.preFetchFeeRate(signer, amountData, _hash, _abortController, lpVersions);
+        const _signDataPromise = (0, Utils_1.mapArrayToObject)(lpVersions, (contractVersion) => {
+            return this._contract(contractVersion).preFetchBlockDataForSignatures == null ?
+                this.preFetchSignData(Promise.resolve(true), contractVersion) :
+                undefined;
+        });
         return lps.map(lp => {
             return {
                 intermediary: lp,
                 quote: (async () => {
                     if (lp.services[SwapType_1.SwapType.TO_BTC] == null)
                         throw new Error("LP service for processing to btc swaps not found!");
+                    const version = lp.getContractVersion(this.chainIdentifier);
                     const abortController = (0, Utils_1.extendAbortController)(_abortController.signal);
-                    const reputationPromise = this.preFetchIntermediaryReputation(amountData, lp, abortController);
+                    const reputationPromise = this.preFetchIntermediaryReputation(amountData, lp, abortController, version);
                     try {
                         const { signDataPromise, resp } = await (0, RetryUtils_1.tryWithRetries)(async (retryCount) => {
                             const { signDataPrefetch, response } = IntermediaryAPI_1.IntermediaryAPI.initToBTC(this.chainIdentifier, lp.url, {
@@ -177,12 +183,12 @@ class ToBTCWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                                 token: amountData.token,
                                 offerer: signer,
                                 exactIn: amountData.exactIn,
-                                feeRate: (0, Utils_1.throwIfUndefined)(feeRatePromise),
+                                feeRate: (0, Utils_1.throwIfUndefined)(feeRatePromise[version]),
                                 additionalParams
                             }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
-                            let signDataPromise = _signDataPromise;
+                            let signDataPromise = _signDataPromise[version];
                             if (signDataPromise == null) {
-                                signDataPromise = this.preFetchSignData(signDataPrefetch);
+                                signDataPromise = this.preFetchSignData(signDataPrefetch, version);
                             }
                             else
                                 signDataPrefetch.catch(() => { });
@@ -191,8 +197,8 @@ class ToBTCWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                                 resp: await response
                             };
                         }, undefined, RequestError_1.RequestError, abortController.signal);
-                        let hash = _hash ?? this._contract.getHashForOnchain(outputScript, resp.amount, _options.confirmations, nonce).toString("hex");
-                        const data = new this._swapDataDeserializer(resp.data);
+                        let hash = _hash?.[version] ?? this._contract(version).getHashForOnchain(outputScript, resp.amount, _options.confirmations, nonce).toString("hex");
+                        const data = new (this._swapDataDeserializer(version))(resp.data);
                         data.setOfferer(signer);
                         const inputWithoutFees = data.getAmount() - resp.swapFee - resp.networkFee;
                         const swapFeeBtc = resp.swapFee * resp.amount / inputWithoutFees;
@@ -200,7 +206,7 @@ class ToBTCWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                         this.verifyReturnedData(signer, resp, amountData, lp, _options, data, hash);
                         const [pricingInfo, signatureExpiry, reputation] = await Promise.all([
                             this.verifyReturnedPrice(lp.services[SwapType_1.SwapType.TO_BTC], true, resp.amount, data.getAmount(), amountData.token, { networkFee: resp.networkFee, swapFeeBtc }, pricePreFetchPromise, usdPricePrefetchPromise, abortController.signal),
-                            this.verifyReturnedSignature(signer, data, resp, feeRatePromise, signDataPromise, abortController.signal),
+                            this.verifyReturnedSignature(signer, data, resp, feeRatePromise[version], signDataPromise, version, abortController.signal),
                             reputationPromise
                         ]);
                         abortController.signal.throwIfAborted();
@@ -212,7 +218,7 @@ class ToBTCWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                             expiry: signatureExpiry,
                             swapFee: resp.swapFee,
                             swapFeeBtc,
-                            feeRate: (await feeRatePromise),
+                            feeRate: (await feeRatePromise[version]),
                             signatureData: resp,
                             data,
                             networkFee: resp.networkFee,
@@ -223,7 +229,8 @@ class ToBTCWrapper extends IToBTCWrapper_1.IToBTCWrapper {
                             satsPerVByte: Number(resp.satsPervByte),
                             exactIn: amountData.exactIn,
                             requiredConfirmations: _options.confirmations,
-                            nonce
+                            nonce,
+                            contractVersion: version
                         });
                         return quote;
                     }
@@ -238,7 +245,7 @@ class ToBTCWrapper extends IToBTCWrapper_1.IToBTCWrapper {
     /**
      * @inheritDoc
      */
-    async recoverFromSwapDataAndState(init, state, lp) {
+    async recoverFromSwapDataAndState(init, state, contractVersion, lp) {
         const data = init.data;
         const swapInit = {
             pricingInfo: {
@@ -262,7 +269,8 @@ class ToBTCWrapper extends IToBTCWrapper_1.IToBTCWrapper {
             data,
             networkFee: 0n,
             networkFeeBtc: 0n,
-            exactIn: true
+            exactIn: true,
+            contractVersion
         };
         const swap = new ToBTCSwap_1.ToBTCSwap(this, swapInit);
         swap._commitTxId = await init.getInitTxId();

--- a/dist/swaps/spv_swaps/SpvFromBTCSwap.d.ts
+++ b/dist/swaps/spv_swaps/SpvFromBTCSwap.d.ts
@@ -200,6 +200,7 @@ export declare class SpvFromBTCSwap<T extends ChainType> extends ISwap<T, SpvFro
      * @private
      */
     private btcTxConfirmedAt?;
+    private _contract;
     constructor(wrapper: SpvFromBTCWrapper<T>, init: SpvFromBTCSwapInit);
     constructor(wrapper: SpvFromBTCWrapper<T>, obj: any);
     /**

--- a/dist/swaps/spv_swaps/SpvFromBTCSwap.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCSwap.js
@@ -216,10 +216,11 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
             this.btcTxConfirmedAt = initOrObject.btcTxConfirmedAt;
             this.posted = initOrObject.posted;
             if (initOrObject.data != null)
-                this._data = new this.wrapper._spvWithdrawalDataDeserializer(initOrObject.data);
+                this._data = new (this.wrapper._spvWithdrawalDataDeserializer(this._contractVersion))(initOrObject.data);
         }
         this.tryCalculateSwapFee();
         this.logger = (0, Logger_1.getLogger)("SPVFromBTC(" + this.getId() + "): ");
+        this._contract = wrapper._contract(this._contractVersion);
     }
     /**
      * @inheritDoc
@@ -555,7 +556,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
         const [txId, voutStr] = this.vaultUtxo.split(":");
         const vaultScript = (0, BitcoinUtils_1.toOutputScript)(this.wrapper._options.bitcoinNetwork, this.vaultBtcAddress);
         const out2script = (0, BitcoinUtils_1.toOutputScript)(this.wrapper._options.bitcoinNetwork, this.btcDestinationAddress);
-        const opReturnData = this.wrapper._contract.toOpReturnData(this.recipient, [
+        const opReturnData = this._contract.toOpReturnData(this.recipient, [
             this.outputTotalSwap / this.vaultTokenMultipliers[0],
             this.outputTotalGas / this.vaultTokenMultipliers[1]
         ]);
@@ -691,7 +692,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
             psbt.finalizeIdx(i);
         }
         const btcTx = await this.wrapper._btcRpc.parseTransaction(buffer_1.Buffer.from(psbt.toBytes(true)).toString("hex"));
-        const data = await this.wrapper._contract.getWithdrawalData(btcTx);
+        const data = await this._contract.getWithdrawalData(btcTx);
         this.logger.debug("submitPsbt(): parsed withdrawal data: ", data);
         //Verify correct withdrawal data
         if (!data.isRecipient(this.recipient) ||
@@ -719,7 +720,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
         }
         //Verify tx is parsable by the contract
         try {
-            await this.wrapper._contract.checkWithdrawalTx(data);
+            await this._contract.checkWithdrawalTx(data);
         }
         catch (e) {
             throw new Error("Transaction not parsable by the contract: " + (e.message ?? e.toString()));
@@ -972,7 +973,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
             throw new Error("Must be in BTC_TX_CONFIRMED state!");
         if (this._data == null)
             throw new Error("Expected swap to have withdrawal data filled!");
-        const vaultData = await this.wrapper._contract.getVaultData(this.vaultOwner, this.vaultId);
+        const vaultData = await this._contract.getVaultData(this.vaultOwner, this.vaultId);
         if (vaultData == null)
             throw new Error(`Vault data for ${this.vaultOwner}:${this.vaultId.toString(10)} not found (already closed???)!`);
         const btcTx = await this.wrapper._btcRpc.getTransaction(this._data.btcTx.txid);
@@ -990,9 +991,9 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
         //Parse transactions to withdrawal data
         const withdrawalData = [];
         for (let tx of txs) {
-            withdrawalData.push(await this.wrapper._contract.getWithdrawalData(tx));
+            withdrawalData.push(await this._contract.getWithdrawalData(tx));
         }
-        return await this.wrapper._contract.txsClaim(address ?? this._getInitiator(), vaultData, withdrawalData.map(tx => { return { tx }; }), this.wrapper._synchronizer, true);
+        return await this._contract.txsClaim(address ?? this._getInitiator(), vaultData, withdrawalData.map(tx => { return { tx }; }), this.wrapper._synchronizer(this._contractVersion), true);
     }
     /**
      * Settles the swap by claiming the funds on the destination chain if the swap requires manual settlement, you can
@@ -1028,7 +1029,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
                 this.logger.info("claim(): Transaction state is CLAIMED, swap was successfully claimed by the watchtower");
                 return this._claimTxId;
             }
-            const withdrawalState = await this.wrapper._contract.getWithdrawalState(this._data, this._genesisSmartChainBlockHeight);
+            const withdrawalState = await this._contract.getWithdrawalState(this._data, this._genesisSmartChainBlockHeight);
             if (withdrawalState != null && withdrawalState.type === base_1.SpvWithdrawalStateType.CLAIMED) {
                 this.logger.info("claim(): Transaction status is CLAIMED, swap was successfully claimed by the watchtower");
                 this._claimTxId = withdrawalState.txId;
@@ -1061,7 +1062,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
             try {
                 //Be smart about checking withdrawal state
                 if (await this._shouldCheckWithdrawalState()) {
-                    status = await this.wrapper._contract.getWithdrawalState(this._data, this._genesisSmartChainBlockHeight) ?? { type: base_1.SpvWithdrawalStateType.NOT_FOUND };
+                    status = await this._contract.getWithdrawalState(this._data, this._genesisSmartChainBlockHeight) ?? { type: base_1.SpvWithdrawalStateType.NOT_FOUND };
                 }
             }
             catch (e) {
@@ -1313,7 +1314,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
         }
         if (this._state === SpvFromBTCSwapState.BROADCASTED || this._state === SpvFromBTCSwapState.BTC_TX_CONFIRMED) {
             if (await this._shouldCheckWithdrawalState()) {
-                const status = await this.wrapper._contract.getWithdrawalState(this._data, this._genesisSmartChainBlockHeight);
+                const status = await this._contract.getWithdrawalState(this._data, this._genesisSmartChainBlockHeight);
                 this.logger.debug("syncStateFromChain(): status of " + this._data.btcTx.txid, status);
                 switch (status?.type) {
                     case base_1.SpvWithdrawalStateType.FRONTED:
@@ -1401,9 +1402,9 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
      */
     async _shouldCheckWithdrawalState(frontingAddress, vaultDataUtxo) {
         if (frontingAddress === undefined)
-            frontingAddress = await this.wrapper._contract.getFronterAddress(this.vaultOwner, this.vaultId, this._data);
+            frontingAddress = await this._contract.getFronterAddress(this.vaultOwner, this.vaultId, this._data);
         if (vaultDataUtxo === undefined)
-            vaultDataUtxo = await this.wrapper._contract.getVaultLatestUtxo(this.vaultOwner, this.vaultId);
+            vaultDataUtxo = await this._contract.getVaultLatestUtxo(this.vaultOwner, this.vaultId);
         if (frontingAddress != null)
             return true; //In case the swap is fronted there will for sure be a fronted event
         if (vaultDataUtxo == null)

--- a/dist/swaps/spv_swaps/SpvFromBTCWrapper.d.ts
+++ b/dist/swaps/spv_swaps/SpvFromBTCWrapper.d.ts
@@ -88,7 +88,7 @@ export declare class SpvFromBTCWrapper<T extends ChainType> extends ISwapWrapper
     /**
      * @internal
      */
-    protected readonly btcRelay: T["BtcRelay"];
+    protected readonly btcRelay: (version?: string) => BtcRelay<any, T["TX"], any>;
     /**
      * @internal
      */
@@ -96,11 +96,11 @@ export declare class SpvFromBTCWrapper<T extends ChainType> extends ISwapWrapper
     /**
      * @internal
      */
-    readonly _synchronizer: RelaySynchronizer<any, T["TX"], any>;
+    readonly _synchronizer: (version?: string) => RelaySynchronizer<any, T["TX"], any>;
     /**
      * @internal
      */
-    readonly _contract: T["SpvVaultContract"];
+    readonly _contract: (version?: string) => T["SpvVaultContract"];
     /**
      * @internal
      */
@@ -108,27 +108,37 @@ export declare class SpvFromBTCWrapper<T extends ChainType> extends ISwapWrapper
     /**
      * @internal
      */
-    readonly _spvWithdrawalDataDeserializer: new (data: any) => T["SpvVaultWithdrawalData"];
+    readonly _spvWithdrawalDataDeserializer: (version?: string) => (new (data: any) => T["SpvVaultWithdrawalData"]);
     /**
      * @internal
      */
     readonly _pendingSwapStates: Array<SpvFromBTCSwap<T>["_state"]>;
+    private readonly versionedContracts;
+    private readonly versionedSynchronizer;
     /**
      * @param chainIdentifier
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Pricing to use
      * @param tokens
-     * @param spvWithdrawalDataDeserializer Deserializer for SpvVaultWithdrawalData
-     * @param btcRelay
-     * @param synchronizer Btc relay synchronizer
+     * @param versionedContracts
+     * @param versionedSynchronizer
      * @param btcRpc Bitcoin RPC which also supports getting transactions by txoHash
      * @param options
      * @param events Instance to use for emitting events
      */
-    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], contract: T["SpvVaultContract"], prices: ISwapPrice, tokens: WrapperCtorTokens, spvWithdrawalDataDeserializer: new (data: any) => T["SpvVaultWithdrawalData"], btcRelay: BtcRelay<any, T["TX"], any>, synchronizer: RelaySynchronizer<any, T["TX"], any>, btcRpc: BitcoinRpcWithAddressIndex<any>, options?: AllOptional<SpvFromBTCWrapperOptions>, events?: EventEmitter<{
+    constructor(chainIdentifier: string, unifiedStorage: UnifiedSwapStorage<T>, unifiedChainEvents: UnifiedSwapEventListener<T>, chain: T["ChainInterface"], prices: ISwapPrice, tokens: WrapperCtorTokens, versionedContracts: {
+        [version: string]: {
+            btcRelay: BtcRelay<any, T["TX"], any>;
+            spvVaultContract: T["SpvVaultContract"];
+            spvVaultWithdrawalDataConstructor: new (data: any) => T["SpvVaultWithdrawalData"];
+        };
+    }, versionedSynchronizer: {
+        [version: string]: {
+            synchronizer: RelaySynchronizer<any, T["TX"], any>;
+        };
+    }, btcRpc: BitcoinRpcWithAddressIndex<any>, options?: AllOptional<SpvFromBTCWrapperOptions>, events?: EventEmitter<{
         swapState: [ISwap];
     }>);
     private processEventFront;
@@ -155,6 +165,7 @@ export declare class SpvFromBTCWrapper<T extends ChainType> extends ISwapWrapper
      * @param pricePrefetch
      * @param nativeTokenPricePrefetch
      * @param abortController
+     * @param contractVersion
      * @private
      */
     private preFetchCallerFeeShare;
@@ -195,7 +206,7 @@ export declare class SpvFromBTCWrapper<T extends ChainType> extends ISwapWrapper
      * @param vault SPV vault processing the swap
      * @param lp Intermediary (LP) used as a counterparty for the swap
      */
-    recoverFromState(state: SpvWithdrawalClaimedState | SpvWithdrawalFrontedState, vault?: SpvVaultData | null, lp?: Intermediary): Promise<SpvFromBTCSwap<T> | null>;
+    recoverFromState(state: SpvWithdrawalClaimedState | SpvWithdrawalFrontedState, contractVersion: string, vault?: SpvVaultData | null, lp?: Intermediary): Promise<SpvFromBTCSwap<T> | null>;
     /**
      * Returns a random dummy PSBT that can be used for fee estimation, the last output (the LP output) is omitted
      *  to allow for coinselection algorithm to determine maximum sendable amount there

--- a/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
@@ -6,6 +6,7 @@ const base_1 = require("@atomiqlabs/base");
 const SpvFromBTCSwap_1 = require("./SpvFromBTCSwap");
 const utils_1 = require("@scure/btc-signer/utils");
 const SwapType_1 = require("../../enums/SwapType");
+const Intermediary_1 = require("../../intermediaries/Intermediary");
 const Utils_1 = require("../../utils/Utils");
 const BitcoinUtils_1 = require("../../utils/BitcoinUtils");
 const IntermediaryAPI_1 = require("../../intermediaries/apis/IntermediaryAPI");
@@ -27,17 +28,15 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Pricing to use
      * @param tokens
-     * @param spvWithdrawalDataDeserializer Deserializer for SpvVaultWithdrawalData
-     * @param btcRelay
-     * @param synchronizer Btc relay synchronizer
+     * @param versionedContracts
+     * @param versionedSynchronizer
      * @param btcRpc Bitcoin RPC which also supports getting transactions by txoHash
      * @param options
      * @param events Instance to use for emitting events
      */
-    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, spvWithdrawalDataDeserializer, btcRelay, synchronizer, btcRpc, options, events) {
+    constructor(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, versionedContracts, versionedSynchronizer, btcRpc, options, events) {
         super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, {
             ...options,
             bitcoinNetwork: options?.bitcoinNetwork ?? utils_1.TEST_NETWORK,
@@ -60,6 +59,16 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
         /**
          * @internal
          */
+        this.btcRelay = (version) => {
+            const _version = version ?? "v1";
+            const data = this.versionedContracts[_version];
+            if (data == null)
+                throw new Error(`Invalid contract version ${_version} requested`);
+            return data.btcRelay;
+        };
+        /**
+         * @internal
+         */
         this.tickSwapState = [
             SpvFromBTCSwap_1.SpvFromBTCSwapState.CREATED,
             SpvFromBTCSwap_1.SpvFromBTCSwapState.QUOTE_SOFT_EXPIRED,
@@ -67,6 +76,36 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             SpvFromBTCSwap_1.SpvFromBTCSwapState.POSTED,
             SpvFromBTCSwap_1.SpvFromBTCSwapState.BROADCASTED
         ];
+        /**
+         * @internal
+         */
+        this._synchronizer = (version) => {
+            const _version = version ?? "v1";
+            const data = this.versionedSynchronizer[_version];
+            if (data == null)
+                throw new Error(`Invalid contract version ${_version} requested`);
+            return data.synchronizer;
+        };
+        /**
+         * @internal
+         */
+        this._contract = (version) => {
+            const _version = version ?? "v1";
+            const data = this.versionedContracts[_version];
+            if (data == null)
+                throw new Error(`Invalid contract version ${_version} requested`);
+            return data.spvVaultContract;
+        };
+        /**
+         * @internal
+         */
+        this._spvWithdrawalDataDeserializer = (version) => {
+            const _version = version ?? "v1";
+            const data = this.versionedContracts[_version];
+            if (data == null)
+                throw new Error(`Invalid contract version ${_version} requested`);
+            return data.spvVaultWithdrawalDataConstructor;
+        };
         /**
          * @internal
          */
@@ -79,10 +118,10 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             SpvFromBTCSwap_1.SpvFromBTCSwapState.DECLINED,
             SpvFromBTCSwap_1.SpvFromBTCSwapState.BTC_TX_CONFIRMED
         ];
-        this._spvWithdrawalDataDeserializer = spvWithdrawalDataDeserializer;
-        this._contract = contract;
-        this.btcRelay = btcRelay;
-        this._synchronizer = synchronizer;
+        this.versionedContracts = {};
+        this.versionedSynchronizer = {};
+        this.versionedContracts = versionedContracts;
+        this.versionedSynchronizer = versionedSynchronizer;
         this._btcRpc = btcRpc;
     }
     async processEventFront(event, swap) {
@@ -173,19 +212,20 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
      * @param pricePrefetch
      * @param nativeTokenPricePrefetch
      * @param abortController
+     * @param contractVersion
      * @private
      */
-    async preFetchCallerFeeShare(amountData, options, pricePrefetch, nativeTokenPricePrefetch, abortController) {
+    async preFetchCallerFeeShare(amountData, options, pricePrefetch, nativeTokenPricePrefetch, abortController, contractVersion) {
         if (options.unsafeZeroWatchtowerFee)
             return 0n;
         if (amountData.amount === 0n)
             return 0n;
         try {
             const [feePerBlock, btcRelayData, currentBtcBlock, claimFeeRate, nativeTokenPrice] = await Promise.all([
-                this.btcRelay.getFeePerBlock(),
-                this.btcRelay.getTipData(),
+                this.btcRelay(contractVersion).getFeePerBlock(),
+                this.btcRelay(contractVersion).getTipData(),
                 this._btcRpc.getTipHeight(),
-                this._contract.getClaimFee(this._chain.randomAddress()),
+                this._contract(contractVersion).getClaimFee(this._chain.randomAddress()),
                 nativeTokenPricePrefetch ?? (amountData.token === this._chain.getNativeCurrencyAddress() ?
                     pricePrefetch :
                     this._prices.preFetchPrice(this.chainIdentifier, this._chain.getNativeCurrencyAddress(), abortController.signal))
@@ -243,6 +283,7 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
         abortSignal.throwIfAborted();
         if (btcFeeRate != null && resp.btcFeeRate > btcFeeRate)
             throw new IntermediaryError_1.IntermediaryError(`Required bitcoin fee rate returned from the LP is too high! Maximum accepted: ${btcFeeRate} sats/vB, required by LP: ${resp.btcFeeRate} sats/vB`);
+        const lpVersion = lp.getContractVersion(this.chainIdentifier);
         //Vault related
         let vaultScript;
         let vaultAddressType;
@@ -288,7 +329,7 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
                 //Fetch vault data
                 let vault;
                 try {
-                    vault = await this._contract.getVaultData(resp.address, resp.vaultId);
+                    vault = await this._contract(lpVersion).getVaultData(resp.address, resp.vaultId);
                 }
                 catch (e) {
                     this.logger.error("Error getting spv vault (owner: " + resp.address + " vaultId: " + resp.vaultId.toString(10) + "): ", e);
@@ -367,7 +408,7 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
                     throw new IntermediaryError_1.IntermediaryError("Invalid ancestor transaction (not found)");
                 btcTx = _btcTx;
             }
-            const withdrawalData = await this._contract.getWithdrawalData(btcTx);
+            const withdrawalData = await this._contract(lpVersion).getWithdrawalData(btcTx);
             abortSignal.throwIfAborted();
             pendingWithdrawals.unshift(withdrawalData);
             utxo = pendingWithdrawals[0].getSpentVaultUtxo();
@@ -393,7 +434,7 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
         //Also verify that all the withdrawal txns are valid, this is an extra sanity check
         try {
             for (let withdrawal of pendingWithdrawals) {
-                await this._contract.checkWithdrawalTx(withdrawal);
+                await this._contract(lpVersion).checkWithdrawalTx(withdrawal);
             }
         }
         catch (e) {
@@ -427,6 +468,7 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
         };
         if (amountData.token === this._chain.getNativeCurrencyAddress() && _options.gasAmount !== 0n)
             throw new UserError_1.UserError("Cannot specify `gasAmount` for swaps to a native token!");
+        const lpVersions = Intermediary_1.Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
         const _abortController = (0, Utils_1.extendAbortController)(abortSignal);
         const pricePrefetchPromise = this.preFetchPrice(amountData, _abortController.signal);
         const usdPricePrefetchPromise = this.preFetchUsdPrice(_abortController.signal);
@@ -435,7 +477,9 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
         const gasTokenPricePrefetchPromise = _options.gasAmount === 0n ?
             undefined :
             this.preFetchPrice({ token: nativeTokenAddress }, _abortController.signal);
-        const callerFeePrefetchPromise = this.preFetchCallerFeeShare(amountData, _options, pricePrefetchPromise, gasTokenPricePrefetchPromise, _abortController);
+        const callerFeePrefetchPromise = (0, Utils_1.mapArrayToObject)(lpVersions, (contractVersion) => {
+            return this.preFetchCallerFeeShare(amountData, _options, pricePrefetchPromise, gasTokenPricePrefetchPromise, _abortController, contractVersion);
+        });
         const bitcoinFeeRatePromise = _options.maxAllowedBitcoinFeeRate != Infinity ?
             Promise.resolve(_options.maxAllowedBitcoinFeeRate) :
             this._btcRpc.getFeeRate().then(x => this._options.maxBtcFeeOffset + (x * this._options.maxBtcFeeMultiplier)).catch(e => {
@@ -448,6 +492,7 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
                 quote: (0, RetryUtils_1.tryWithRetries)(async () => {
                     if (lp.services[SwapType_1.SwapType.SPV_VAULT_FROM_BTC] == null)
                         throw new Error("LP service for processing spv vault swaps not found!");
+                    const version = lp.getContractVersion(this.chainIdentifier);
                     const abortController = (0, Utils_1.extendAbortController)(_abortController.signal);
                     try {
                         const resp = await (0, RetryUtils_1.tryWithRetries)(async (retryCount) => {
@@ -458,14 +503,14 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
                                 exactOut: !amountData.exactIn,
                                 gasToken: nativeTokenAddress,
                                 gasAmount: _options.gasAmount,
-                                callerFeeRate: (0, Utils_1.throwIfUndefined)(callerFeePrefetchPromise, "Caller fee prefetch failed!"),
+                                callerFeeRate: (0, Utils_1.throwIfUndefined)(callerFeePrefetchPromise[version], "Caller fee prefetch failed!"),
                                 frontingFeeRate: 0n,
                                 stickyAddress: options?.stickyAddress,
                                 additionalParams
                             }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
                         }, undefined, e => e instanceof RequestError_1.RequestError, abortController.signal);
                         this.logger.debug("create(" + lp.url + "): LP response: ", resp);
-                        const callerFeeShare = (await callerFeePrefetchPromise);
+                        const callerFeeShare = (await callerFeePrefetchPromise[version]);
                         const [pricingInfo, gasPricingInfo, { vault, vaultUtxoValue }] = await Promise.all([
                             this.verifyReturnedPrice(lp.services[SwapType_1.SwapType.SPV_VAULT_FROM_BTC], false, resp.btcAmountSwap, resp.total * (100000n + callerFeeShare) / 100000n, amountData.token, { swapFeeBtc: resp.swapFeeBtc }, pricePrefetchPromise, usdPricePrefetchPromise, abortController.signal),
                             _options.gasAmount === 0n ? Promise.resolve(undefined) : this.verifyReturnedPrice({ ...lp.services[SwapType_1.SwapType.SPV_VAULT_FROM_BTC], swapBaseFee: 0 }, //Base fee should be charged only on the amount, not on gas
@@ -503,7 +548,8 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
                             callerFeeShare: resp.callerFeeShare,
                             frontingFeeShare: resp.frontingFeeShare,
                             executionFeeShare: resp.executionFeeShare,
-                            genesisSmartChainBlockHeight: await (0, Utils_1.throwIfUndefined)(finalizedBlockHeightPrefetchPromise, "Finalize block height promise failed!")
+                            genesisSmartChainBlockHeight: await (0, Utils_1.throwIfUndefined)(finalizedBlockHeightPrefetchPromise, "Finalize block height promise failed!"),
+                            contractVersion: version
                         };
                         const quote = new SpvFromBTCSwap_1.SpvFromBTCSwap(this, swapInit);
                         return quote;
@@ -523,9 +569,9 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
      * @param vault SPV vault processing the swap
      * @param lp Intermediary (LP) used as a counterparty for the swap
      */
-    async recoverFromState(state, vault, lp) {
+    async recoverFromState(state, contractVersion, vault, lp) {
         //Get the vault
-        vault ??= await this._contract.getVaultData(state.owner, state.vaultId);
+        vault ??= await this._contract(contractVersion).getVaultData(state.owner, state.vaultId);
         if (vault == null)
             return null;
         if (state.btcTxId == null)
@@ -533,7 +579,7 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
         const btcTx = await this._btcRpc.getTransaction(state.btcTxId);
         if (btcTx == null)
             return null;
-        const withdrawalData = await this._contract.getWithdrawalData(btcTx)
+        const withdrawalData = await this._contract(contractVersion).getWithdrawalData(btcTx)
             .catch(e => {
             this.logger.warn(`Error parsing withdrawal data for tx ${btcTx.txid}: `, e);
             return null;
@@ -591,7 +637,8 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             callerFeeShare: withdrawalData.callerFeeRate,
             frontingFeeShare: withdrawalData.frontingFeeRate,
             executionFeeShare: withdrawalData.executionFeeRate,
-            genesisSmartChainBlockHeight: txBlock?.blockHeight ?? 0
+            genesisSmartChainBlockHeight: txBlock?.blockHeight ?? 0,
+            contractVersion
         };
         const quote = new SpvFromBTCSwap_1.SpvFromBTCSwap(this, swapInit);
         quote._data = withdrawalData;
@@ -645,11 +692,20 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             script: randomVaultOutScript,
             amount: 600n
         });
-        const opReturnData = this._contract.toOpReturnData(this._chain.randomAddress(), includeGasToken ? [0xffffffffffffffffn, 0xffffffffffffffffn] : [0xffffffffffffffffn]);
+        let longestOpReturnData = undefined;
+        for (let contractVersion in this.versionedContracts) {
+            if (this.versionedContracts[contractVersion].spvVaultContract == null)
+                continue;
+            const opReturnData = this._contract(contractVersion).toOpReturnData(this._chain.randomAddress(), includeGasToken ? [0xffffffffffffffffn, 0xffffffffffffffffn] : [0xffffffffffffffffn]);
+            if (longestOpReturnData == null || longestOpReturnData.length < opReturnData.length)
+                longestOpReturnData = opReturnData;
+        }
+        if (longestOpReturnData == null)
+            throw new Error(`No contract version supporting the Spv Vault BTC -> ${this.chainIdentifier} swaps found!`);
         psbt.addOutput({
             script: Buffer.concat([
-                opReturnData.length <= 75 ? Buffer.from([0x6a, opReturnData.length]) : Buffer.from([0x6a, 0x4c, opReturnData.length]),
-                opReturnData
+                longestOpReturnData.length <= 75 ? Buffer.from([0x6a, longestOpReturnData.length]) : Buffer.from([0x6a, 0x4c, longestOpReturnData.length]),
+                longestOpReturnData
             ]),
             amount: 0n
         });
@@ -662,7 +718,7 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
     async _checkPastSwaps(pastSwaps) {
         const changedSwaps = new Set();
         const removeSwaps = [];
-        const broadcastedOrConfirmedSwaps = [];
+        const broadcastedOrConfirmedSwaps = {};
         for (let pastSwap of pastSwaps) {
             let changed = false;
             if (pastSwap._state === SpvFromBTCSwap_1.SpvFromBTCSwapState.SIGNED ||
@@ -696,56 +752,63 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
                 changedSwaps.add(pastSwap);
             if (pastSwap._state === SpvFromBTCSwap_1.SpvFromBTCSwapState.BROADCASTED || pastSwap._state === SpvFromBTCSwap_1.SpvFromBTCSwapState.BTC_TX_CONFIRMED) {
                 if (pastSwap._data != null)
-                    broadcastedOrConfirmedSwaps.push(pastSwap);
+                    (broadcastedOrConfirmedSwaps[pastSwap._contractVersion ?? "v1"] ??= []).push(pastSwap);
             }
         }
-        const checkWithdrawalStateSwaps = [];
-        const _fronts = await this._contract.getFronterAddresses(broadcastedOrConfirmedSwaps.map(val => ({
-            ...val.getSpvVaultData(),
-            withdrawal: val._data
-        })));
-        const _vaultUtxos = await this._contract.getVaultLatestUtxos(broadcastedOrConfirmedSwaps.map(val => val.getSpvVaultData()));
-        for (const pastSwap of broadcastedOrConfirmedSwaps) {
-            const fronterAddress = _fronts[pastSwap._data.getTxId()];
-            const vault = pastSwap.getSpvVaultData();
-            const latestVaultUtxo = _vaultUtxos[vault.owner]?.[vault.vaultId.toString(10)];
-            if (fronterAddress === undefined)
-                this.logger.warn(`_checkPastSwaps(): No fronter address returned for ${pastSwap._data.getTxId()}`);
-            if (latestVaultUtxo === undefined)
-                this.logger.warn(`_checkPastSwaps(): No last vault utxo returned for ${pastSwap._data.getTxId()}`);
-            if (await pastSwap._shouldCheckWithdrawalState(fronterAddress, latestVaultUtxo))
-                checkWithdrawalStateSwaps.push(pastSwap);
-        }
-        const withdrawalStates = await this._contract.getWithdrawalStates(checkWithdrawalStateSwaps.map(val => ({
-            withdrawal: val._data,
-            scStartBlockheight: val._genesisSmartChainBlockHeight
-        })));
-        for (const pastSwap of checkWithdrawalStateSwaps) {
-            const status = withdrawalStates[pastSwap._data.getTxId()];
-            if (status == null) {
-                this.logger.warn(`_checkPastSwaps(): No withdrawal state returned for ${pastSwap._data.getTxId()}`);
+        for (let contractVersion in broadcastedOrConfirmedSwaps) {
+            if (this.versionedContracts[contractVersion] == null) {
+                this.logger.warn(`_checkPastSwaps(): No contract was found for ${this.chainIdentifier} version ${contractVersion}! Skipping these swaps!`);
                 continue;
             }
-            this.logger.debug("syncStateFromChain(): status of " + pastSwap._data.btcTx.txid, status?.type);
-            let changed = false;
-            switch (status.type) {
-                case base_1.SpvWithdrawalStateType.FRONTED:
-                    pastSwap._frontTxId = status.txId;
-                    pastSwap._state = SpvFromBTCSwap_1.SpvFromBTCSwapState.FRONTED;
-                    changed ||= true;
-                    break;
-                case base_1.SpvWithdrawalStateType.CLAIMED:
-                    pastSwap._claimTxId = status.txId;
-                    pastSwap._state = SpvFromBTCSwap_1.SpvFromBTCSwapState.CLAIMED;
-                    changed ||= true;
-                    break;
-                case base_1.SpvWithdrawalStateType.CLOSED:
-                    pastSwap._state = SpvFromBTCSwap_1.SpvFromBTCSwapState.CLOSED;
-                    changed ||= true;
-                    break;
+            const _broadcastedOrConfirmedSwaps = broadcastedOrConfirmedSwaps[contractVersion];
+            const checkWithdrawalStateSwaps = [];
+            const _fronts = await this._contract(contractVersion).getFronterAddresses(_broadcastedOrConfirmedSwaps.map(val => ({
+                ...val.getSpvVaultData(),
+                withdrawal: val._data
+            })));
+            const _vaultUtxos = await this._contract(contractVersion).getVaultLatestUtxos(_broadcastedOrConfirmedSwaps.map(val => val.getSpvVaultData()));
+            for (const pastSwap of _broadcastedOrConfirmedSwaps) {
+                const fronterAddress = _fronts[pastSwap._data.getTxId()];
+                const vault = pastSwap.getSpvVaultData();
+                const latestVaultUtxo = _vaultUtxos[vault.owner]?.[vault.vaultId.toString(10)];
+                if (fronterAddress === undefined)
+                    this.logger.warn(`_checkPastSwaps(): No fronter address returned for ${pastSwap._data.getTxId()}`);
+                if (latestVaultUtxo === undefined)
+                    this.logger.warn(`_checkPastSwaps(): No last vault utxo returned for ${pastSwap._data.getTxId()}`);
+                if (await pastSwap._shouldCheckWithdrawalState(fronterAddress, latestVaultUtxo))
+                    checkWithdrawalStateSwaps.push(pastSwap);
             }
-            if (changed)
-                changedSwaps.add(pastSwap);
+            const withdrawalStates = await this._contract(contractVersion).getWithdrawalStates(checkWithdrawalStateSwaps.map(val => ({
+                withdrawal: val._data,
+                scStartBlockheight: val._genesisSmartChainBlockHeight
+            })));
+            for (const pastSwap of checkWithdrawalStateSwaps) {
+                const status = withdrawalStates[pastSwap._data.getTxId()];
+                if (status == null) {
+                    this.logger.warn(`_checkPastSwaps(): No withdrawal state returned for ${pastSwap._data.getTxId()}`);
+                    continue;
+                }
+                this.logger.debug("syncStateFromChain(): status of " + pastSwap._data.btcTx.txid, status?.type);
+                let changed = false;
+                switch (status.type) {
+                    case base_1.SpvWithdrawalStateType.FRONTED:
+                        pastSwap._frontTxId = status.txId;
+                        pastSwap._state = SpvFromBTCSwap_1.SpvFromBTCSwapState.FRONTED;
+                        changed ||= true;
+                        break;
+                    case base_1.SpvWithdrawalStateType.CLAIMED:
+                        pastSwap._claimTxId = status.txId;
+                        pastSwap._state = SpvFromBTCSwap_1.SpvFromBTCSwapState.CLAIMED;
+                        changed ||= true;
+                        break;
+                    case base_1.SpvWithdrawalStateType.CLOSED:
+                        pastSwap._state = SpvFromBTCSwap_1.SpvFromBTCSwapState.CLOSED;
+                        changed ||= true;
+                        break;
+                }
+                if (changed)
+                    changedSwaps.add(pastSwap);
+            }
         }
         return {
             changedSwaps: Array.from(changedSwaps),

--- a/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
@@ -466,7 +466,10 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             feeSafetyFactor: options?.feeSafetyFactor ?? 1.25,
             maxAllowedBitcoinFeeRate: options?.maxAllowedBitcoinFeeRate ?? options?.maxAllowedNetworkFeeRate ?? Infinity
         };
-        if (amountData.token === this._chain.getNativeCurrencyAddress() && _options.gasAmount !== 0n)
+        if (_options.gasAmount !== 0n &&
+            (this._chain.shouldGetNativeTokenDrop != null
+                ? !this._chain.shouldGetNativeTokenDrop(amountData.token)
+                : amountData.token === this._chain.getNativeCurrencyAddress()))
             throw new UserError_1.UserError("Cannot specify `gasAmount` for swaps to a native token!");
         const lpVersions = Intermediary_1.Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
         const _abortController = (0, Utils_1.extendAbortController)(abortSignal);

--- a/dist/swaps/trusted/ln/LnForGasWrapper.js
+++ b/dist/swaps/trusted/ln/LnForGasWrapper.js
@@ -73,7 +73,8 @@ class LnForGasWrapper extends ISwapWrapper_1.ISwapWrapper {
             swapFee: resp.swapFee,
             swapFeeBtc: resp.swapFeeSats,
             token,
-            exactIn: false
+            exactIn: false,
+            contractVersion: "v1"
         };
         const quote = new LnForGasSwap_1.LnForGasSwap(this, quoteInit);
         return quote;

--- a/dist/swaps/trusted/onchain/OnchainForGasWrapper.js
+++ b/dist/swaps/trusted/onchain/OnchainForGasWrapper.js
@@ -84,7 +84,8 @@ class OnchainForGasWrapper extends ISwapWrapper_1.ISwapWrapper {
             swapFee: resp.swapFee,
             swapFeeBtc: resp.swapFeeSats,
             exactIn: false,
-            token
+            token,
+            contractVersion: "v1"
         });
         return quote;
     }

--- a/dist/utils/Utils.d.ts
+++ b/dist/utils/Utils.d.ts
@@ -18,6 +18,15 @@ export declare function throwIfUndefined<T>(promise: Promise<T | undefined>, msg
  */
 export declare function promiseAny<T>(promises: Promise<T>[]): Promise<T>;
 /**
+ * Maps an array to object properties using the translation function
+ *
+ * @param array
+ * @param translator
+ */
+export declare function mapArrayToObject<T extends string[], O>(array: T, translator: (key: T[number]) => O): {
+    [key in T[number]]: O;
+};
+/**
  * Maps a JS object to another JS object based on the translation function, the translation function is called for every
  *  property (value/key) of the old object and returns the new value of for this property
  *

--- a/dist/utils/Utils.js
+++ b/dist/utils/Utils.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.parseHashValueExact32Bytes = exports.toDecimal = exports.fromDecimal = exports.getTxoHash = exports.randomBytes = exports.toBigInt = exports.bigIntCompare = exports.bigIntMax = exports.bigIntMin = exports.extendAbortController = exports.mapToArray = exports.objectMap = exports.promiseAny = exports.throwIfUndefined = void 0;
+exports.parseHashValueExact32Bytes = exports.toDecimal = exports.fromDecimal = exports.getTxoHash = exports.randomBytes = exports.toBigInt = exports.bigIntCompare = exports.bigIntMax = exports.bigIntMin = exports.extendAbortController = exports.mapToArray = exports.objectMap = exports.mapArrayToObject = exports.promiseAny = exports.throwIfUndefined = void 0;
 const buffer_1 = require("buffer");
 const utils_1 = require("@noble/hashes/utils");
 const sha2_1 = require("@noble/hashes/sha2");
@@ -48,6 +48,20 @@ function promiseAny(promises) {
     });
 }
 exports.promiseAny = promiseAny;
+/**
+ * Maps an array to object properties using the translation function
+ *
+ * @param array
+ * @param translator
+ */
+function mapArrayToObject(array, translator) {
+    const obj = {};
+    array.forEach((item) => {
+        obj[item] = translator(item);
+    });
+    return obj;
+}
+exports.mapArrayToObject = mapArrayToObject;
 /**
  * Maps a JS object to another JS object based on the translation function, the translation function is called for every
  *  property (value/key) of the old object and returns the new value of for this property

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.7.5",
+  "version": "8.7.6",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.7.4",
+  "version": "8.7.5",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.7.2",
+  "version": "8.7.3",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "adambor",
   "license": "ISC",
   "dependencies": {
-    "@atomiqlabs/base": "github:atomiqlabs/atomiq-base#develop",
+    "@atomiqlabs/base": "^13.5.0",
     "@atomiqlabs/bolt11": "1.6.1",
     "@atomiqlabs/btc-mempool": "^1.0.4",
     "@atomiqlabs/messenger-nostr": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.7.1",
+  "version": "8.7.2",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.7.6",
+  "version": "8.7.7",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.6.9",
+  "version": "8.7.0",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",
@@ -23,7 +23,7 @@
   "author": "adambor",
   "license": "ISC",
   "dependencies": {
-    "@atomiqlabs/base": "^13.1.9",
+    "@atomiqlabs/base": "github:atomiqlabs/atomiq-base#develop",
     "@atomiqlabs/bolt11": "1.6.1",
     "@atomiqlabs/btc-mempool": "^1.0.4",
     "@atomiqlabs/messenger-nostr": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.7.3",
+  "version": "8.7.4",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",
@@ -23,7 +23,7 @@
   "author": "adambor",
   "license": "ISC",
   "dependencies": {
-    "@atomiqlabs/base": "^13.5.0",
+    "@atomiqlabs/base": "^13.5.2",
     "@atomiqlabs/bolt11": "1.6.1",
     "@atomiqlabs/btc-mempool": "^1.0.4",
     "@atomiqlabs/messenger-nostr": "^2.0.0",

--- a/src/events/UnifiedSwapEventListener.ts
+++ b/src/events/UnifiedSwapEventListener.ts
@@ -82,9 +82,10 @@ export class UnifiedSwapEventListener<
 
         for(let event of events) {
             const escrowHash = chainEventToEscrowHash(event);
+            const eventVersion = event.contractVersion ?? "v1";
             if(escrowHash!=null) {
                 const swap = swapsByEscrowHash[escrowHash];
-                if(swap!=null) {
+                if(swap!=null && (swap._contractVersion ?? "v1")===eventVersion) {
                     const obj = this.listeners[swap.getType()];
                     if(obj==null) continue;
                     await obj.listener(event, swap);
@@ -124,8 +125,9 @@ export class UnifiedSwapEventListener<
 
         for(let claimData in htlcCheckInitializeEvents) {
             const event = htlcCheckInitializeEvents[claimData];
+            const eventVersion = event.contractVersion ?? "v1";
             const swap = swapsByClaimDataHash[claimData];
-            if(swap!=null) {
+            if(swap!=null && (swap._contractVersion ?? "v1")===eventVersion) {
                 const obj = this.listeners[swap.getType()];
                 if(obj==null) continue;
                 await obj.listener(event, swap);

--- a/src/intermediaries/Intermediary.ts
+++ b/src/intermediaries/Intermediary.ts
@@ -56,6 +56,10 @@ export class Intermediary {
      */
     readonly addresses: {[chainIdentifier: string]: string};
     /**
+     * Contract versions of the intermediary on smart chains
+     */
+    readonly contractVersions: {[chainIdentifier: string]: string};
+    /**
      * Swap protocol services offered by the intermediary
      */
     readonly services: ServicesType;
@@ -99,12 +103,14 @@ export class Intermediary {
         url: string,
         addresses: {[chainIdentifier: string]: string},
         services: ServicesType,
-        reputation: { [chainIdentifier: string]: SingleChainReputationType } = {}
+        reputation: { [chainIdentifier: string]: SingleChainReputationType } = {},
+        contractVersions: {[chainIdentifier: string]: string} = {},
     ) {
         this.url = url;
         this.addresses = addresses;
         this.services = services;
         this.reputation = reputation;
+        this.contractVersions = contractVersions;
 
         this.swapBounds = {};
         for(let _swapType in this.services) {
@@ -245,6 +251,30 @@ export class Intermediary {
      */
     getAddress(chainIdentifier: string) {
         return this.addresses[chainIdentifier];
+    }
+
+    /**
+     * Returns the contract version used by the intermediary for a given chain
+     *
+     * @param chainIdentifier
+     */
+    getContractVersion(chainIdentifier: string): string {
+        return this.contractVersions[chainIdentifier] ?? "v1";
+    }
+
+    /**
+     * Returns the range of contract versions used by the LPs
+     *
+     * @param chainIdentifier
+     * @param lps
+     */
+    static getContractVersionsForLps(chainIdentifier: string, lps: Intermediary[]): string[] {
+        const versions: string[] = [];
+        lps.forEach((lp) => {
+            const lpVersion = lp.getContractVersion(chainIdentifier);
+            if(!versions.includes(lpVersion)) versions.push(lpVersion);
+        });
+        return versions;
     }
 
 }

--- a/src/intermediaries/IntermediaryDiscovery.ts
+++ b/src/intermediaries/IntermediaryDiscovery.ts
@@ -169,7 +169,7 @@ export class IntermediaryDiscovery extends EventEmitter {
     /**
      * Swap contracts for checking intermediary signatures
      */
-    swapContracts: {[key: string]: SwapContract};
+    swapContracts: {[chainIdentifier: string]: {[contractVersion: string]: {swapContract: SwapContract}}};
     /**
      * Registry URL used as a source for the list of intermediaries, this should be a link to a
      *  github-hosted JSON file
@@ -193,7 +193,7 @@ export class IntermediaryDiscovery extends EventEmitter {
     private overrideNodeUrls?: string[];
 
     constructor(
-        swapContracts: {[key: string]: SwapContract},
+        swapContracts: {[chainIdentifier: string]: {[contractVersion: string]: {swapContract: SwapContract}}},
         registryUrl: string = REGISTRY_URL,
         nodeUrls?: string[],
         httpRequestTimeout?: number,
@@ -236,7 +236,11 @@ export class IntermediaryDiscovery extends EventEmitter {
      * @param url
      * @param abortSignal
      */
-    private async getNodeInfo(url: string, abortSignal?: AbortSignal) : Promise<{addresses: {[key: string]: string}, info: InfoHandlerResponseEnvelope}> {
+    private async getNodeInfo(url: string, abortSignal?: AbortSignal) : Promise<{
+        addresses: {[chainIdentifier: string]: string},
+        contractVersions: {[chainIdentifier: string]: string},
+        info: InfoHandlerResponseEnvelope
+    }> {
         const response = await tryWithRetries(
             () => IntermediaryAPI.getIntermediaryInfo(url, this.httpRequestTimeout, abortSignal),
             {maxRetries: 3, delay: 100, exponential: true},
@@ -247,14 +251,22 @@ export class IntermediaryDiscovery extends EventEmitter {
         abortSignal?.throwIfAborted();
 
         const promises: Promise<void>[] = [];
-        const addresses: {[key: string]: string} = {};
+        const addresses: {[chainIdentifier: string]: string} = {};
+        const contractVersions: {[chainIdentifier: string]: string} = {};
         for(let chain in response.chains) {
             if(this.swapContracts[chain]!=null) {
+                const {signature, address, contractVersion} = response.chains[chain];
+                const _contractVersion = contractVersion ?? "v1";
+                const contract = this.swapContracts[chain][_contractVersion];
+                if(contract==null) {
+                    logger.warn("getNodeInfo(): Unknown chain contract version "+_contractVersion+" for "+chain+" reported by intermediary: "+url);
+                    continue;
+                }
                 promises.push((async () => {
-                    const {signature, address} = response.chains[chain];
                     try {
-                        await this.swapContracts[chain].isValidDataSignature(Buffer.from(response.envelope), signature, address);
+                        await contract.swapContract.isValidDataSignature(Buffer.from(response.envelope), signature, address);
                         addresses[chain] = address;
+                        contractVersions[chain] = _contractVersion;
                     } catch (e) {
                         logger.warn("getNodeInfo(): Failed to verify "+chain+" signature for intermediary: "+url);
                     }
@@ -285,6 +297,7 @@ export class IntermediaryDiscovery extends EventEmitter {
 
         return {
             addresses,
+            contractVersions,
             info
         };
     }
@@ -303,7 +316,7 @@ export class IntermediaryDiscovery extends EventEmitter {
             for(let key in nodeInfo.info.services) {
                 services[swapHandlerTypeToSwapType(key as SwapHandlerType)] = nodeInfo.info.services[key as SwapHandlerType];
             }
-            return new Intermediary(url, nodeInfo.addresses, services);
+            return new Intermediary(url, nodeInfo.addresses, services, undefined, nodeInfo.contractVersions);
         } catch (e: any) {
             logger.warn("fetchIntermediaries(): Intermediary "+url+` is unreachable due to ${e.name ?? e.message} error, skipping...`);
             logger.debug("fetchIntermediaries(): Error contacting intermediary "+url+": ", e);

--- a/src/intermediaries/IntermediaryDiscovery.ts
+++ b/src/intermediaries/IntermediaryDiscovery.ts
@@ -1,6 +1,6 @@
 import {Intermediary, ServicesType} from "./Intermediary";
 import {SwapType} from "../enums/SwapType";
-import {SwapContract} from "@atomiqlabs/base";
+import {SpvVaultContract, SwapContract} from "@atomiqlabs/base";
 import {EventEmitter} from "events";
 import {Buffer} from "buffer";
 import {bigIntMax, bigIntMin, extendAbortController} from "../utils/Utils";
@@ -169,7 +169,7 @@ export class IntermediaryDiscovery extends EventEmitter {
     /**
      * Swap contracts for checking intermediary signatures
      */
-    swapContracts: {[chainIdentifier: string]: {[contractVersion: string]: {swapContract: SwapContract}}};
+    swapContracts: {[chainIdentifier: string]: {[contractVersion: string]: {swapContract: SwapContract, spvVaultContract: SpvVaultContract}}};
     /**
      * Registry URL used as a source for the list of intermediaries, this should be a link to a
      *  github-hosted JSON file
@@ -193,7 +193,7 @@ export class IntermediaryDiscovery extends EventEmitter {
     private overrideNodeUrls?: string[];
 
     constructor(
-        swapContracts: {[chainIdentifier: string]: {[contractVersion: string]: {swapContract: SwapContract}}},
+        swapContracts: {[chainIdentifier: string]: {[contractVersion: string]: {swapContract: SwapContract, spvVaultContract: SpvVaultContract}}},
         registryUrl: string = REGISTRY_URL,
         nodeUrls?: string[],
         httpRequestTimeout?: number,
@@ -489,6 +489,8 @@ export class IntermediaryDiscovery extends EventEmitter {
     /**
      * Returns swap candidates for a specific swap type & token address
      *
+     * @remark Also filters the LPs based on supported swap versions
+     *
      * @param chainIdentifier Chain identifier of the smart chain
      * @param swapType Swap protocol type
      * @param tokenAddress Token address
@@ -504,6 +506,10 @@ export class IntermediaryDiscovery extends EventEmitter {
             if(swapService.chainTokens==null) return false;
             if(swapService.chainTokens[chainIdentifier]==null) return false;
             if(!swapService.chainTokens[chainIdentifier].includes(tokenAddress.toString())) return false;
+            const contracts = this.swapContracts[chainIdentifier][e.getContractVersion(chainIdentifier) ?? "v1"];
+            if(contracts==null) return false;
+            if(swapType===SwapType.FROM_BTCLN_AUTO && !contracts.swapContract?.supportsInitWithoutClaimer) return false;
+            if(swapType===SwapType.SPV_VAULT_FROM_BTC && contracts.spvVaultContract==null) return false;
             return true;
         });
 

--- a/src/intermediaries/apis/IntermediaryAPI.ts
+++ b/src/intermediaries/apis/IntermediaryAPI.ts
@@ -14,7 +14,8 @@ export type InfoHandlerResponse = {
     chains: {
         [chainIdentifier: string]: {
             address: string,
-            signature: string
+            signature: string,
+            contractVersion?: string,
         }
     }
 };

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -6,7 +6,7 @@ import {
     ChainSwapType,
     ChainType, LightningNetworkApi,
     Messenger,
-    RelaySynchronizer
+    RelaySynchronizer, SpvWithdrawalClaimedState, SpvWithdrawalFrontedState, SwapCommitState, SwapContract, SwapData
 } from "@atomiqlabs/base";
 import {
     ToBTCLNOptions,
@@ -190,14 +190,20 @@ type ChainSpecificData<T extends ChainType> = {
         [SwapType.FROM_BTCLN_AUTO]: FromBTCLNAutoWrapper<T>
     }
     chainEvents: T["Events"],
-    swapContract: T["Contract"],
-    spvVaultContract: T["SpvVaultContract"],
     chainInterface: T["ChainInterface"],
-    btcRelay: BtcRelay<any, T["TX"], BtcBlock, T["Signer"]>,
-    synchronizer: RelaySynchronizer<any, T["TX"], BtcBlock>,
     unifiedChainEvents: UnifiedSwapEventListener<T>,
     unifiedSwapStorage: UnifiedSwapStorage<T>,
-    reviver: (val: any) => ISwap<T>
+    reviver: (val: any) => ISwap<T>,
+    defaultVersion: string,
+
+    versionedContracts: {
+        [contractVersion: string]: {
+            swapContract: T["Contract"],
+            spvVaultContract: T["SpvVaultContract"],
+            btcRelay: BtcRelay<any, T["TX"], BtcBlock, T["Signer"]>,
+            synchronizer: RelaySynchronizer<any, T["TX"], BtcBlock>,
+        }
+    }
 };
 
 type MultiChainData<T extends MultiChain> = {
@@ -358,12 +364,37 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         };
 
         this._chains = objectMap<CtorMultiChainData<T>, MultiChainData<T>>(chainsData, <InputKey extends keyof CtorMultiChainData<T>>(chainData: CtorMultiChainData<T>[InputKey], key: string) => {
-            const {
-                swapContract, chainEvents, btcRelay,
-                chainInterface, spvVaultContract, spvVaultWithdrawalDataConstructor,
-                chainId
+            let {
+                chainInterface, chainEvents, chainId,
+                btcRelay,
+                swapContract, swapDataConstructor,
+                spvVaultContract, spvVaultWithdrawalDataConstructor, spvVaultDataConstructor,
+                defaultVersion, versions
             } = chainData;
-            const synchronizer = bitcoinSynchronizer(btcRelay);
+
+            defaultVersion ??= "v1";
+
+            if(versions==null) {
+                versions = {
+                    [defaultVersion]: {
+                        btcRelay,
+                        swapContract,
+                        swapDataConstructor,
+                        spvVaultContract,
+                        spvVaultDataConstructor,
+                        spvVaultWithdrawalDataConstructor
+                    }
+                }
+            }
+
+            const versionedContracts = objectMap(versions, (value, key) => {
+                return {
+                    swapContract: value.swapContract,
+                    spvVaultContract: value.spvVaultContract,
+                    btcRelay: value.btcRelay,
+                    synchronizer: bitcoinSynchronizer(value.btcRelay)
+                };
+            });
 
             const storageHandler = swapStorage(storagePrefix + chainId);
             const unifiedSwapStorage = new UnifiedSwapStorage<T[InputKey]>(storageHandler, this.options.noSwapCache);
@@ -376,10 +407,9 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 unifiedSwapStorage,
                 unifiedChainEvents,
                 chainInterface,
-                swapContract,
                 pricing,
                 this._tokens[chainId],
-                chainData.swapDataConstructor,
+                versions,
                 {
                     getRequestTimeout: this.options.getRequestTimeout,
                     postRequestTimeout: this.options.postRequestTimeout,
@@ -391,10 +421,9 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 unifiedSwapStorage,
                 unifiedChainEvents,
                 chainInterface,
-                swapContract,
                 pricing,
                 this._tokens[chainId],
-                chainData.swapDataConstructor,
+                versions,
                 this._bitcoinRpc,
                 {
                     getRequestTimeout: this.options.getRequestTimeout,
@@ -408,10 +437,9 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 unifiedSwapStorage,
                 unifiedChainEvents,
                 chainInterface,
-                swapContract,
                 pricing,
                 this._tokens[chainId],
-                chainData.swapDataConstructor,
+                versions,
                 lightningApi,
                 {
                     getRequestTimeout: this.options.getRequestTimeout,
@@ -425,12 +453,10 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 unifiedSwapStorage,
                 unifiedChainEvents,
                 chainInterface,
-                swapContract,
                 pricing,
                 this._tokens[chainId],
-                chainData.swapDataConstructor,
-                btcRelay,
-                synchronizer,
+                versions,
+                versionedContracts,
                 this._bitcoinRpc,
                 {
                     getRequestTimeout: this.options.getRequestTimeout,
@@ -468,18 +494,17 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 }
             );
 
+            // This is gated on the default version of the contracts
             if(spvVaultContract!=null) {
                 wrappers[SwapType.SPV_VAULT_FROM_BTC] = new SpvFromBTCWrapper<T[InputKey]>(
                     key,
                     unifiedSwapStorage,
                     unifiedChainEvents,
                     chainInterface,
-                    spvVaultContract,
                     pricing,
                     this._tokens[chainId],
-                    spvVaultWithdrawalDataConstructor,
-                    btcRelay,
-                    synchronizer,
+                    versions,
+                    versionedContracts,
                     bitcoinRpc,
                     {
                         getRequestTimeout: this.options.getRequestTimeout,
@@ -490,16 +515,16 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 );
             }
 
+            // This is gated on the default version of the contracts
             if(swapContract.supportsInitWithoutClaimer) {
                 wrappers[SwapType.FROM_BTCLN_AUTO] = new FromBTCLNAutoWrapper<T[InputKey]>(
                     key,
                     unifiedSwapStorage,
                     unifiedChainEvents,
                     chainInterface,
-                    swapContract,
                     pricing,
                     this._tokens[chainId],
-                    chainData.swapDataConstructor,
+                    versions,
                     lightningApi,
                     this.messenger,
                     {
@@ -521,22 +546,22 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
 
             return {
                 chainEvents,
-                spvVaultContract,
-                swapContract,
                 chainInterface,
-                btcRelay,
-                synchronizer,
 
                 wrappers,
 
                 unifiedChainEvents,
                 unifiedSwapStorage,
 
-                reviver
+                defaultVersion,
+
+                reviver,
+
+                versionedContracts
             }
         });
 
-        const contracts = objectMap(chainsData, (data) => data.swapContract);
+        const contracts = objectMap(chainsData, (data) => data.versions ?? {[data.defaultVersion ?? "v1"]: {swapContract: data.swapContract}});
         if(options.intermediaryUrl!=null) {
             this.intermediaryDiscovery = new IntermediaryDiscovery(contracts, options.registryUrl, Array.isArray(options.intermediaryUrl) ? options.intermediaryUrl : [options.intermediaryUrl], options.getRequestTimeout);
         } else {
@@ -595,7 +620,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
             chainPromises.push((async() => {
                 const {
                     chainInterface,
-                    swapContract,
+                    versionedContracts,
                     unifiedChainEvents,
                     unifiedSwapStorage,
                     wrappers,
@@ -607,8 +632,10 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                     await _chainInterface.verifyNetwork(this.bitcoinNetwork);
                 }
 
-                await swapContract.start();
-                this.logger.debug("init(): Intialized swap contract: "+chainIdentifier);
+                for(let contractVersion in versionedContracts) {
+                    await versionedContracts[contractVersion].swapContract.start();
+                    this.logger.debug("init(): Intialized swap contract: "+chainIdentifier+` version: ${contractVersion}`);
+                }
 
                 await unifiedSwapStorage.init();
                 if(unifiedSwapStorage.storage instanceof IndexedDBUnifiedStorage) {
@@ -1872,18 +1899,56 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
      *  initiated after this blockheight
      */
     async recoverSwaps<C extends ChainIds<T>>(chainId: C, signer: string, startBlockheight?: number): Promise<ISwap<T[C]>[]> {
-        const {spvVaultContract, swapContract, unifiedSwapStorage, reviver, wrappers} = this._chains[chainId];
+        //TODO: Recover swaps from all the known contract versions
+        const {versionedContracts, unifiedSwapStorage, reviver, wrappers} = this._chains[chainId];
 
-        if(
-            swapContract.getHistoricalSwaps==null ||
-            (spvVaultContract!=null && spvVaultContract.getHistoricalWithdrawalStates==null)
-        ) throw new Error(`Historical swap recovery is not supported for ${chainId}`);
+        const recoveredSwaps: ISwap<T[C]>[] = [];
+        let someVersionSupportsRecovery = false;
+        const recoveredEscrowStates: {
+            [p: string]: {
+                init?: {
+                    data: SwapData
+                    getInitTxId: () => Promise<string>
+                    getTxBlock: () => Promise<{
+                        blockTime: number
+                        blockHeight: number
+                    }>
+                },
+                state: SwapCommitState
+                contractVersion: string
+            }
+        } = {};
+        const recoveredSpvStates: {
+            [contractVersion: string]: {
+                [escrowHash: string]: SpvWithdrawalClaimedState | SpvWithdrawalFrontedState
+            }
+        } = {};
 
-        const {swaps} = await swapContract.getHistoricalSwaps(signer, startBlockheight);
-        const spvVaultData = await spvVaultContract?.getHistoricalWithdrawalStates!(signer, startBlockheight);
+        for(let contractVersion in versionedContracts) {
+            const {swapContract, spvVaultContract} = versionedContracts[contractVersion];
 
-        const escrowHashes = Object.keys(swaps);
-        if(spvVaultData!=null) Object.keys(spvVaultData.withdrawals).forEach(btcTxId => escrowHashes.push(btcTxId));
+            if(
+                swapContract.getHistoricalSwaps==null ||
+                (spvVaultContract!=null && spvVaultContract.getHistoricalWithdrawalStates==null)
+            ) {
+                this.logger.warn(`recoverSwaps(): Swap data recovery not supported on ${chainId}, with contract version ${contractVersion}`);
+                continue;
+            }
+
+            someVersionSupportsRecovery = true;
+
+            const {swaps} = await swapContract.getHistoricalSwaps(signer, startBlockheight);
+            const spvVaultData = wrappers[SwapType.SPV_VAULT_FROM_BTC]==null
+                ? undefined
+                : await spvVaultContract?.getHistoricalWithdrawalStates!(signer, startBlockheight);
+
+            for(let key in swaps) recoveredEscrowStates[key] = {...swaps[key], contractVersion};
+            if(spvVaultData!=null) for(let key in spvVaultData.withdrawals) (recoveredSpvStates[contractVersion] ??= {})[key] = spvVaultData.withdrawals[key];
+        }
+        if(!someVersionSupportsRecovery) throw new Error(`Historical swap recovery is not supported for ${chainId}`);
+
+        const escrowHashes = Object.keys(recoveredEscrowStates);
+        for(let contractVersion in recoveredSpvStates) Object.keys(recoveredSpvStates[contractVersion]).forEach(btcTxId => escrowHashes.push(btcTxId));
         this.logger.debug(`recoverSwaps(): Loaded on-chain data for ${escrowHashes.length} swaps`);
         this.logger.debug(`recoverSwaps(): Fetching if swap escrowHashes are known: ${escrowHashes.join(", ")}`);
         const knownSwapsArray = await unifiedSwapStorage.query([[{key: "escrowHash", value: escrowHashes}]], reviver);
@@ -1894,11 +1959,10 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         });
         this.logger.debug(`recoverSwaps(): Fetched known swaps escrowHashes: ${Object.keys(knownSwaps).join(", ")}`);
 
-        const recoveredSwaps: ISwap<T[C]>[] = [];
-
-        for(let escrowHash in swaps) {
-            const {init, state} = swaps[escrowHash];
+        for(let escrowHash in recoveredEscrowStates) {
+            const {init, state, contractVersion} = recoveredEscrowStates[escrowHash];
             const knownSwap = knownSwaps[escrowHash];
+            const { swapContract } = versionedContracts[contractVersion];
 
             if(knownSwap==null) {
                 if(init==null) {
@@ -1907,6 +1971,10 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 }
             } else if(knownSwap instanceof IEscrowSwap) {
                 this.logger.debug(`recoverSwaps(escrow): Forcibly updating ${escrowHash} swap: swap already known and in local storage!`);
+                if((knownSwap._contractVersion ?? "v1")!==contractVersion) {
+                    this.logger.debug(`recoverSwaps(escrow): Skipping ${escrowHash} swap: swap uses contract version ${knownSwap._contractVersion ?? "v1"}, but state comes from ${contractVersion}!`);
+                    continue;
+                }
                 if(await knownSwap._forciblySetOnchainState(state)) {
                     await knownSwap._save();
                 }
@@ -1926,27 +1994,27 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                     //To BTCLN
                     typeIdentified = true;
                     const lp = this.intermediaryDiscovery.intermediaries.find(val => val.supportsChain(chainId) && data.isClaimer(val.getAddress(chainId)));
-                    swap = await wrappers[SwapType.TO_BTCLN].recoverFromSwapDataAndState(init, state, lp);
+                    swap = await wrappers[SwapType.TO_BTCLN].recoverFromSwapDataAndState(init, state, contractVersion, lp);
                 } else if(data.isClaimer(signer)) {
                     //From BTCLN
                     typeIdentified = true;
                     const lp = this.intermediaryDiscovery.intermediaries.find(val => val.supportsChain(chainId) && data.isOfferer(val.getAddress(chainId)));
-                    if(this.supportsSwapType(chainId, SwapType.FROM_BTCLN_AUTO)) {
-                        swap = await wrappers[SwapType.FROM_BTCLN_AUTO].recoverFromSwapDataAndState(init, state, lp);
+                    if(swapContract.supportsInitWithoutClaimer && wrappers[SwapType.FROM_BTCLN_AUTO]!=null) {
+                        swap = await wrappers[SwapType.FROM_BTCLN_AUTO].recoverFromSwapDataAndState(init, state, contractVersion, lp);
                     } else {
-                        swap = await wrappers[SwapType.FROM_BTCLN].recoverFromSwapDataAndState(init, state, lp);
+                        swap = await wrappers[SwapType.FROM_BTCLN].recoverFromSwapDataAndState(init, state, contractVersion, lp);
                     }
                 }
             } else if(data.getType()===ChainSwapType.CHAIN_NONCED) {
                 //To BTC
                 typeIdentified = true;
                 const lp = this.intermediaryDiscovery.intermediaries.find(val => val.supportsChain(chainId) && data.isClaimer(val.getAddress(chainId)));
-                swap = await wrappers[SwapType.TO_BTC].recoverFromSwapDataAndState(init, state, lp);
+                swap = await wrappers[SwapType.TO_BTC].recoverFromSwapDataAndState(init, state, contractVersion, lp);
             } else if(data.getType()===ChainSwapType.CHAIN) {
                 //From BTC
                 typeIdentified = true;
                 const lp = this.intermediaryDiscovery.intermediaries.find(val => val.supportsChain(chainId) && data.isOfferer(val.getAddress(chainId)));
-                swap = await wrappers[SwapType.FROM_BTC].recoverFromSwapDataAndState(init, state, lp);
+                swap = await wrappers[SwapType.FROM_BTC].recoverFromSwapDataAndState(init, state, contractVersion, lp);
             }
 
             if(swap!=null) {
@@ -1956,17 +2024,20 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
             }
         }
 
-        if(spvVaultContract!=null && spvVaultData!=null) {
+        for(let contractVersion in recoveredSpvStates) {
+            const { spvVaultContract } = versionedContracts[contractVersion];
+            const spvVaultData = recoveredSpvStates[contractVersion];
+
             const vaultsData = await spvVaultContract.getMultipleVaultData(
-                Object.keys(spvVaultData.withdrawals)
+                Object.keys(spvVaultData)
                     .map(btcTxId => ({
-                        owner: spvVaultData.withdrawals[btcTxId].owner,
-                        vaultId: spvVaultData.withdrawals[btcTxId].vaultId
+                        owner: spvVaultData[btcTxId].owner,
+                        vaultId: spvVaultData[btcTxId].vaultId
                     }))
             );
 
-            for(let btcTxId in spvVaultData.withdrawals) {
-                const state = spvVaultData.withdrawals[btcTxId];
+            for(let btcTxId in spvVaultData) {
+                const state = spvVaultData[btcTxId];
                 const knownSwap = knownSwaps[btcTxId];
 
                 if(knownSwap!=null) {
@@ -1988,6 +2059,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                 );
                 const swap = await wrappers[SwapType.SPV_VAULT_FROM_BTC].recoverFromState(
                     state,
+                    contractVersion,
                     vaultsData[state.owner]?.[state.vaultId.toString(10)],
                     lp
                 );

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -561,7 +561,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
             }
         });
 
-        const contracts = objectMap(chainsData, (data) => data.versions ?? {[data.defaultVersion ?? "v1"]: {swapContract: data.swapContract}});
+        const contracts = objectMap(chainsData, (data) => data.versions ?? {[data.defaultVersion ?? "v1"]: {swapContract: data.swapContract, spvVaultContract: data.spvVaultContract}});
         if(options.intermediaryUrl!=null) {
             this.intermediaryDiscovery = new IntermediaryDiscovery(contracts, options.registryUrl, Array.isArray(options.intermediaryUrl) ? options.intermediaryUrl : [options.intermediaryUrl], options.getRequestTimeout);
         } else {

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -1108,6 +1108,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         options?: SpvFromBTCOptions
     ): Promise<SpvFromBTCSwap<T[ChainIdentifier]>> {
         if(this._chains[chainIdentifier]==null) throw new Error("Invalid chain identifier! Unknown chain: "+chainIdentifier);
+        if(this._chains[chainIdentifier].wrappers[SwapType.SPV_VAULT_FROM_BTC]==null) throw new Error("Chain "+chainIdentifier+" doesn't support new BTC swap protocol (spv vault swaps)!");
         if(!this._chains[chainIdentifier].chainInterface.isValidAddress(recipient, true)) throw new Error("Invalid "+chainIdentifier+" address");
         recipient = this._chains[chainIdentifier].chainInterface.normalizeAddress(recipient);
         const amountData = {
@@ -1285,6 +1286,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         options?: FromBTCLNAutoOptions
     ): Promise<FromBTCLNAutoSwap<T[ChainIdentifier]>> {
         if(this._chains[chainIdentifier]==null) throw new Error("Invalid chain identifier! Unknown chain: "+chainIdentifier);
+        if(this._chains[chainIdentifier].wrappers[SwapType.FROM_BTCLN_AUTO]==null) throw new Error("Chain "+chainIdentifier+" doesn't support new lightning swap protocol (from btcln auto)!");
         if(!this._chains[chainIdentifier].chainInterface.isValidAddress(recipient, true)) throw new Error("Invalid "+chainIdentifier+" address");
         recipient = this._chains[chainIdentifier].chainInterface.normalizeAddress(recipient);
         const amountData = {
@@ -1331,6 +1333,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         options?: FromBTCLNAutoOptions
     ): Promise<FromBTCLNAutoSwap<T[ChainIdentifier]>> {
         if(this._chains[chainIdentifier]==null) throw new Error("Invalid chain identifier! Unknown chain: "+chainIdentifier);
+        if(this._chains[chainIdentifier].wrappers[SwapType.FROM_BTCLN_AUTO]==null) throw new Error("Chain "+chainIdentifier+" doesn't support new lightning swap protocol (from btcln auto)!");
         if(typeof(lnurl)==="string" && !this.Utils.isValidLNURL(lnurl)) throw new Error("Invalid LNURL-withdraw link");
         if(!this._chains[chainIdentifier].chainInterface.isValidAddress(recipient, true)) throw new Error("Invalid "+chainIdentifier+" address");
         recipient = this._chains[chainIdentifier].chainInterface.normalizeAddress(recipient);

--- a/src/swapper/SwapperUtils.ts
+++ b/src/swapper/SwapperUtils.ts
@@ -404,7 +404,9 @@ export class SwapperUtils<T extends MultiChain> {
         feeRate?: any
     }): Promise<TokenAmount> {
         if(this.root._chains[token.chainId]==null) throw new Error("Invalid chain identifier! Unknown chain: "+token.chainId);
-        const {swapContract, chainInterface} = this.root._chains[token.chainId];
+        const {defaultVersion, versionedContracts, chainInterface} = this.root._chains[token.chainId];
+
+        const {swapContract} = versionedContracts[defaultVersion];
 
         let signer: string;
         if(typeof(wallet)==="string") {

--- a/src/swapper/SwapperUtils.ts
+++ b/src/swapper/SwapperUtils.ts
@@ -455,6 +455,18 @@ export class SwapperUtils<T extends MultiChain> {
     }
 
     /**
+     * Returns whether when swapping to the provided token a gas drop can be requested
+     *
+     * @param token
+     */
+    destinationTokenSupportsGasDrop<ChainIdentifier extends ChainIds<T>>(token: SCToken<ChainIdentifier>): boolean {
+        if(this.root._chains[token.chainId]==null) throw new Error("Invalid chain identifier! Unknown chain: "+token.chainId);
+        const {chainInterface} = this.root._chains[token.chainId];
+        if(chainInterface.shouldGetNativeTokenDrop!=null) return chainInterface.shouldGetNativeTokenDrop(token.address);
+        return chainInterface.getNativeCurrencyAddress() !== token.address;
+    }
+
+    /**
      * Returns a random signer for a given smart chain
      *
      * @param chainIdentifier

--- a/src/swaps/ISwap.ts
+++ b/src/swaps/ISwap.ts
@@ -25,7 +25,8 @@ export type ISwapInit = {
     expiry: number,
     swapFee: bigint,
     swapFeeBtc: bigint,
-    exactIn: boolean
+    exactIn: boolean,
+    contractVersion: string
 };
 
 /**
@@ -140,6 +141,10 @@ export abstract class ISwap<
      * @internal
      */
     _persisted: boolean = false;
+    /**
+     * @internal
+     */
+    _contractVersion?: string;
 
 
     /**
@@ -181,6 +186,7 @@ export abstract class ISwap<
             this.version = this.currentVersion;
             this.createdAt = Date.now();
             this._randomNonce = randomBytes(16).toString("hex");
+            this._contractVersion = swapInitOrObj.contractVersion;
         } else {
             this.expiry = swapInitOrObj.expiry;
             this.url = swapInitOrObj.url;
@@ -211,6 +217,7 @@ export abstract class ISwap<
             this.createdAt = swapInitOrObj.createdAt ?? swapInitOrObj.expiry;
 
             this._randomNonce = swapInitOrObj.randomNonce;
+            this._contractVersion = swapInitOrObj.contractVersion;
         }
         if(this.version!==this.currentVersion) {
             this.upgradeVersion();
@@ -648,7 +655,8 @@ export abstract class ISwap<
             initiated: this.initiated,
             exactIn: this.exactIn,
             createdAt: this.createdAt,
-            randomNonce: this._randomNonce
+            randomNonce: this._randomNonce,
+            contractVersion: this._contractVersion
         }
     }
 

--- a/src/swaps/escrow_swaps/IEscrowSelfInitSwap.ts
+++ b/src/swaps/escrow_swaps/IEscrowSelfInitSwap.ts
@@ -89,7 +89,7 @@ export abstract class IEscrowSelfInitSwap<
         while(!expired) {
             await timeoutPromise(intervalSeconds*1000, abortSignal);
             try {
-                expired = await this.wrapper._contract.isInitAuthorizationExpired(this._data, this.signatureData);
+                expired = await this._contract.isInitAuthorizationExpired(this._data, this.signatureData);
             } catch (e) {
                 this.logger.error("watchdogWaitTillSignatureExpiry(): Error when checking signature expiry: ", e);
             }
@@ -106,14 +106,14 @@ export abstract class IEscrowSelfInitSwap<
      * @internal
      */
     protected getCommitFee(): Promise<bigint> {
-        return this.wrapper._contract.getCommitFee(this._getInitiator(), this.getSwapData(), this.feeRate);
+        return this._contract.getCommitFee(this._getInitiator(), this.getSwapData(), this.feeRate);
     }
 
     /**
      * Returns the transaction fee paid on the smart chain side to initiate the escrow
      */
     async getSmartChainNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>> {
-        const swapContract: T["Contract"] = this.wrapper._contract;
+        const swapContract: T["Contract"] = this._contract;
         return toTokenAmount(
             await (
                 swapContract.getRawCommitFee!=null ?
@@ -178,7 +178,7 @@ export abstract class IEscrowSelfInitSwap<
     async _verifyQuoteDefinitelyExpired(): Promise<boolean> {
         if(this._data==null || this.signatureData==null) throw new Error("data or signature data are null!");
 
-        return this.wrapper._contract.isInitAuthorizationExpired(
+        return this._contract.isInitAuthorizationExpired(
             this._data!, this.signatureData!
         );
     }
@@ -190,7 +190,7 @@ export abstract class IEscrowSelfInitSwap<
         if(this._data==null || this.signatureData==null) throw new Error("data or signature data are null!");
 
         try {
-            await this.wrapper._contract.isValidInitAuthorization(
+            await this._contract.isValidInitAuthorization(
                 this._getInitiator(), this._data!, this.signatureData!, this.feeRate
             );
             return true;

--- a/src/swaps/escrow_swaps/IEscrowSwap.ts
+++ b/src/swaps/escrow_swaps/IEscrowSwap.ts
@@ -50,6 +50,11 @@ export abstract class IEscrowSwap<
      */
     _claimTxId?: string;
 
+    /**
+     * @internal
+     */
+    protected _contract: T["Contract"];
+
     protected constructor(wrapper: D["Wrapper"], obj: any);
     protected constructor(wrapper: D["Wrapper"], swapInit: IEscrowSwapInit<T["Data"]>);
     protected constructor(
@@ -61,12 +66,14 @@ export abstract class IEscrowSwap<
         if(isIEscrowSwapInit(swapInitOrObj)) {
             this._data = swapInitOrObj.data;
         } else {
-            if(swapInitOrObj.data!=null) this._data = new wrapper._swapDataDeserializer(swapInitOrObj.data);
+            if(swapInitOrObj.data!=null) this._data = new (wrapper._swapDataDeserializer(this._contractVersion))(swapInitOrObj.data);
 
             this._commitTxId = swapInitOrObj.commitTxId;
             this._claimTxId = swapInitOrObj.claimTxId;
             this._refundTxId = swapInitOrObj.refundTxId;
         }
+
+        this._contract = wrapper._contract(this._contractVersion);
     }
 
     /**
@@ -170,7 +177,7 @@ export abstract class IEscrowSwap<
         while(status?.type===SwapCommitStateType.NOT_COMMITED) {
             await timeoutPromise(intervalSeconds*1000, abortSignal);
             try {
-                status = await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data);
+                status = await this._contract.getCommitStatus(this._getInitiator(), this._data);
                 if(
                     status?.type===SwapCommitStateType.NOT_COMMITED &&
                     await this._verifyQuoteDefinitelyExpired()
@@ -200,7 +207,7 @@ export abstract class IEscrowSwap<
         while(status?.type===SwapCommitStateType.COMMITED || status?.type===SwapCommitStateType.REFUNDABLE) {
             await timeoutPromise(intervalSeconds*1000, abortSignal);
             try {
-                status = await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data);
+                status = await this._contract.getCommitStatus(this._getInitiator(), this._data);
             } catch (e) {
                 this.logger.error("watchdogWaitTillResult(): Error when fetching commit status: ", e);
             }

--- a/src/swaps/escrow_swaps/IEscrowSwapWrapper.ts
+++ b/src/swaps/escrow_swaps/IEscrowSwapWrapper.ts
@@ -34,46 +34,68 @@ export abstract class IEscrowSwapWrapper<
     /**
      * @internal
      */
-    readonly _contract: T["Contract"];
+    readonly _contract: (version?: string) => T["Contract"] = (version?: string) => {
+        const _version = version ?? "v1";
+        const data = this._versionedContracts[_version];
+        if(data==null) throw new Error(`Invalid contract version ${_version} requested`);
+        return data.swapContract;
+    };
     /**
      * @internal
      */
-    readonly _swapDataDeserializer: new (data: any) => T["Data"];
+    readonly _swapDataDeserializer: (version?: string) => new (data: any) => T["Data"] = (version?: string) => {
+        const _version = version ?? "v1";
+        const data = this._versionedContracts[_version];
+        if(data==null) throw new Error(`Invalid contract version ${_version} requested`);
+        return data.swapDataConstructor;
+    };
+
+    //TODO: Properly populate in constructor
+    readonly _versionedContracts: {
+        [version: string]: {
+            swapContract: T["Contract"],
+            swapDataConstructor: new (data: any) => T["Data"]
+        }
+    } = {};
 
     constructor(
         chainIdentifier: string,
         unifiedStorage: UnifiedSwapStorage<T>,
         unifiedChainEvents: UnifiedSwapEventListener<T>,
         chain: T["ChainInterface"],
-        contract: T["Contract"],
         prices: ISwapPrice,
         tokens: WrapperCtorTokens,
-        swapDataDeserializer: new (data: any) => T["Data"],
         options: O,
+        versionedContracts: {
+            [version: string]: {
+                swapContract: T["Contract"],
+                swapDataConstructor: new (data: any) => T["Data"]
+            }
+        },
         events?: EventEmitter<{swapState: [ISwap]}>
     ) {
         super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, options, events);
-        this._swapDataDeserializer = swapDataDeserializer;
-        this._contract = contract;
+        this._versionedContracts = versionedContracts;
     }
 
     /**
      * Pre-fetches signature verification data from the server's pre-sent promise, doesn't throw, instead returns null
      *
      * @param signDataPrefetch Promise that resolves when we receive "signDataPrefetch" from the LP in streaming mode
+     * @param contractVersion
      * @returns Pre-fetched signature verification data or null if failed
      *
      * @internal
      */
-    protected preFetchSignData(signDataPrefetch: Promise<any | null>): Promise<T["PreFetchVerification"] | undefined> {
-        if(this._contract.preFetchForInitSignatureVerification==null) {
+    protected preFetchSignData(signDataPrefetch: Promise<any | null>, contractVersion: string): Promise<T["PreFetchVerification"] | undefined> {
+        if(this._contract(contractVersion).preFetchForInitSignatureVerification==null) {
             // Catch promise rejections, should they happen
             signDataPrefetch.catch(() => {});
             return Promise.resolve(undefined);
         }
         return signDataPrefetch.then(obj => {
             if(obj==null) return undefined;
-            return this._contract.preFetchForInitSignatureVerification!(obj);
+            return this._contract(contractVersion).preFetchForInitSignatureVerification!(obj);
         }).catch(e => {
             this.logger.error("preFetchSignData(): Error: ", e);
         });
@@ -87,6 +109,7 @@ export abstract class IEscrowSwapWrapper<
      * @param signature Response of the intermediary
      * @param feeRatePromise Pre-fetched fee rate promise
      * @param preFetchSignatureVerificationData Pre-fetched signature verification data
+     * @param contractVersion
      * @param abortSignal
      * @returns Swap initialization signature expiry
      * @throws {SignatureVerificationError} when swap init signature is invalid
@@ -99,11 +122,12 @@ export abstract class IEscrowSwapWrapper<
         signature: SignatureData,
         feeRatePromise: Promise<any>,
         preFetchSignatureVerificationData: Promise<any>,
-        abortSignal?: AbortSignal
+        contractVersion: string,
+        abortSignal?: AbortSignal,
     ): Promise<number> {
         const [feeRate, preFetchedSignatureData] = await Promise.all([feeRatePromise, preFetchSignatureVerificationData]);
-        await this._contract.isValidInitAuthorization(initiator, data, signature, feeRate, preFetchedSignatureData);
-        return await this._contract.getInitAuthorizationExpiry(data, signature, preFetchedSignatureData);
+        await this._contract(contractVersion).isValidInitAuthorization(initiator, data, signature, feeRate, preFetchedSignatureData);
+        return await this._contract(contractVersion).getInitAuthorizationExpiry(data, signature, preFetchedSignatureData);
     }
 
     /**
@@ -186,7 +210,7 @@ export abstract class IEscrowSwapWrapper<
 
         const swapExpiredStatus: {[id: string]: boolean} = {};
 
-        const checkStatusSwaps: (D["Swap"] & {_data: T["Data"]})[] = [];
+        const checkStatusSwaps: {[contractVersion: string]: (D["Swap"] & {_data: T["Data"]})[]} = {};
 
         for(let pastSwap of pastSwaps) {
             if(pastSwap._shouldFetchExpiryStatus()) {
@@ -195,24 +219,37 @@ export abstract class IEscrowSwapWrapper<
             }
             if(pastSwap._shouldFetchOnchainState()) {
                 //Add to swaps for which status should be checked
-                if(pastSwap._data!=null) checkStatusSwaps.push(pastSwap as (D["Swap"] & {_data: T["Data"]}));
+                if(pastSwap._data!=null) (checkStatusSwaps[pastSwap._contractVersion ?? "v1"] ??= []).push(pastSwap as (D["Swap"] & {_data: T["Data"]}));
             }
         }
 
-        const swapStatuses = await this._contract.getCommitStatuses(checkStatusSwaps.map(val => ({signer: val._getInitiator(), swapData: val._data})));
+        for(let version in checkStatusSwaps) {
+            if(this._versionedContracts[version]==null) {
+                this.logger.warn(`_checkPastSwaps(): No contract was found for ${this.chainIdentifier} version ${version}! Skipping these swaps!`);
+                continue;
+            }
 
-        for(let pastSwap of checkStatusSwaps) {
-            const escrowHash = pastSwap.getEscrowHash();
-            const shouldSave = await pastSwap._sync(
-                false,
-                swapExpiredStatus[pastSwap.getId()],
-                escrowHash==null ? undefined : swapStatuses[escrowHash]
+            const _checkStatusSwap = checkStatusSwaps[version];
+            const swapStatuses = await this._contract(version).getCommitStatuses(
+                _checkStatusSwap.map(val => ({
+                    signer: val._getInitiator(),
+                    swapData: val._data
+                }))
             );
-            if(shouldSave) {
-                if(pastSwap.isQuoteExpired()) {
-                    removeSwaps.push(pastSwap);
-                } else {
-                    changedSwaps.push(pastSwap);
+
+            for(let pastSwap of _checkStatusSwap) {
+                const escrowHash = pastSwap.getEscrowHash();
+                const shouldSave = await pastSwap._sync(
+                    false,
+                    swapExpiredStatus[pastSwap.getId()],
+                    escrowHash==null ? undefined : swapStatuses[escrowHash]
+                );
+                if(shouldSave) {
+                    if(pastSwap.isQuoteExpired()) {
+                        removeSwaps.push(pastSwap);
+                    } else {
+                        changedSwaps.push(pastSwap);
+                    }
                 }
             }
         }
@@ -239,6 +276,7 @@ export abstract class IEscrowSwapWrapper<
             getTxBlock: () => Promise<{blockTime: number, blockHeight: number}>
         },
         state: SwapCommitState,
+        contractVersion: string,
         lp?: Intermediary
     ): Promise<D["Swap"] | null>;
 

--- a/src/swaps/escrow_swaps/frombtc/IFromBTCLNWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/IFromBTCLNWrapper.ts
@@ -38,10 +38,9 @@ export abstract class IFromBTCLNWrapper<
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Swap pricing handler
      * @param tokens
-     * @param swapDataDeserializer Deserializer for SwapData
+     * @param versionedContracts
      * @param lnApi
      * @param options
      * @param events Instance to use for emitting events
@@ -51,15 +50,19 @@ export abstract class IFromBTCLNWrapper<
         unifiedStorage: UnifiedSwapStorage<T>,
         unifiedChainEvents: UnifiedSwapEventListener<T>,
         chain: T["ChainInterface"],
-        contract: T["Contract"],
         prices: ISwapPrice,
         tokens: WrapperCtorTokens,
-        swapDataDeserializer: new (data: any) => T["Data"],
+        versionedContracts: {
+            [version: string]: {
+                swapContract: T["Contract"],
+                swapDataConstructor: new (data: any) => T["Data"]
+            }
+        },
         lnApi: LightningNetworkApi,
         options: O,
         events?: EventEmitter<{swapState: [IEscrowSwap]}>
     ) {
-        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, options, events);
+        super(chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, options, versionedContracts, events);
         this.lnApi = lnApi;
     }
 

--- a/src/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/IFromBTCSelfInitSwap.ts
@@ -196,7 +196,7 @@ export abstract class IFromBTCSelfInitSwap<
         required: TokenAmount<SCToken<T["ChainId"]>, true>
     }> {
         const [balance, commitFee] = await Promise.all([
-            this.wrapper._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
+            this._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
             this.getCommitFee()
         ]);
         const totalFee = commitFee + this.getSwapData().getTotalDeposit();
@@ -247,7 +247,7 @@ export abstract class IFromBTCSelfInitSwap<
             await this._saveAndEmit();
         }
 
-        return await this.wrapper._contract.txsInit(
+        return await this._contract.txsInit(
             this._getInitiator(), this._data, this.signatureData, skipChecks, this.feeRate
         ).catch(e => Promise.reject(e instanceof SignatureVerificationError ? new Error("Request timed out") : e));
     }
@@ -274,7 +274,7 @@ export abstract class IFromBTCSelfInitSwap<
      *  smart chain
      */
     async getClaimNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>> {
-        const swapContract: T["Contract"] = this.wrapper._contract;
+        const swapContract: T["Contract"] = this._contract;
         return toTokenAmount(
             await swapContract.getClaimFee(this._getInitiator(), this.getSwapData()),
             this.wrapper._getNativeToken(),

--- a/src/swaps/escrow_swaps/frombtc/IFromBTCWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/IFromBTCWrapper.ts
@@ -1,7 +1,7 @@
 import {ISwapWrapperOptions} from "../../ISwapWrapper";
 import {Intermediary} from "../../../intermediaries/Intermediary";
 import {IntermediaryError} from "../../../errors/IntermediaryError";
-import {randomBytes} from "../../../utils/Utils";
+import {mapArrayToObject, randomBytes} from "../../../utils/Utils";
 import {BigIntBufferUtils, ChainType} from "@atomiqlabs/base";
 import {IEscrowSwapDefinition, IEscrowSwapWrapper} from "../IEscrowSwapWrapper";
 import {IEscrowSwap} from "../IEscrowSwap";
@@ -39,6 +39,7 @@ export abstract class IFromBTCWrapper<
      * @param claimHash optional claim hash of the swap or null
      * @param abortController
      *
+     * @param contractVersions
      * @returns Fee rate
      *
      * @internal
@@ -46,15 +47,18 @@ export abstract class IFromBTCWrapper<
     protected preFetchFeeRate(
         signer: string,
         amountData: AmountData,
-        claimHash: string | undefined,
-        abortController: AbortController
-    ): Promise<string | undefined> {
-        return this._contract.getInitFeeRate(this._chain.randomAddress(), signer, amountData.token, claimHash)
-            .catch(e => {
-                this.logger.warn("preFetchFeeRate(): Error: ", e);
-                abortController.abort(e);
-                return undefined;
-            });
+        claimHash: {[contractVersion: string]: string} | undefined,
+        abortController: AbortController,
+        contractVersions: string[]
+    ): {[contractVersion: string]: Promise<string | undefined>} {
+        return mapArrayToObject(contractVersions, (contractVersion) => {
+            return this._contract(contractVersion).getInitFeeRate(this._chain.randomAddress(), signer, amountData.token, claimHash?.[contractVersion])
+                .catch(e => {
+                    this.logger.warn("preFetchFeeRate(): Error: ", e);
+                    abortController.abort(e);
+                    return undefined;
+                });
+        });
     }
 
     /**
@@ -64,12 +68,18 @@ export abstract class IFromBTCWrapper<
      * @param lp Intermediary
      * @param abortController
      *
+     * @param contractVersion
      * @returns Intermediary's liquidity balance
      *
      * @internal
      */
-    protected preFetchIntermediaryLiquidity(amountData: AmountData, lp: Intermediary, abortController: AbortController): Promise<bigint | undefined> {
-        return lp.getLiquidity(this.chainIdentifier, this._contract, amountData.token.toString(), abortController.signal).catch(e => {
+    protected preFetchIntermediaryLiquidity(
+        amountData: AmountData,
+        lp: Intermediary,
+        abortController: AbortController,
+        contractVersion: string
+    ): Promise<bigint | undefined> {
+        return lp.getLiquidity(this.chainIdentifier, this._contract(contractVersion), amountData.token.toString(), abortController.signal).catch(e => {
             this.logger.warn("preFetchIntermediaryLiquidity(): Error: ", e);
             abortController.abort(e);
             return undefined;

--- a/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNSwap.ts
@@ -474,16 +474,16 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
         required: TokenAmount<SCToken<T["ChainId"]>, true>
     }> {
         const [balance, feeRate] = await Promise.all([
-            this.wrapper._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
-            this.feeRate!=null ? Promise.resolve<string>(this.feeRate) : this.wrapper._contract.getInitFeeRate(
+            this._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
+            this.feeRate!=null ? Promise.resolve<string>(this.feeRate) : this._contract.getInitFeeRate(
                 this.getSwapData().getOfferer(),
                 this.getSwapData().getClaimer(),
                 this.getSwapData().getToken(),
                 this.getSwapData().getClaimHash()
             )
         ]);
-        const commitFee = await this.wrapper._contract.getCommitFee(this._getInitiator(), this.getSwapData(), feeRate);
-        const claimFee = await this.wrapper._contract.getClaimFee(this._getInitiator(), this.getSwapData(), feeRate);
+        const commitFee = await this._contract.getCommitFee(this._getInitiator(), this.getSwapData(), feeRate);
+        const claimFee = await this._contract.getClaimFee(this._getInitiator(), this.getSwapData(), feeRate);
         const totalFee = commitFee + claimFee + this.getSwapData().getTotalDeposit();
         return {
             enoughBalance: balance >= totalFee,
@@ -494,7 +494,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
 
     private isValidSecretPreimage(secret: string) {
         const paymentHash = Buffer.from(sha256(Buffer.from(secret, "hex")));
-        const claimHash = this.wrapper._contract.getHashForHtlc(paymentHash).toString("hex");
+        const claimHash = this._contract.getHashForHtlc(paymentHash).toString("hex");
         return this.getSwapData().getClaimHash()===claimHash;
     }
 
@@ -716,10 +716,10 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
         const resp = await IntermediaryAPI.getPaymentAuthorization(this.url, paymentHash.toString("hex"));
         switch(resp.code) {
             case PaymentAuthorizationResponseCodes.AUTH_DATA:
-                const data = new this.wrapper._swapDataDeserializer(resp.data.data);
+                const data = new (this.wrapper._swapDataDeserializer(this._contractVersion))(resp.data.data);
                 try {
                     await this.checkIntermediaryReturnedAuthData(this._getInitiator(), data, resp.data);
-                    this.expiry = await this.wrapper._contract.getInitAuthorizationExpiry(
+                    this.expiry = await this._contract.getInitAuthorizationExpiry(
                         data,
                         resp.data
                     );
@@ -773,8 +773,8 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
         if (data.hasSuccessAction()) throw new IntermediaryError("Invalid has success action");
 
         await Promise.all([
-            this.wrapper._contract.isValidInitAuthorization(this._getInitiator(), data, signature, this.feeRate),
-            this.wrapper._contract.getCommitStatus(data.getClaimer(), data)
+            this._contract.isValidInitAuthorization(this._getInitiator(), data, signature, this.feeRate),
+            this._contract.getCommitStatus(data.getClaimer(), data)
                 .then(status => {
                     if (status?.type !== SwapCommitStateType.NOT_COMMITED)
                         throw new Error("Swap already committed on-chain!");
@@ -846,9 +846,9 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
 
         if(resp.code===PaymentAuthorizationResponseCodes.AUTH_DATA) {
             const sigData = resp.data;
-            const swapData = new this.wrapper._swapDataDeserializer(resp.data.data);
+            const swapData = new (this.wrapper._swapDataDeserializer(this._contractVersion))(resp.data.data);
             await this.checkIntermediaryReturnedAuthData(this._getInitiator(), swapData, sigData);
-            this.expiry = await this.wrapper._contract.getInitAuthorizationExpiry(
+            this.expiry = await this._contract.getInitAuthorizationExpiry(
                 swapData,
                 sigData
             );
@@ -972,7 +972,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
         if(!this.isValidSecretPreimage(useSecret))
             throw new Error("Invalid swap secret pre-image provided!");
 
-        return this.wrapper._contract.txsClaimWithSecret(
+        return this._contract.txsClaimWithSecret(
             address ?? this._getInitiator(),
             this._data, useSecret, true, true
         );
@@ -1092,7 +1092,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
      *  to settle the swap on the smart chain destination side.
      */
     async getCommitAndClaimNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>> {
-        const swapContract: T["Contract"] = this.wrapper._contract;
+        const swapContract: T["Contract"] = this._contract;
         const feeRate = this.feeRate ?? await swapContract.getInitFeeRate(
             this.getSwapData().getOfferer(),
             this.getSwapData().getClaimer(),
@@ -1123,7 +1123,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
      *  call {@link commit} first and then {@link claim}.
      */
     canCommitAndClaimInOneShot(): boolean {
-        return this.wrapper._contract.initAndClaimWithSecret!=null;
+        return this._contract.initAndClaimWithSecret!=null;
     }
 
     /**
@@ -1154,7 +1154,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
             throw new Error("Invalid swap secret pre-image provided!");
 
         const initTxs = await this.txsCommit(skipChecks);
-        const claimTxs = await this.wrapper._contract.txsClaimWithSecret(
+        const claimTxs = await this._contract.txsClaimWithSecret(
             this._getInitiator(), this._data, useSecret,
             true, true, undefined,
             true
@@ -1311,7 +1311,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
             }
 
             //Check if it's already successfully paid
-            commitStatus ??= await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data!);
+            commitStatus ??= await this._contract.getCommitStatus(this._getInitiator(), this._data!);
             if(commitStatus!=null && await this._forciblySetOnchainState(commitStatus)) return true;
 
             //Set the state on expiry here
@@ -1382,7 +1382,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
         if(await this.syncStateFromChain(quoteDefinitelyExpired, commitStatus)) changed = true;
 
         if(this._state===FromBTCLNSwapState.CLAIM_COMMITED) {
-            const expired = await this.wrapper._contract.isExpired(this._getInitiator(), this._data!);
+            const expired = await this._contract.isExpired(this._getInitiator(), this._data!);
             if(expired) {
                 this._state = FromBTCLNSwapState.EXPIRED;
                 changed = true;
@@ -1447,7 +1447,7 @@ export class FromBTCLNSwap<T extends ChainType = ChainType>
                 }
                 break;
             case FromBTCLNSwapState.CLAIM_COMMITED:
-                const expired = await this.wrapper._contract.isExpired(this._getInitiator(), this._data!);
+                const expired = await this._contract.isExpired(this._getInitiator(), this._data!);
                 if(expired) {
                     this._state = FromBTCLNSwapState.EXPIRED;
                     if(save) await this._saveAndEmit();

--- a/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln/FromBTCLNWrapper.ts
@@ -13,7 +13,7 @@ import {UserError} from "../../../../errors/UserError";
 import {IntermediaryError} from "../../../../errors/IntermediaryError";
 import {SwapType} from "../../../../enums/SwapType";
 import {
-    extendAbortController, parseHashValueExact32Bytes,
+    extendAbortController, mapArrayToObject, parseHashValueExact32Bytes,
     throwIfUndefined
 } from "../../../../utils/Utils";
 import {FromBTCLNResponseType, IntermediaryAPI} from "../../../../intermediaries/apis/IntermediaryAPI";
@@ -113,10 +113,9 @@ export class FromBTCLNWrapper<
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Swap pricing handler
      * @param tokens
-     * @param swapDataDeserializer Deserializer for SwapData
+     * @param versionedContracts
      * @param lnApi
      * @param options
      * @param events Instance to use for emitting events
@@ -126,16 +125,20 @@ export class FromBTCLNWrapper<
         unifiedStorage: UnifiedSwapStorage<T>,
         unifiedChainEvents: UnifiedSwapEventListener<T>,
         chain: T["ChainInterface"],
-        contract: T["Contract"],
         prices: ISwapPrice,
         tokens: WrapperCtorTokens,
-        swapDataDeserializer: new (data: any) => T["Data"],
+        versionedContracts: {
+            [version: string]: {
+                swapContract: T["Contract"],
+                swapDataConstructor: new (data: any) => T["Data"]
+            }
+        },
         lnApi: LightningNetworkApi,
         options?: AllOptional<FromBTCLNWrapperOptions>,
         events?: EventEmitter<{swapState: [ISwap]}>
     ) {
         super(
-            chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, lnApi,
+            chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, versionedContracts, lnApi,
             {
                 ...options,
                 safetyFactor: options?.safetyFactor ?? 2,
@@ -254,8 +257,8 @@ export class FromBTCLNWrapper<
         abortSignal?: AbortSignal,
         preFetches?: {
             usdPricePrefetchPromise: Promise<number | undefined>,
-            pricePrefetchPromise?: Promise<bigint | undefined>,
-            feeRatePromise?: Promise<string | undefined>
+            pricePrefetchPromise: Promise<bigint | undefined>,
+            feeRatePromise: {[contractVersion: string]: Promise<string | undefined>},
         }
     ): {
         quote: Promise<FromBTCLNSwap<T>>,
@@ -273,6 +276,8 @@ export class FromBTCLNWrapper<
         if(_options.description!=null && Buffer.byteLength(_options.description, "utf8") > 500)
             throw new UserError("Invalid description length");
 
+        const lpVersions = Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
+
         let secret: Buffer | undefined;
         let paymentHash: Buffer;
         if(_options.paymentHash!=null) {
@@ -280,15 +285,17 @@ export class FromBTCLNWrapper<
         } else {
             ({secret, paymentHash} = this.getSecretAndHash());
         }
-        const claimHash = this._contract.getHashForHtlc(paymentHash);
+        const _hash = mapArrayToObject(lpVersions, (contractVersion: string) => {
+            return this._contract(contractVersion).getHashForHtlc(paymentHash).toString("hex");
+        });
 
         const nativeTokenAddress = this._chain.getNativeCurrencyAddress();
 
         const _abortController = extendAbortController(abortSignal);
-        const _preFetches = {
-            pricePrefetchPromise: preFetches?.pricePrefetchPromise ?? this.preFetchPrice(amountData, _abortController.signal),
-            feeRatePromise: preFetches?.feeRatePromise ?? this.preFetchFeeRate(recipient, amountData, claimHash.toString("hex"), _abortController),
-            usdPricePrefetchPromise: preFetches?.usdPricePrefetchPromise ?? this.preFetchUsdPrice(_abortController.signal),
+        const _preFetches = preFetches ?? {
+            pricePrefetchPromise: this.preFetchPrice(amountData, _abortController.signal),
+            feeRatePromise: this.preFetchFeeRate(recipient, amountData, _hash, _abortController, lpVersions),
+            usdPricePrefetchPromise: this.preFetchUsdPrice(_abortController.signal),
         }
 
         return lps.map(lp => {
@@ -296,10 +303,11 @@ export class FromBTCLNWrapper<
                 intermediary: lp,
                 quote: (async () => {
                     if(lp.services[SwapType.FROM_BTCLN]==null) throw new Error("LP service for processing from btcln swaps not found!");
+                    const version = lp.getContractVersion(this.chainIdentifier);
 
                     const abortController = extendAbortController(_abortController.signal);
 
-                    const liquidityPromise: Promise<bigint | undefined> = this.preFetchIntermediaryLiquidity(amountData, lp, abortController);
+                    const liquidityPromise: Promise<bigint | undefined> = this.preFetchIntermediaryLiquidity(amountData, lp, abortController, version);
 
                     const {lnCapacityPromise, resp} = await tryWithRetries(async(retryCount: number) => {
                         const {lnPublicKey, response} = IntermediaryAPI.initFromBTCLN(
@@ -312,7 +320,7 @@ export class FromBTCLNWrapper<
                                 description: _options.description,
                                 descriptionHash: _options.descriptionHash,
                                 exactOut: !amountData.exactIn,
-                                feeRate: throwIfUndefined(_preFetches.feeRatePromise),
+                                feeRate: throwIfUndefined(_preFetches.feeRatePromise[version]),
                                 additionalParams
                             },
                             this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined
@@ -353,16 +361,17 @@ export class FromBTCLNWrapper<
                             expiry: decodedPr.timeExpireDate*1000,
                             swapFee: resp.swapFee,
                             swapFeeBtc,
-                            feeRate: (await _preFetches.feeRatePromise)!,
-                            initialSwapData: await this._contract.createSwapData(
+                            feeRate: (await _preFetches.feeRatePromise[version])!,
+                            initialSwapData: await this._contract(version).createSwapData(
                                 ChainSwapType.HTLC, lp.getAddress(this.chainIdentifier), recipient, amountData.token,
-                                resp.total, claimHash.toString("hex"),
+                                resp.total, _hash[version],
                                 this.getRandomSequence(), BigInt(Math.floor(Date.now()/1000)), false, true,
                                 resp.securityDeposit, 0n, nativeTokenAddress
                             ),
                             pr: resp.pr,
                             secret: secret?.toString("hex"),
-                            exactIn: amountData.exactIn ?? true
+                            exactIn: amountData.exactIn ?? true,
+                            contractVersion: version
                         } as FromBTCLNSwapInit<T["Data"]>);
                         return quote;
                     } catch (e) {
@@ -410,11 +419,13 @@ export class FromBTCLNWrapper<
             unsafeSkipLnNodeCheck: options?.unsafeSkipLnNodeCheck ?? this._options.unsafeSkipLnNodeCheck
         };
 
+        const lpVersions = Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
+
         const abortController = extendAbortController(abortSignal);
         const preFetches = {
             pricePrefetchPromise: this.preFetchPrice(amountData, abortController.signal),
             usdPricePrefetchPromise: this.preFetchUsdPrice(abortController.signal),
-            feeRatePromise: this.preFetchFeeRate(recipient, amountData, undefined, abortController)
+            feeRatePromise: this.preFetchFeeRate(recipient, amountData, undefined, abortController, lpVersions)
         };
 
         try {
@@ -476,7 +487,7 @@ export class FromBTCLNWrapper<
         const changedSwapSet: Set<FromBTCLNSwap<T>> = new Set();
 
         const swapExpiredStatus: {[id: string]: boolean} = {};
-        const checkStatusSwaps: (FromBTCLNSwap<T> & {_data: T["Data"]})[] = [];
+        const checkStatusSwaps: {[contractVersion: string]: (FromBTCLNSwap<T> & {_data: T["Data"]})[]} = {};
 
         await Promise.all(pastSwaps.map(async (pastSwap) => {
             if(pastSwap._shouldCheckIntermediary()) {
@@ -495,19 +506,27 @@ export class FromBTCLNWrapper<
             }
             if(pastSwap._shouldFetchOnchainState()) {
                 //Add to swaps for which status should be checked
-                if(pastSwap._data!=null) checkStatusSwaps.push(pastSwap as (FromBTCLNSwap<T> & {_data: T["Data"]}));
+                if(pastSwap._data!=null) (checkStatusSwaps[pastSwap._contractVersion ?? "v1"] ??= []).push(pastSwap as (FromBTCLNSwap<T> & {_data: T["Data"]}));
             }
         }));
 
-        const swapStatuses = await this._contract.getCommitStatuses(checkStatusSwaps.map(val => ({signer: val._getInitiator(), swapData: val._data})));
+        for(let version in checkStatusSwaps) {
+            if(this._versionedContracts[version]==null) {
+                this.logger.warn(`_checkPastSwaps(): No contract was found for ${this.chainIdentifier} version ${version}! Skipping these swaps!`);
+                continue;
+            }
 
-        for(let pastSwap of checkStatusSwaps) {
-            const shouldSave = await pastSwap._sync(
-                false, swapExpiredStatus[pastSwap.getId()],
-                swapStatuses[pastSwap.getEscrowHash()!], true
-            );
-            if(shouldSave) {
-                changedSwapSet.add(pastSwap);
+            const _checkStatusSwap = checkStatusSwaps[version];
+            const swapStatuses = await this._contract(version).getCommitStatuses(_checkStatusSwap.map(val => ({signer: val._getInitiator(), swapData: val._data})));
+
+            for(let pastSwap of _checkStatusSwap) {
+                const shouldSave = await pastSwap._sync(
+                    false, swapExpiredStatus[pastSwap.getId()],
+                    swapStatuses[pastSwap.getEscrowHash()!], true
+                );
+                if(shouldSave) {
+                    changedSwapSet.add(pastSwap);
+                }
             }
         }
 
@@ -534,6 +553,7 @@ export class FromBTCLNWrapper<
     async recoverFromSwapDataAndState(
         init: {data: T["Data"], getInitTxId: () => Promise<string>, getTxBlock: () => Promise<{blockTime: number, blockHeight: number}>},
         state: SwapCommitState,
+        contractVersion: string,
         lp?: Intermediary
     ): Promise<FromBTCLNSwap<T> | null> {
         const data = init.data;
@@ -564,7 +584,8 @@ export class FromBTCLNWrapper<
             data,
             pr: paymentHash ?? undefined,
             secret,
-            exactIn: false
+            exactIn: false,
+            contractVersion
         }
         const swap = new FromBTCLNSwap(this, swapInit);
         swap._commitTxId = await init.getInitTxId();

--- a/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoSwap.ts
@@ -731,7 +731,7 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
 
     private isValidSecretPreimage(secret: string) {
         const paymentHash = Buffer.from(sha256(Buffer.from(secret, "hex")));
-        const claimHash = this.wrapper._contract.getHashForHtlc(paymentHash).toString("hex");
+        const claimHash = this._contract.getHashForHtlc(paymentHash).toString("hex");
         return this.getSwapData().getClaimHash()===claimHash;
     }
 
@@ -917,7 +917,7 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
         const resp = await IntermediaryAPI.getInvoiceStatus(this.url, paymentHash.toString("hex"));
         switch(resp.code) {
             case InvoiceStatusResponseCodes.PAID:
-                const data = new this.wrapper._swapDataDeserializer(resp.data.data);
+                const data = new (this.wrapper._swapDataDeserializer(this._contractVersion))(resp.data.data);
                 if(this._state===FromBTCLNAutoSwapState.PR_CREATED || this._state===FromBTCLNAutoSwapState.QUOTE_SOFT_EXPIRED) try {
                     await this._saveRealSwapData(data, save);
                     return true;
@@ -977,7 +977,7 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
         if (!data.isDepositToken(this.getSwapData().getDepositToken())) throw new IntermediaryError("Invalid deposit token used!");
         if (data.hasSuccessAction()) throw new IntermediaryError("Invalid has success action");
 
-        if (await this.wrapper._contract.isExpired(this._getInitiator(), data)) throw new IntermediaryError("Not enough time to claim!");
+        if (await this.wrapper._contract(this._contractVersion).isExpired(this._getInitiator(), data)) throw new IntermediaryError("Not enough time to claim!");
         if (this.wrapper._getHtlcTimeout(data) <= (Date.now()/1000)) throw new IntermediaryError("HTLC expires too soon!");
     }
 
@@ -1054,7 +1054,7 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
                 abortController.signal.throwIfAborted();
 
                 if(resp.code===InvoiceStatusResponseCodes.PAID) {
-                    const swapData = new this.wrapper._swapDataDeserializer(resp.data.data);
+                    const swapData = new (this.wrapper._swapDataDeserializer(this._contractVersion))(resp.data.data);
                     return await this._saveRealSwapData(swapData, true);
                 }
 
@@ -1167,7 +1167,7 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
         if(!this.isValidSecretPreimage(useSecret))
             throw new Error("Invalid swap secret pre-image provided!");
 
-        return await this.wrapper._contract.txsClaimWithSecret(
+        return await this._contract.txsClaimWithSecret(
             address ?? this._getInitiator(),
             this._data, useSecret, true, true
         );
@@ -1384,7 +1384,7 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
             }
 
             //Check if it's already successfully paid
-            commitStatus ??= await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data!);
+            commitStatus ??= await this._contract.getCommitStatus(this._getInitiator(), this._data!);
             if(commitStatus!=null && await this._forciblySetOnchainState(commitStatus)) return true;
 
             if(this._state===FromBTCLNAutoSwapState.PR_PAID) {
@@ -1453,7 +1453,7 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
         if(await this.syncStateFromChain(quoteDefinitelyExpired, commitStatus)) changed = true;
 
         if(this._state===FromBTCLNAutoSwapState.CLAIM_COMMITED) {
-            const expired = await this.wrapper._contract.isExpired(this._getInitiator(), this._data!);
+            const expired = await this._contract.isExpired(this._getInitiator(), this._data!);
             if(expired) {
                 this._state = FromBTCLNAutoSwapState.EXPIRED;
                 changed = true;
@@ -1521,7 +1521,7 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
             throw new Error("Invalid swap secret pre-image provided!");
 
         if(!noCheckExpiry) {
-            if(await this.wrapper._contract.isExpired(this._getInitiator(), this._data)) throw new Error("On-chain HTLC already expired!");
+            if(await this._contract.isExpired(this._getInitiator(), this._data)) throw new Error("On-chain HTLC already expired!");
         }
         await this.wrapper._messenger.broadcast(new SwapClaimWitnessMessage(this._data, useSecret));
     }
@@ -1548,7 +1548,7 @@ export class FromBTCLNAutoSwap<T extends ChainType = ChainType>
                 break;
             case FromBTCLNAutoSwapState.PR_PAID:
             case FromBTCLNAutoSwapState.CLAIM_COMMITED:
-                const expired = await this.wrapper._contract.isExpired(this._getInitiator(), this._data!);
+                const expired = await this._contract.isExpired(this._getInitiator(), this._data!);
                 if(expired) {
                     this._state = FromBTCLNAutoSwapState.EXPIRED;
                     if(save) await this._saveAndEmit();

--- a/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
@@ -12,7 +12,7 @@ import {UserError} from "../../../../errors/UserError";
 import {IntermediaryError} from "../../../../errors/IntermediaryError";
 import {SwapType} from "../../../../enums/SwapType";
 import {
-    extendAbortController, parseHashValueExact32Bytes,
+    extendAbortController, mapArrayToObject, parseHashValueExact32Bytes,
     randomBytes,
     throwIfUndefined
 } from "../../../../utils/Utils";
@@ -148,10 +148,9 @@ export class FromBTCLNAutoWrapper<
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Swap pricing handler
      * @param tokens
-     * @param swapDataDeserializer Deserializer for SwapData
+     * @param versionedContracts
      * @param lnApi
      * @param messenger
      * @param options
@@ -162,17 +161,21 @@ export class FromBTCLNAutoWrapper<
         unifiedStorage: UnifiedSwapStorage<T>,
         unifiedChainEvents: UnifiedSwapEventListener<T>,
         chain: T["ChainInterface"],
-        contract: T["Contract"],
         prices: ISwapPrice,
         tokens: WrapperCtorTokens,
-        swapDataDeserializer: new (data: any) => T["Data"],
+        versionedContracts: {
+            [version: string]: {
+                swapContract: T["Contract"],
+                swapDataConstructor: new (data: any) => T["Data"]
+            }
+        },
         lnApi: LightningNetworkApi,
         messenger: Messenger,
         options?: AllOptional<FromBTCLNAutoWrapperOptions>,
         events?: EventEmitter<{swapState: [ISwap]}>
     ) {
         super(
-            chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer, lnApi,
+            chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens, versionedContracts, lnApi,
             {
                 ...options,
                 safetyFactor: options?.safetyFactor ?? 2,
@@ -255,30 +258,34 @@ export class FromBTCLNAutoWrapper<
      * @param options Options as passed to the swap creation function
      * @param abortController
      *
+     * @param contractVersions
      * @private
      */
-    private async preFetchClaimerBounty(
+    private preFetchClaimerBounty(
         signer: string,
         amountData: AmountData,
         options: {feeSafetyFactor: number, unsafeZeroWatchtowerFee: boolean},
-        abortController: AbortController
-    ): Promise<bigint | undefined> {
-        if(options.unsafeZeroWatchtowerFee) return 0n;
+        abortController: AbortController,
+        contractVersions: string[]
+    ): {[chainVersion: string]: Promise<bigint | undefined>} {
+        return mapArrayToObject(contractVersions, async (contractVersion) => {
+            if(options.unsafeZeroWatchtowerFee) return 0n;
 
-        const dummyAmount = BigInt(Math.floor(Math.random()* 0x1000000));
-        const dummySwapData = await this._contract.createSwapData(
-            ChainSwapType.HTLC, this._chain.randomAddress(), signer, amountData.token,
-            dummyAmount, this._contract.getHashForHtlc(randomBytes(32)).toString("hex"),
-            this.getRandomSequence(), BigInt(Math.floor(Date.now()/1000)), false, true,
-            BigInt(Math.floor(Math.random() * 0x10000)), BigInt(Math.floor(Math.random() * 0x10000))
-        );
+            const dummyAmount = BigInt(Math.floor(Math.random()* 0x1000000));
+            const dummySwapData = await this._contract(contractVersion).createSwapData(
+                ChainSwapType.HTLC, this._chain.randomAddress(), signer, amountData.token,
+                dummyAmount, this._contract(contractVersion).getHashForHtlc(randomBytes(32)).toString("hex"),
+                this.getRandomSequence(), BigInt(Math.floor(Date.now()/1000)), false, true,
+                BigInt(Math.floor(Math.random() * 0x10000)), BigInt(Math.floor(Math.random() * 0x10000))
+            );
 
-        try {
-            const result = await this._contract.getClaimFee(this._chain.randomAddress(), dummySwapData);
-            return result * BigInt(Math.floor(options.feeSafetyFactor*1000000)) / 1_000_000n
-        } catch (e) {
-            abortController.abort(e);
-        }
+            try {
+                const result = await this._contract(contractVersion).getClaimFee(this._chain.randomAddress(), dummySwapData);
+                return result * BigInt(Math.floor(options.feeSafetyFactor*1000000)) / 1_000_000n
+            } catch (e) {
+                abortController.abort(e);
+            }
+        });
     }
 
     /**
@@ -354,10 +361,10 @@ export class FromBTCLNAutoWrapper<
         additionalParams?: Record<string, any>,
         abortSignal?: AbortSignal,
         preFetches?: {
-            pricePrefetchPromise?: Promise<bigint | undefined>,
-            usdPricePrefetchPromise?: Promise<number | undefined>,
+            pricePrefetchPromise: Promise<bigint | undefined>,
+            usdPricePrefetchPromise: Promise<number | undefined>,
+            claimerBountyPrefetch: {[contractVersion: string]: Promise<bigint | undefined>},
             gasTokenPricePrefetchPromise?: Promise<bigint | undefined>,
-            claimerBountyPrefetch?: Promise<bigint | undefined>,
         }
     ): {
         quote: Promise<FromBTCLNAutoSwap<T>>,
@@ -381,6 +388,8 @@ export class FromBTCLNAutoWrapper<
         if(_options.description!=null && Buffer.byteLength(_options.description, "utf8") > 500)
             throw new UserError("Invalid description length");
 
+        const lpVersions = Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
+
         let secret: Buffer | undefined;
         let paymentHash: Buffer;
         if(_options?.paymentHash!=null) {
@@ -388,19 +397,20 @@ export class FromBTCLNAutoWrapper<
         } else {
             ({secret, paymentHash} = this.getSecretAndHash());
         }
-        const claimHash = this._contract.getHashForHtlc(paymentHash);
+        const _hash = mapArrayToObject(lpVersions, (contractVersion: string) => {
+            return this._contract(contractVersion).getHashForHtlc(paymentHash).toString("hex");
+        });
 
         const nativeTokenAddress = this._chain.getNativeCurrencyAddress();
 
         const _abortController = extendAbortController(abortSignal);
 
-        preFetches ??= {};
-        const _preFetches = {
-            pricePrefetchPromise: preFetches?.pricePrefetchPromise ?? this.preFetchPrice(amountData, _abortController.signal),
-            usdPricePrefetchPromise: preFetches?.usdPricePrefetchPromise ?? this.preFetchUsdPrice(_abortController.signal),
-            claimerBountyPrefetch: preFetches?.claimerBountyPrefetch ?? this.preFetchClaimerBounty(recipient, amountData, _options, _abortController),
+        const _preFetches = preFetches ?? {
+            pricePrefetchPromise: this.preFetchPrice(amountData, _abortController.signal),
+            usdPricePrefetchPromise: this.preFetchUsdPrice(_abortController.signal),
+            claimerBountyPrefetch: this.preFetchClaimerBounty(recipient, amountData, _options, _abortController, lpVersions),
             gasTokenPricePrefetchPromise: _options.gasAmount!==0n || !_options.unsafeZeroWatchtowerFee ?
-                (preFetches.gasTokenPricePrefetchPromise ??= this.preFetchPrice({token: nativeTokenAddress}, _abortController.signal)) :
+                this.preFetchPrice({token: nativeTokenAddress}, _abortController.signal) :
                 undefined
         };
 
@@ -409,10 +419,11 @@ export class FromBTCLNAutoWrapper<
                 intermediary: lp,
                 quote: (async () => {
                     if(lp.services[SwapType.FROM_BTCLN_AUTO]==null) throw new Error("LP service for processing from btcln auto swaps not found!");
+                    const version = lp.getContractVersion(this.chainIdentifier);
 
                     const abortController = extendAbortController(_abortController.signal);
 
-                    const liquidityPromise: Promise<bigint | undefined> = this.preFetchIntermediaryLiquidity(amountData, lp, abortController);
+                    const liquidityPromise: Promise<bigint | undefined> = this.preFetchIntermediaryLiquidity(amountData, lp, abortController, version);
 
                     const {lnCapacityPromise, resp} = await tryWithRetries(async(retryCount: number) => {
                         const {lnPublicKey, response} = IntermediaryAPI.initFromBTCLNAuto(
@@ -428,7 +439,7 @@ export class FromBTCLNAutoWrapper<
                                 additionalParams,
                                 gasToken: this._chain.getNativeCurrencyAddress(),
                                 gasAmount: _options.gasAmount,
-                                claimerBounty: throwIfUndefined(_preFetches.claimerBountyPrefetch)
+                                claimerBounty: throwIfUndefined(_preFetches.claimerBountyPrefetch[version])
                             },
                             this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined
                         );
@@ -448,7 +459,7 @@ export class FromBTCLNAutoWrapper<
                     if(decodedPr.millisatoshis==null) throw new IntermediaryError("Invalid returned swap invoice, no msat amount field");
                     if(decodedPr.timeExpireDate==null) throw new IntermediaryError("Invalid returned swap invoice, no expiry date field");
                     const amountIn = (BigInt(decodedPr.millisatoshis) + 999n) / 1000n;
-                    const claimerBounty = (await _preFetches.claimerBountyPrefetch)!;
+                    const claimerBounty = (await _preFetches.claimerBountyPrefetch[version])!;
 
                     try {
                         this.verifyReturnedData(resp, amountData, lp, _options, decodedPr, paymentHash, claimerBounty);
@@ -485,15 +496,16 @@ export class FromBTCLNAutoWrapper<
 
                             gasPricingInfo,
 
-                            initialSwapData: await this._contract.createSwapData(
+                            initialSwapData: await this._contract(version).createSwapData(
                                 ChainSwapType.HTLC, lp.getAddress(this.chainIdentifier), recipient, amountData.token,
-                                resp.total, claimHash.toString("hex"),
+                                resp.total, _hash[version],
                                 this.getRandomSequence(), BigInt(Math.floor(Date.now()/1000)), false, true,
                                 _options.gasAmount + resp.claimerBounty, resp.claimerBounty, nativeTokenAddress
                             ),
                             pr: resp.pr,
                             secret: secret?.toString("hex"),
-                            exactIn: amountData.exactIn ?? true
+                            exactIn: amountData.exactIn ?? true,
+                            contractVersion: version
                         };
                         const quote = new FromBTCLNAutoSwap<T>(this, swapInit);
                         return quote;
@@ -546,6 +558,8 @@ export class FromBTCLNAutoWrapper<
             descriptionHash: parseHashValueExact32Bytes(options?.descriptionHash, "description hash")
         };
 
+        const lpVersions = Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
+
         const abortController = extendAbortController(abortSignal);
         const preFetches = {
             pricePrefetchPromise: this.preFetchPrice(amountData, abortController.signal),
@@ -553,7 +567,7 @@ export class FromBTCLNAutoWrapper<
             gasTokenPricePrefetchPromise: _options.gasAmount!==0n || !_options.unsafeZeroWatchtowerFee ?
                 this.preFetchPrice({token: this._chain.getNativeCurrencyAddress()}, abortController.signal) :
                 undefined,
-            claimerBountyPrefetch: this.preFetchClaimerBounty(recipient, amountData, _options, abortController)
+            claimerBountyPrefetch: this.preFetchClaimerBounty(recipient, amountData, _options, abortController, lpVersions)
         };
 
         try {
@@ -615,7 +629,7 @@ export class FromBTCLNAutoWrapper<
         const changedSwapSet: Set<FromBTCLNAutoSwap<T>> = new Set();
 
         const swapExpiredStatus: {[id: string]: boolean} = {};
-        const checkStatusSwaps: (FromBTCLNAutoSwap<T> & {_data: T["Data"]})[] = [];
+        const checkStatusSwaps: {[contractVersion: string]: (FromBTCLNAutoSwap<T> & {_data: T["Data"]})[]} = {};
 
         await Promise.all(pastSwaps.map(async (pastSwap) => {
             if(pastSwap._shouldCheckIntermediary()) {
@@ -634,19 +648,27 @@ export class FromBTCLNAutoWrapper<
             }
             if(pastSwap._shouldFetchOnchainState()) {
                 //Add to swaps for which status should be checked
-                if(pastSwap._data!=null) checkStatusSwaps.push(pastSwap as FromBTCLNAutoSwap<T> & {_data: T["Data"]});
+                if(pastSwap._data!=null) (checkStatusSwaps[pastSwap._contractVersion ?? "v1"] ??= []).push(pastSwap as FromBTCLNAutoSwap<T> & {_data: T["Data"]});
             }
         }));
 
-        const swapStatuses = await this._contract.getCommitStatuses(checkStatusSwaps.map(val => ({signer: val._getInitiator(), swapData: val._data})));
+        for(let version in checkStatusSwaps) {
+            if (this._versionedContracts[version] == null) {
+                this.logger.warn(`_checkPastSwaps(): No contract was found for ${this.chainIdentifier} version ${version}! Skipping these swaps!`);
+                continue;
+            }
 
-        for(let pastSwap of checkStatusSwaps) {
-            const shouldSave = await pastSwap._sync(
-                false, swapExpiredStatus[pastSwap.getId()],
-                swapStatuses[pastSwap.getEscrowHash()!], true
-            );
-            if(shouldSave) {
-                changedSwapSet.add(pastSwap);
+            const _checkStatusSwap = checkStatusSwaps[version];
+            const swapStatuses = await this._contract(version).getCommitStatuses(_checkStatusSwap.map(val => ({signer: val._getInitiator(), swapData: val._data})));
+
+            for(let pastSwap of _checkStatusSwap) {
+                const shouldSave = await pastSwap._sync(
+                    false, swapExpiredStatus[pastSwap.getId()],
+                    swapStatuses[pastSwap.getEscrowHash()!], true
+                );
+                if(shouldSave) {
+                    changedSwapSet.add(pastSwap);
+                }
             }
         }
 
@@ -672,6 +694,7 @@ export class FromBTCLNAutoWrapper<
     async recoverFromSwapDataAndState(
         init: {data: T["Data"], getInitTxId: () => Promise<string>, getTxBlock: () => Promise<{blockTime: number, blockHeight: number}>},
         state: SwapCommitState,
+        contractVersion: string,
         lp?: Intermediary
     ): Promise<FromBTCLNAutoSwap<T> | null> {
         const data = init.data;
@@ -702,7 +725,8 @@ export class FromBTCLNAutoWrapper<
             data,
             pr: paymentHash ?? undefined,
             secret,
-            exactIn: false
+            exactIn: false,
+            contractVersion
         }
         const swap = new FromBTCLNAutoSwap(this, swapInit);
         swap._commitTxId = await init.getInitTxId();

--- a/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/ln_auto/FromBTCLNAutoWrapper.ts
@@ -382,8 +382,15 @@ export class FromBTCLNAutoWrapper<
             descriptionHash: parseHashValueExact32Bytes(options?.descriptionHash, "description hash")
         };
 
-        if(amountData.token===this._chain.getNativeCurrencyAddress() && _options.gasAmount!==0n)
-            throw new UserError("Cannot specify `gasAmount` for swaps to a native token!");
+
+        if(
+            _options.gasAmount!==0n &&
+            (
+                this._chain.shouldGetNativeTokenDrop!=null
+                    ? !this._chain.shouldGetNativeTokenDrop(amountData.token)
+                    : amountData.token===this._chain.getNativeCurrencyAddress()
+            )
+        ) throw new UserError("Cannot specify `gasAmount` for swaps to a native token!");
 
         if(_options.description!=null && Buffer.byteLength(_options.description, "utf8") > 500)
             throw new UserError("Invalid description length");

--- a/src/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.ts
+++ b/src/swaps/escrow_swaps/frombtc/onchain/FromBTCSwap.ts
@@ -385,7 +385,7 @@ export class FromBTCSwap<T extends ChainType = ChainType>
     private inferRequiredConfirmationsCount(btcTx: Omit<BtcTxWithBlockheight, "hex" | "raw">, vout: number): number | undefined {
         const txOut = btcTx.outs[vout];
         for(let i=1;i<=20;i++) {
-            const computedClaimHash = this.wrapper._contract.getHashForOnchain(
+            const computedClaimHash = this._contract.getHashForOnchain(
                 Buffer.from(txOut.scriptPubKey.hex, "hex"),
                 BigInt(txOut.value),
                 i
@@ -976,13 +976,13 @@ export class FromBTCSwap<T extends ChainType = ChainType>
         if(tx.blockhash==null || tx.confirmations==null || tx.blockheight==null || tx.confirmations<this.requiredConfirmations)
             throw new Error("Bitcoin transaction not confirmed yet!");
 
-        return await this.wrapper._contract.txsClaimWithTxData(signer ?? this._getInitiator(), this._data, {
+        return await this._contract.txsClaimWithTxData(signer ?? this._getInitiator(), this._data, {
             blockhash: tx.blockhash,
             confirmations: tx.confirmations,
             txid: tx.txid,
             hex: tx.hex,
             height: tx.blockheight
-        }, this.requiredConfirmations, this.vout, undefined, this.wrapper._synchronizer, true);
+        }, this.requiredConfirmations, this.vout, undefined, this.wrapper._synchronizer(this._contractVersion), true);
     }
 
     /**
@@ -1017,7 +1017,7 @@ export class FromBTCSwap<T extends ChainType = ChainType>
                 this.logger.info("claim(): Transaction state is CLAIM_CLAIMED, swap was successfully claimed by the watchtower");
                 return this._claimTxId!;
             }
-            const status = await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data);
+            const status = await this._contract.getCommitStatus(this._getInitiator(), this._data);
             if(status?.type===SwapCommitStateType.PAID) {
                 this.logger.info("claim(): Transaction commit status is PAID, swap was successfully claimed by the watchtower");
                 if(this._claimTxId==null) this._claimTxId = await status.getClaimTxId();
@@ -1149,7 +1149,7 @@ export class FromBTCSwap<T extends ChainType = ChainType>
                 quoteExpired = quoteDefinitelyExpired ?? await this._verifyQuoteDefinitelyExpired(); //Make sure we check for expiry here, to prevent race conditions
             }
 
-            const status = commitStatus ?? await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data);
+            const status = commitStatus ?? await this._contract.getCommitStatus(this._getInitiator(), this._data);
             if(status!=null && await this._forciblySetOnchainState(status)) return true;
 
             if(this._state===FromBTCSwapState.PR_CREATED || this._state===FromBTCSwapState.QUOTE_SOFT_EXPIRED) {

--- a/src/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.ts
+++ b/src/swaps/escrow_swaps/frombtc/onchain/FromBTCWrapper.ts
@@ -18,7 +18,7 @@ import {Buffer} from "buffer";
 import {IntermediaryError} from "../../../../errors/IntermediaryError";
 import {SwapType} from "../../../../enums/SwapType";
 import {
-    extendAbortController,
+    extendAbortController, mapArrayToObject,
     randomBytes,
     throwIfUndefined
 } from "../../../../utils/Utils";
@@ -109,25 +109,46 @@ export class FromBTCWrapper<
     /**
      * @internal
      */
-    readonly _synchronizer: RelaySynchronizer<any, T["TX"], any>;
+    readonly _synchronizer: (version?: string) => RelaySynchronizer<any, T["TX"], any> = (version?: string) => {
+        const _version = version ?? "v1";
+        const data = this.versionedSynchronizer[_version];
+        if(data==null) throw new Error(`Invalid contract version ${_version} requested`);
+        return data.synchronizer;
+    };
+
     /**
      * @internal
      */
     readonly _btcRpc: BitcoinRpcWithAddressIndex<any>;
 
-    private readonly btcRelay: BtcRelay<any, T["TX"], any>;
+    private readonly btcRelay: (version?: string) => BtcRelay<any, T["TX"], any> = (version?: string) => {
+        const _version = version ?? "v1";
+        const data = this.versionedBtcRelay[_version];
+        if(data==null) throw new Error(`Invalid contract version ${_version} requested`);
+        return data.btcRelay;
+    };
+
+    private readonly versionedBtcRelay: {
+        [version: string]: {
+            btcRelay: BtcRelay<any, T["TX"], any>
+        }
+    }= {};
+
+    private readonly versionedSynchronizer: {
+        [version: string]: {
+            synchronizer: RelaySynchronizer<any, T["TX"], any>
+        }
+    }= {};
 
     /**
      * @param chainIdentifier
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Pricing to use
      * @param tokens
-     * @param swapDataDeserializer Deserializer for SwapData
-     * @param btcRelay
-     * @param synchronizer Btc relay synchronizer
+     * @param versionedContracts
+     * @param versionedSynchronizer
      * @param btcRpc Bitcoin RPC which also supports getting transactions by txoHash
      * @param options
      * @param events Instance to use for emitting events
@@ -137,18 +158,26 @@ export class FromBTCWrapper<
         unifiedStorage: UnifiedSwapStorage<T>,
         unifiedChainEvents: UnifiedSwapEventListener<T>,
         chain: T["ChainInterface"],
-        contract: T["Contract"],
         prices: ISwapPrice,
         tokens: WrapperCtorTokens,
-        swapDataDeserializer: new (data: any) => T["Data"],
-        btcRelay: BtcRelay<any, T["TX"], any>,
-        synchronizer: RelaySynchronizer<any, T["TX"], any>,
+        versionedContracts: {
+            [version: string]: {
+                swapContract: T["Contract"],
+                swapDataConstructor: new (data: any) => T["Data"],
+                btcRelay: BtcRelay<any, T["TX"], any>
+            }
+        },
+        versionedSynchronizer: {
+            [version: string]: {
+                synchronizer: RelaySynchronizer<any, T["TX"], any>
+            }
+        },
         btcRpc: BitcoinRpcWithAddressIndex<any>,
         options?: AllOptional<FromBTCWrapperOptions>,
         events?: EventEmitter<{swapState: [ISwap]}>
     ) {
         super(
-            chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer,
+            chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens,
             {
                 ...options,
                 bitcoinNetwork: options?.bitcoinNetwork ?? TEST_NETWORK,
@@ -158,11 +187,12 @@ export class FromBTCWrapper<
                 minSendWindow: options?.minSendWindow ?? 30*60, //Minimum time window for user to send in the on-chain funds for From BTC swap
                 bitcoinBlocktime: options?.bitcoinBlocktime ?? 10*60
             },
+            versionedContracts,
             events
         );
-        this.btcRelay = btcRelay;
-        this._synchronizer = synchronizer;
         this._btcRpc = btcRpc;
+        this.versionedBtcRelay = versionedContracts;
+        this.versionedSynchronizer = versionedSynchronizer;
     }
 
     /**
@@ -225,6 +255,7 @@ export class FromBTCWrapper<
      * @param amountData
      * @param options Options as passed to the swap creation function
      * @param abortController
+     * @param contractVersion
      *
      * @private
      */
@@ -236,7 +267,8 @@ export class FromBTCWrapper<
             blockSafetyFactor: bigint,
             unsafeZeroWatchtowerFee: boolean
         },
-        abortController: AbortController
+        abortController: AbortController,
+        contractVersion: string
     ): Promise<{
         feePerBlock: bigint,
         safetyFactor: bigint,
@@ -257,19 +289,19 @@ export class FromBTCWrapper<
         }
 
         const dummyAmount = BigInt(Math.floor(Math.random()* 0x1000000));
-        const dummySwapData = await this._contract.createSwapData(
+        const dummySwapData = await this._contract(contractVersion).createSwapData(
             ChainSwapType.CHAIN, signer, signer, amountData.token,
-            dummyAmount, this._contract.getHashForOnchain(randomBytes(20), dummyAmount, 3).toString("hex"),
+            dummyAmount, this._contract(contractVersion).getHashForOnchain(randomBytes(20), dummyAmount, 3).toString("hex"),
             this.getRandomSequence(), startTimestamp, false, true,
             BigInt(Math.floor(Math.random() * 0x10000)), BigInt(Math.floor(Math.random() * 0x10000))
         );
 
         try {
             const [feePerBlock, btcRelayData, currentBtcBlock, claimFeeRate] = await Promise.all([
-                this.btcRelay.getFeePerBlock(),
-                this.btcRelay.getTipData(),
+                this.btcRelay(contractVersion).getFeePerBlock(),
+                this.btcRelay(contractVersion).getTipData(),
                 this._btcRpc.getTipHeight(),
-                this._contract.getClaimFee(signer, dummySwapData)
+                this._contract(contractVersion).getClaimFee(signer, dummySwapData)
             ]);
 
             if(btcRelayData==null) throw new Error("Btc relay not initialized!");
@@ -386,9 +418,11 @@ export class FromBTCWrapper<
             throw new IntermediaryError("Send window too low");
         }
 
+        const version = lp.getContractVersion(this.chainIdentifier);
+
         const lockingScript = toOutputScript(this._options.bitcoinNetwork, resp.btcAddress);
-        const desiredExtraData = this._contract.getExtraData(lockingScript, resp.amount, requiredConfirmations);
-        const desiredClaimHash = this._contract.getHashForOnchain(lockingScript, resp.amount, requiredConfirmations);
+        const desiredExtraData = this._contract(version).getExtraData(lockingScript, resp.amount, requiredConfirmations);
+        const desiredClaimHash = this._contract(version).getHashForOnchain(lockingScript, resp.amount, requiredConfirmations);
         if(!desiredClaimHash.equals(Buffer.from(data.getClaimHash(), "hex"))) {
             throw new IntermediaryError("Invalid claim hash returned!");
         }
@@ -426,6 +460,7 @@ export class FromBTCWrapper<
         } else if(typeof(options?.feeSafetyFactor)==="number") {
             feeSafetyFactorPPM = BigInt(Math.floor(options.feeSafetyFactor * 1_000_000));
         }
+        const lpVersions = Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
 
         const _options = {
             blockSafetyFactor: options?.blockSafetyFactor!=null ? BigInt(options.blockSafetyFactor) : 1n,
@@ -438,21 +473,27 @@ export class FromBTCWrapper<
         const _abortController = extendAbortController(abortSignal);
         const pricePrefetchPromise: Promise<bigint | undefined> = this.preFetchPrice(amountData, _abortController.signal);
         const usdPricePrefetchPromise: Promise<number | undefined> = this.preFetchUsdPrice(_abortController.signal);
-        const claimerBountyPrefetchPromise = this.preFetchClaimerBounty(recipient, amountData, _options, _abortController);
+        const claimerBountyPrefetchPromise = mapArrayToObject(lpVersions, (contractVersion: string) => {
+            return this.preFetchClaimerBounty(recipient, amountData, _options, _abortController, contractVersion);
+        });
         const nativeTokenAddress = this._chain.getNativeCurrencyAddress();
-        const feeRatePromise: Promise<string | undefined> = this.preFetchFeeRate(recipient, amountData, undefined, _abortController);
-        const _signDataPromise: Promise<T["PreFetchVerification"] | undefined> | undefined = this._contract.preFetchBlockDataForSignatures==null ?
-            this.preFetchSignData(Promise.resolve(true)) :
-            undefined;
+        const feeRatePromise = this.preFetchFeeRate(recipient, amountData, undefined, _abortController, lpVersions);
+
+        const _signDataPromise = mapArrayToObject(lpVersions, (contractVersion: string) => {
+            return this._contract(contractVersion).preFetchBlockDataForSignatures == null ?
+                this.preFetchSignData(Promise.resolve(true), contractVersion) :
+                undefined;
+        });
 
         return lps.map(lp => {
             return {
                 intermediary: lp,
                 quote: (async () => {
                     if(lp.services[SwapType.FROM_BTC]==null) throw new Error("LP service for processing from btc swaps not found!");
+                    const version = lp.getContractVersion(this.chainIdentifier);
 
                     const abortController = extendAbortController(_abortController.signal);
-                    const liquidityPromise: Promise<bigint | undefined> = this.preFetchIntermediaryLiquidity(amountData, lp, abortController);
+                    const liquidityPromise: Promise<bigint | undefined> = this.preFetchIntermediaryLiquidity(amountData, lp, abortController, version);
 
                     try {
                         const {signDataPromise, resp} = await tryWithRetries(async(retryCount: number) => {
@@ -466,16 +507,16 @@ export class FromBTCWrapper<
                                     exactOut: !amountData.exactIn,
                                     sequence,
 
-                                    claimerBounty: throwIfUndefined(claimerBountyPrefetchPromise),
-                                    feeRate: throwIfUndefined(feeRatePromise),
+                                    claimerBounty: throwIfUndefined(claimerBountyPrefetchPromise[version]),
+                                    feeRate: throwIfUndefined(feeRatePromise[version]),
                                     additionalParams
                                 },
                                 this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined
                             );
 
-                            let signDataPromise = _signDataPromise;
+                            let signDataPromise = _signDataPromise[version];
                             if(signDataPromise==null) {
-                                signDataPromise = this.preFetchSignData(signDataPrefetch);
+                                signDataPromise = this.preFetchSignData(signDataPrefetch, version);
                             } else signDataPrefetch.catch(() => {});
 
                             return {
@@ -484,19 +525,19 @@ export class FromBTCWrapper<
                             };
                         }, undefined, e => e instanceof RequestError, abortController.signal);
 
-                        const data: T["Data"] = new this._swapDataDeserializer(resp.data);
+                        const data: T["Data"] = new (this._swapDataDeserializer(version))(resp.data);
                         data.setClaimer(recipient);
 
                         const swapFeeBtc = resp.swapFee * resp.amount / (data.getAmount() + resp.swapFee);
 
-                        this.verifyReturnedData(recipient, resp, amountData, lp, _options, data, sequence, (await claimerBountyPrefetchPromise)!, nativeTokenAddress);
+                        this.verifyReturnedData(recipient, resp, amountData, lp, _options, data, sequence, (await claimerBountyPrefetchPromise[version])!, nativeTokenAddress);
                         const [pricingInfo, signatureExpiry] = await Promise.all([
                             //Get intermediary's liquidity
                             this.verifyReturnedPrice(
                                 lp.services[SwapType.FROM_BTC], false, resp.amount, resp.total,
                                 amountData.token, {swapFeeBtc}, pricePrefetchPromise, usdPricePrefetchPromise, abortController.signal
                             ),
-                            this.verifyReturnedSignature(recipient, data, resp, feeRatePromise, signDataPromise, abortController.signal),
+                            this.verifyReturnedSignature(recipient, data, resp, feeRatePromise[version], signDataPromise, version, abortController.signal),
                             this.verifyIntermediaryLiquidity(data.getAmount(), throwIfUndefined(liquidityPromise)),
                         ]);
 
@@ -506,13 +547,14 @@ export class FromBTCWrapper<
                             expiry: signatureExpiry,
                             swapFee: resp.swapFee,
                             swapFeeBtc,
-                            feeRate: (await feeRatePromise)!,
+                            feeRate: (await feeRatePromise[version])!,
                             signatureData: resp,
                             data,
                             address: resp.btcAddress,
                             amount: resp.amount,
                             exactIn: amountData.exactIn ?? true,
-                            requiredConfirmations: resp.confirmations
+                            requiredConfirmations: resp.confirmations,
+                            contractVersion: version
                         } as FromBTCSwapInit<T["Data"]>);
                         return quote;
                     } catch (e) {
@@ -530,6 +572,7 @@ export class FromBTCWrapper<
     async recoverFromSwapDataAndState(
         init: {data: T["Data"], getInitTxId: () => Promise<string>, getTxBlock: () => Promise<{blockTime: number, blockHeight: number}>},
         state: SwapCommitState,
+        contractVersion: string,
         lp?: Intermediary
     ): Promise<FromBTCSwap<T> | null> {
         const data = init.data;
@@ -550,7 +593,8 @@ export class FromBTCWrapper<
             feeRate: "",
             signatureData: undefined,
             data,
-            exactIn: false
+            exactIn: false,
+            contractVersion
         }
         const swap = new FromBTCSwap(this, swapInit);
         swap._commitTxId = await init.getInitTxId();

--- a/src/swaps/escrow_swaps/tobtc/IToBTCSwap.ts
+++ b/src/swaps/escrow_swaps/tobtc/IToBTCSwap.ts
@@ -449,7 +449,7 @@ export abstract class IToBTCSwap<
         required: TokenAmount<SCToken<T["ChainId"]>, true>
     }> {
         const [balance, commitFee] = await Promise.all([
-            this.wrapper._contract.getBalance(this._getInitiator(), this._data.getToken(), false),
+            this._contract.getBalance(this._getInitiator(), this._data.getToken(), false),
             this._data.getToken()===this.wrapper._chain.getNativeCurrencyAddress() ? this.getCommitFee() : Promise.resolve(null)
         ]);
         let required = this._data.getAmount();
@@ -471,7 +471,7 @@ export abstract class IToBTCSwap<
         required: TokenAmount<SCToken<T["ChainId"]>, true>
     }> {
         const [balance, commitFee] = await Promise.all([
-            this.wrapper._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
+            this._contract.getBalance(this._getInitiator(), this.wrapper._chain.getNativeCurrencyAddress(), false),
             this.getCommitFee()
         ]);
         return {
@@ -601,7 +601,7 @@ export abstract class IToBTCSwap<
             await this._saveAndEmit();
         }
 
-        return await this.wrapper._contract.txsInit(
+        return await this._contract.txsInit(
             this._getInitiator(), this._data, this.signatureData, skipChecks, this.feeRate
         ).catch(e => Promise.reject(e instanceof SignatureVerificationError ? new Error("Request timed out") : e));
     }
@@ -732,7 +732,7 @@ export abstract class IToBTCSwap<
                 }
                 return processed;
             case RefundAuthorizationResponseCodes.REFUND_DATA:
-                await this.wrapper._contract.isValidRefundAuthorization(this._data, resp.data);
+                await this._contract.isValidRefundAuthorization(this._data, resp.data);
                 this._state = ToBTCSwapState.REFUNDABLE;
                 if(save) await this._saveAndEmit();
                 return true;
@@ -799,14 +799,14 @@ export abstract class IToBTCSwap<
                 return true;
             case RefundAuthorizationResponseCodes.REFUND_DATA:
                 const resultData = result.data;
-                await this.wrapper._contract.isValidRefundAuthorization(
+                await this._contract.isValidRefundAuthorization(
                     this._data,
                     resultData
                 );
                 await this._saveAndEmit(ToBTCSwapState.REFUNDABLE);
                 return false;
             case RefundAuthorizationResponseCodes.EXPIRED:
-                if(await this.wrapper._contract.isExpired(this._getInitiator(), this._data)) throw new Error("Swap expired");
+                if(await this._contract.isExpired(this._getInitiator(), this._data)) throw new Error("Swap expired");
                 throw new IntermediaryError("Swap expired");
             case RefundAuthorizationResponseCodes.NOT_FOUND:
                 if((this._state as ToBTCSwapState)===ToBTCSwapState.CLAIMED) return true;
@@ -824,7 +824,7 @@ export abstract class IToBTCSwap<
      * Get the estimated smart chain transaction fee of the refund transaction
      */
     async getRefundNetworkFee(): Promise<TokenAmount<SCToken<T["ChainId"]>, true>> {
-        const swapContract: T["Contract"] = this.wrapper._contract;
+        const swapContract: T["Contract"] = this._contract;
         return toTokenAmount(
             await swapContract.getRefundFee(this._getInitiator(), this._data),
             this.wrapper._getNativeToken(),
@@ -855,13 +855,13 @@ export abstract class IToBTCSwap<
             signer = this._getInitiator();
         }
 
-        if(await this.wrapper._contract.isExpired(this._getInitiator(), this._data)) {
-            return await this.wrapper._contract.txsRefund(signer, this._data, true, true);
+        if(await this._contract.isExpired(this._getInitiator(), this._data)) {
+            return await this._contract.txsRefund(signer, this._data, true, true);
         } else {
             if(this.url==null) throw new Error("LP URL not known, cannot get cooperative refund message, wait till expiry to refund!");
             const res = await IntermediaryAPI.getRefundAuthorization(this.url, this.getLpIdentifier(), this._data.getSequence());
             if(res.code===RefundAuthorizationResponseCodes.REFUND_DATA) {
-                return await this.wrapper._contract.txsRefundWithAuthorization(
+                return await this._contract.txsRefundWithAuthorization(
                     signer,
                     this._data,
                     res.data,
@@ -974,7 +974,7 @@ export abstract class IToBTCSwap<
                 quoteExpired = quoteDefinitelyExpired ?? await this._verifyQuoteDefinitelyExpired();
             }
 
-            commitStatus ??= await this.wrapper._contract.getCommitStatus(this._getInitiator(), this._data);
+            commitStatus ??= await this._contract.getCommitStatus(this._getInitiator(), this._data);
             if(commitStatus!=null && await this._forciblySetOnchainState(commitStatus)) return true;
 
             if((this._state===ToBTCSwapState.CREATED || this._state===ToBTCSwapState.QUOTE_SOFT_EXPIRED)) {
@@ -1083,7 +1083,7 @@ export abstract class IToBTCSwap<
                 break;
             case ToBTCSwapState.COMMITED:
             case ToBTCSwapState.SOFT_CLAIMED:
-                const expired = await this.wrapper._contract.isExpired(this._getInitiator(), this._data);
+                const expired = await this._contract.isExpired(this._getInitiator(), this._data);
                 if(expired) {
                     this._state = ToBTCSwapState.REFUNDABLE;
                     if(save) await this._saveAndEmit();

--- a/src/swaps/escrow_swaps/tobtc/IToBTCWrapper.ts
+++ b/src/swaps/escrow_swaps/tobtc/IToBTCWrapper.ts
@@ -5,6 +5,7 @@ import {Intermediary, SingleChainReputationType} from "../../../intermediaries/I
 import {IntermediaryError} from "../../../errors/IntermediaryError";
 import {IEscrowSwapWrapper} from "../IEscrowSwapWrapper";
 import {AmountData} from "../../../types/AmountData";
+import {mapArrayToObject} from "../../../utils/Utils";
 
 export type IToBTCDefinition<T extends ChainType, W extends IToBTCWrapper<T, any>, S extends IToBTCSwap<T>> = SwapTypeDefinition<T, W, S>;
 
@@ -44,6 +45,7 @@ export abstract class IToBTCWrapper<
      * @param amountData
      * @param lp Intermediary
      * @param abortController
+     * @param contractVersion
      * @returns Intermediary's reputation or null if failed
      * @throws {IntermediaryError} If the intermediary vault doesn't exist
      *
@@ -52,9 +54,10 @@ export abstract class IToBTCWrapper<
     protected preFetchIntermediaryReputation(
         amountData: Omit<AmountData, "amount">,
         lp: Intermediary,
-        abortController: AbortController
+        abortController: AbortController,
+        contractVersion: string
     ): Promise<SingleChainReputationType | undefined> {
-        return lp.getReputation(this.chainIdentifier, this._contract, [amountData.token.toString()], abortController.signal).then(res => {
+        return lp.getReputation(this.chainIdentifier, this._contract(contractVersion), [amountData.token.toString()], abortController.signal).then(res => {
             if(res==null) throw new IntermediaryError("Invalid data returned - invalid LP vault");
             return res;
         }).catch(e => {
@@ -71,17 +74,26 @@ export abstract class IToBTCWrapper<
      * @param amountData
      * @param claimHash optional hash of the swap or null
      * @param abortController
+     * @param contractVersions
      * @returns Fee rate
      *
      * @internal
      */
-    protected preFetchFeeRate(signer: string, amountData: Omit<AmountData, "amount">, claimHash: string | undefined, abortController: AbortController): Promise<string | undefined> {
-        return this._contract.getInitPayInFeeRate(signer, this._chain.randomAddress(), amountData.token, claimHash)
-            .catch(e => {
-                this.logger.warn("preFetchFeeRate(): Error: ", e);
-                abortController.abort(e);
-                return undefined;
-            });
+    protected preFetchFeeRate(
+        signer: string,
+        amountData: Omit<AmountData, "amount">,
+        claimHash: {[contractVersion: string]: string} | undefined,
+        abortController: AbortController,
+        contractVersions: string[]
+    ): {[contractVersion: string]: Promise<string | undefined>} {
+        return mapArrayToObject(contractVersions, (contractVersion) => {
+            return this._contract(contractVersion).getInitPayInFeeRate(signer, this._chain.randomAddress(), amountData.token, claimHash?.[contractVersion])
+                .catch(e => {
+                    this.logger.warn("preFetchFeeRate(): Error: ", e);
+                    abortController.abort(e);
+                    return undefined;
+                });
+        });
     }
 
     /**

--- a/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNSwap.ts
+++ b/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNSwap.ts
@@ -104,7 +104,7 @@ export class ToBTCLNSwap<T extends ChainType = ChainType> extends IToBTCSwap<T, 
         const hash = Buffer.from(sha256(secretBuffer));
 
         if(check) {
-            const claimHash = this.wrapper._contract.getHashForHtlc(hash);
+            const claimHash = this._contract.getHashForHtlc(hash);
 
             const expectedClaimHash = Buffer.from(this.getClaimHash(), "hex");
             if(!claimHash.equals(expectedClaimHash)) throw new IntermediaryError("Invalid payment secret returned");

--- a/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.ts
+++ b/src/swaps/escrow_swaps/tobtc/ln/ToBTCLNWrapper.ts
@@ -9,7 +9,7 @@ import {ISwapPrice} from "../../../../prices/abstract/ISwapPrice";
 import {EventEmitter} from "events";
 import {IntermediaryError} from "../../../../errors/IntermediaryError";
 import {SwapType} from "../../../../enums/SwapType";
-import {extendAbortController, throwIfUndefined} from "../../../../utils/Utils";
+import {extendAbortController, mapArrayToObject, throwIfUndefined} from "../../../../utils/Utils";
 import {IntermediaryAPI, ToBTCLNResponseType} from "../../../../intermediaries/apis/IntermediaryAPI";
 import {RequestError} from "../../../../errors/RequestError";
 import {LNURL, LNURLPaySuccessAction} from "../../../../lnurl/LNURL";
@@ -102,21 +102,26 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
         unifiedStorage: UnifiedSwapStorage<T>,
         unifiedChainEvents: UnifiedSwapEventListener<T>,
         chain: T["ChainInterface"],
-        contract: T["Contract"],
         prices: ISwapPrice,
         tokens: WrapperCtorTokens,
-        swapDataDeserializer: new (data: any) => T["Data"],
+        versionedContracts: {
+            [version: string]: {
+                swapContract: T["Contract"],
+                swapDataConstructor: new (data: any) => T["Data"]
+            }
+        },
         options?: AllOptional<ToBTCLNWrapperOptions>,
         events?: EventEmitter<{swapState: [ISwap]}>
     ) {
         super(
-            chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer,
+            chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens,
             {
                 ...options,
                 paymentTimeoutSeconds: options?.paymentTimeoutSeconds ?? 5*24*60*60,
                 lightningBaseFee: options?.lightningBaseFee ?? 10,
                 lightningFeePPM: options?.lightningFeePPM ?? 2000
             },
+            versionedContracts,
             events
         );
     }
@@ -221,7 +226,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
             throw new IntermediaryError("Invalid data returned - total amount");
 
         if(parsedPr.tagsObject.payment_hash==null) throw new Error("Swap invoice doesn't contain payment hash field!");
-        const claimHash = this._contract.getHashForHtlc(Buffer.from(parsedPr.tagsObject.payment_hash, "hex"));
+        const claimHash = this._contract(lp.getContractVersion(this.chainIdentifier)).getHashForHtlc(Buffer.from(parsedPr.tagsObject.payment_hash, "hex"));
 
         if(
             data.getAmount() !== resp.total ||
@@ -265,18 +270,19 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
             expiryTimestamp: bigint
         },
         preFetches: {
-            feeRatePromise: Promise<string | undefined>,
+            feeRatePromise: {[contractVersion: string]: Promise<string | undefined>},
             pricePreFetchPromise: Promise<bigint | undefined>,
             usdPricePrefetchPromise: Promise<number | undefined>,
-            signDataPrefetchPromise?: Promise<T["PreFetchVerification"] | undefined>
+            signDataPrefetchPromise?: {[contractVersion: string]: Promise<T["PreFetchVerification"] | undefined> | undefined}
         },
         abort: AbortSignal | AbortController,
         additionalParams?: Record<string, any>,
     ) {
         if(lp.services[SwapType.TO_BTCLN]==null) throw new Error("LP service for processing to btcln swaps not found!");
+        const version = lp.getContractVersion(this.chainIdentifier);
 
         const abortController = abort instanceof AbortController ? abort : extendAbortController(abort);
-        const reputationPromise = this.preFetchIntermediaryReputation(amountData, lp, abortController);
+        const reputationPromise = this.preFetchIntermediaryReputation(amountData, lp, abortController, version);
 
         try {
             const {signDataPromise, resp} = await tryWithRetries(async(retryCount: number) => {
@@ -286,13 +292,13 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
                     maxFee: await calculatedOptions.maxFee,
                     expiryTimestamp: calculatedOptions.expiryTimestamp,
                     token: amountData.token,
-                    feeRate: throwIfUndefined(preFetches.feeRatePromise),
+                    feeRate: throwIfUndefined(preFetches.feeRatePromise[version]),
                     additionalParams
                 }, this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined);
 
-                let signDataPromise = preFetches.signDataPrefetchPromise;
+                let signDataPromise = preFetches.signDataPrefetchPromise?.[version];
                 if(signDataPromise==null) {
-                    signDataPromise = this.preFetchSignData(signDataPrefetch);
+                    signDataPromise = this.preFetchSignData(signDataPrefetch, version);
                 } else signDataPrefetch.catch(() => {});
 
                 return {
@@ -304,7 +310,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
             if(parsedPr.millisatoshis==null) throw new Error("Swap invoice doesn't have msat amount field!");
             const amountOut: bigint = (BigInt(parsedPr.millisatoshis) + 999n) / 1000n;
             const totalFee: bigint = resp.swapFee + resp.maxFee;
-            const data: T["Data"] = new this._swapDataDeserializer(resp.data);
+            const data: T["Data"] = new (this._swapDataDeserializer(version))(resp.data);
             data.setOfferer(signer);
 
             await this.verifyReturnedData(signer, resp, parsedPr, amountData.token, lp, calculatedOptions, data);
@@ -318,7 +324,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
                     preFetches.pricePreFetchPromise, preFetches.usdPricePrefetchPromise, abortController.signal
                 ),
                 this.verifyReturnedSignature(
-                    signer, data, resp, preFetches.feeRatePromise, signDataPromise, abortController.signal
+                    signer, data, resp, preFetches.feeRatePromise[version], signDataPromise, version, abortController.signal
                 ),
                 reputationPromise
             ]);
@@ -332,14 +338,15 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
                 expiry: signatureExpiry,
                 swapFee: resp.swapFee,
                 swapFeeBtc,
-                feeRate: (await preFetches.feeRatePromise)!,
+                feeRate: (await preFetches.feeRatePromise[version])!,
                 signatureData: resp,
                 data,
                 networkFee: resp.maxFee,
                 networkFeeBtc: resp.routingFeeSats,
                 confidence: resp.confidence,
                 pr,
-                exactIn: false
+                exactIn: false,
+                contractVersion: version
             } as IToBTCSwapInit<T["Data"]>);
             return quote;
         } catch (e) {
@@ -370,10 +377,10 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
         additionalParams?: Record<string, any>,
         abortSignal?: AbortSignal,
         preFetches?: {
-            feeRatePromise: Promise<string | undefined>,
+            feeRatePromise: {[contractVersion: string]: Promise<string | undefined>},
             pricePreFetchPromise: Promise<bigint | undefined>,
             usdPricePrefetchPromise: Promise<number | undefined>,
-            signDataPrefetchPromise?: Promise<T["PreFetchVerification"] | undefined>
+            signDataPrefetchPromise?: {[contractVersion: string]: Promise<T["PreFetchVerification"] | undefined> | undefined}
         }
     ): Promise<{
         quote: Promise<ToBTCLNSwap<T>>,
@@ -383,19 +390,27 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
         if(parsedPr.millisatoshis==null) throw new UserError("Must be an invoice with amount");
         const amountOut: bigint = (BigInt(parsedPr.millisatoshis) + 999n) / 1000n;
 
+        const lpVersions = Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
+
         const _options = this.toRequiredSwapOptions({...amountData, amount: amountOut}, options);
 
         if(parsedPr.tagsObject.payment_hash==null) throw new Error("Provided lightning invoice doesn't contain payment hash field!");
         await this.checkPaymentHashWasPaid(parsedPr.tagsObject.payment_hash);
 
-        const claimHash = this._contract.getHashForHtlc(Buffer.from(parsedPr.tagsObject.payment_hash, "hex"));
+        const _hash = mapArrayToObject(lpVersions, (contractVersion: string) => {
+            return this._contract(contractVersion).getHashForHtlc(Buffer.from(parsedPr.tagsObject.payment_hash!, "hex")).toString("hex");
+        });
 
         const _abortController = extendAbortController(abortSignal);
         const _preFetches = preFetches ?? {
             pricePreFetchPromise: this.preFetchPrice(amountData, _abortController.signal),
-            feeRatePromise: this.preFetchFeeRate(signer, amountData, claimHash.toString("hex"), _abortController),
+            feeRatePromise: this.preFetchFeeRate(signer, amountData, _hash, _abortController, lpVersions),
             usdPricePrefetchPromise: this.preFetchUsdPrice(_abortController.signal),
-            signDataPrefetchPromise: this._contract.preFetchBlockDataForSignatures==null ? this.preFetchSignData(Promise.resolve(true)) : undefined
+            signDataPrefetchPromise: mapArrayToObject(lpVersions, (contractVersion: string) => {
+                return this._contract(contractVersion).preFetchBlockDataForSignatures==null ?
+                    this.preFetchSignData(Promise.resolve(true), contractVersion) :
+                    undefined;
+            })
         };
 
         return lps.map(lp => {
@@ -451,7 +466,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
             expiryTimestamp: bigint
         },
         preFetches: {
-            feeRatePromise: Promise<string | undefined>,
+            feeRatePromise: {[contractVersion: string]: Promise<string | undefined>},
             pricePreFetchPromise: Promise<bigint | undefined>,
             usdPricePrefetchPromise: Promise<number | undefined>
         },
@@ -459,9 +474,10 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
         additionalParams?: Record<string, any>,
     ) {
         if(lp.services[SwapType.TO_BTCLN]==null) throw new Error("LP service for processing to btcln swaps not found!");
+        const version = lp.getContractVersion(this.chainIdentifier);
 
         const abortController = extendAbortController(abortSignal);
-        const reputationPromise = this.preFetchIntermediaryReputation(amountData, lp, abortController);
+        const reputationPromise = this.preFetchIntermediaryReputation(amountData, lp, abortController, version);
 
         try {
             const {signDataPromise, prepareResp} = await tryWithRetries(async(retryCount: number) => {
@@ -476,7 +492,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
                 }, this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined);
 
                 return {
-                    signDataPromise: this.preFetchSignData(signDataPrefetch),
+                    signDataPromise: this.preFetchSignData(signDataPrefetch, version),
                     prepareResp: await response
                 };
             }, undefined, e => e instanceof RequestError, abortController.signal);
@@ -498,7 +514,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
                 (retryCount: number) => IntermediaryAPI.initToBTCLNExactIn(lp.url, {
                     pr: invoice,
                     reqId: prepareResp.reqId,
-                    feeRate: throwIfUndefined(preFetches.feeRatePromise),
+                    feeRate: throwIfUndefined(preFetches.feeRatePromise[version]),
                     additionalParams
                 }, this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined),
                 undefined, RequestError, abortController.signal
@@ -507,7 +523,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
             if(parsedInvoice.millisatoshis==null) throw new Error("Swap invoice doesn't have msat amount field!");
             const amountOut: bigint = (BigInt(parsedInvoice.millisatoshis) + 999n) / 1000n;
             const totalFee: bigint = resp.swapFee + resp.maxFee;
-            const data: T["Data"] = new this._swapDataDeserializer(resp.data);
+            const data: T["Data"] = new (this._swapDataDeserializer(version))(resp.data);
             data.setOfferer(signer);
 
             await this.verifyReturnedData(signer, resp, parsedInvoice, amountData.token, lp, calculatedOptions, data, amountData.amount);
@@ -521,7 +537,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
                     preFetches.pricePreFetchPromise, preFetches.usdPricePrefetchPromise, abortSignal
                 ),
                 this.verifyReturnedSignature(
-                    signer, data, resp, preFetches.feeRatePromise, signDataPromise, abortController.signal
+                    signer, data, resp, preFetches.feeRatePromise[version], signDataPromise, version, abortController.signal
                 ),
                 reputationPromise
             ]);
@@ -535,14 +551,15 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
                 expiry: signatureExpiry,
                 swapFee: resp.swapFee,
                 swapFeeBtc,
-                feeRate: (await preFetches.feeRatePromise)!,
+                feeRate: (await preFetches.feeRatePromise[version])!,
                 signatureData: resp,
                 data,
                 networkFee: resp.maxFee,
                 networkFeeBtc: resp.routingFeeSats,
                 confidence: resp.confidence,
                 pr: invoice,
-                exactIn: true
+                exactIn: true,
+                contractVersion: version
             } as IToBTCSwapInit<T["Data"]>);
             return quote;
         } catch (e) {
@@ -578,13 +595,17 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
     }[]> {
         if(!this.isInitialized) throw new Error("Not initialized, call init() first!");
 
+        const lpVersions = Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
+
         const _abortController = extendAbortController(abortSignal);
         const pricePreFetchPromise: Promise<bigint | undefined> = this.preFetchPrice(amountData, _abortController.signal);
         const usdPricePrefetchPromise: Promise<number | undefined> = this.preFetchUsdPrice(_abortController.signal);
-        const feeRatePromise: Promise<string | undefined> = this.preFetchFeeRate(signer, amountData, undefined, _abortController);
-        const signDataPrefetchPromise: Promise<T["PreFetchVerification"] | undefined> | undefined = this._contract.preFetchBlockDataForSignatures==null ?
-            this.preFetchSignData(Promise.resolve(true)) :
-            undefined;
+        const feeRatePromise = this.preFetchFeeRate(signer, amountData, undefined, _abortController, lpVersions);
+        const signDataPrefetchPromise = mapArrayToObject(lpVersions, (contractVersion: string) => {
+            return this._contract(contractVersion).preFetchBlockDataForSignatures==null ?
+                this.preFetchSignData(Promise.resolve(true), contractVersion) :
+                undefined;
+        });
 
         const _options = this.toRequiredSwapOptions(amountData, options, pricePreFetchPromise, _abortController.signal);
 
@@ -716,6 +737,7 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
     async recoverFromSwapDataAndState(
         init: {data: T["Data"], getInitTxId: () => Promise<string>, getTxBlock: () => Promise<{blockTime: number, blockHeight: number}>},
         state: SwapCommitState,
+        contractVersion: string,
         lp?: Intermediary
     ): Promise<ToBTCLNSwap<T> | null> {
         const data = init.data;
@@ -747,7 +769,8 @@ export class ToBTCLNWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCL
             networkFeeBtc: 0n,
             confidence: 0,
             pr: paymentHash ?? undefined,
-            exactIn: false
+            exactIn: false,
+            contractVersion
         };
         const swap = new ToBTCLNSwap(this, swapInit);
         swap._commitTxId = await init.getInitTxId();

--- a/src/swaps/escrow_swaps/tobtc/onchain/ToBTCSwap.ts
+++ b/src/swaps/escrow_swaps/tobtc/onchain/ToBTCSwap.ts
@@ -102,7 +102,7 @@ export class ToBTCSwap<T extends ChainType = ChainType> extends IToBTCSwap<T, To
 
             const foundVout = btcTx.outs.find(vout => {
                 if(requiredConfirmations!=null) {
-                    return this._data.getClaimHash()===this.wrapper._contract.getHashForOnchain(
+                    return this._data.getClaimHash()===this._contract.getHashForOnchain(
                         Buffer.from(vout.scriptPubKey.hex, "hex"),
                         BigInt(vout.value),
                         requiredConfirmations,
@@ -111,7 +111,7 @@ export class ToBTCSwap<T extends ChainType = ChainType> extends IToBTCSwap<T, To
                 } else {
                     for(let i=1;i<=20;i++) {
                         if(
-                            this._data.getClaimHash()===this.wrapper._contract.getHashForOnchain(
+                            this._data.getClaimHash()===this._contract.getHashForOnchain(
                                 Buffer.from(vout.scriptPubKey.hex, "hex"),
                                 BigInt(vout.value),
                                 i,

--- a/src/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.ts
+++ b/src/swaps/escrow_swaps/tobtc/onchain/ToBTCWrapper.ts
@@ -15,7 +15,12 @@ import {Buffer} from "buffer";
 import {UserError} from "../../../../errors/UserError";
 import {IntermediaryError} from "../../../../errors/IntermediaryError";
 import {SwapType} from "../../../../enums/SwapType";
-import {extendAbortController, randomBytes, throwIfUndefined} from "../../../../utils/Utils";
+import {
+    extendAbortController,
+    mapArrayToObject,
+    randomBytes,
+    throwIfUndefined
+} from "../../../../utils/Utils";
 import {toOutputScript} from "../../../../utils/BitcoinUtils";
 import {IntermediaryAPI, ToBTCResponseType} from "../../../../intermediaries/apis/IntermediaryAPI";
 import {RequestError} from "../../../../errors/RequestError";
@@ -73,10 +78,9 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents Smart chain on-chain event listener
      * @param chain
-     * @param contract Chain specific swap contract
+     * @param versionedContracts Chain specific versioned contracts
      * @param prices Swap pricing handler
      * @param tokens
-     * @param swapDataDeserializer Deserializer for chain specific SwapData
      * @param btcRpc Bitcoin RPC api
      * @param options
      * @param events Instance to use for emitting events
@@ -86,16 +90,20 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
         unifiedStorage: UnifiedSwapStorage<T>,
         unifiedChainEvents: UnifiedSwapEventListener<T>,
         chain: T["ChainInterface"],
-        contract: T["Contract"],
         prices: ISwapPrice,
         tokens: WrapperCtorTokens,
-        swapDataDeserializer: new (data: any) => T["Data"],
+        versionedContracts: {
+            [version: string]: {
+                swapContract: T["Contract"],
+                swapDataConstructor: new (data: any) => T["Data"]
+            }
+        },
         btcRpc: BitcoinRpc<any>,
         options?: AllOptional<ToBTCWrapperOptions>,
         events?: EventEmitter<{swapState: [ISwap]}>
     ) {
         super(
-            chainIdentifier, unifiedStorage, unifiedChainEvents, chain, contract, prices, tokens, swapDataDeserializer,
+            chainIdentifier, unifiedStorage, unifiedChainEvents, chain, prices, tokens,
             {
                 ...options,
                 bitcoinNetwork: options?.bitcoinNetwork ?? TEST_NETWORK,
@@ -105,6 +113,7 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
                 maxExpectedOnchainSendSafetyFactor: options?.maxExpectedOnchainSendSafetyFactor ?? 4,
                 maxExpectedOnchainSendGracePeriodBlocks: options?.maxExpectedOnchainSendGracePeriodBlocks ?? 12,
             },
+            versionedContracts,
             events
         );
         this._btcRpc = btcRpc;
@@ -234,29 +243,35 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
             confirmationTarget: options?.confirmationTarget ?? 3,
             confirmations: options?.confirmations ?? 2
         };
+        const lpVersions = Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
 
         const nonce: bigint = this.getRandomNonce();
         const outputScript: Buffer = this.btcAddressToOutputScript(recipient);
-        const _hash: string | undefined = !amountData.exactIn ?
-            this._contract.getHashForOnchain(outputScript, amountData.amount, _options.confirmations, nonce).toString("hex") :
+        const _hash = !amountData.exactIn ?
+            mapArrayToObject(lpVersions, (contractVersion: string) => {
+                return this._contract(contractVersion).getHashForOnchain(outputScript, amountData.amount, _options.confirmations, nonce).toString("hex");
+            }) :
             undefined;
 
         const _abortController = extendAbortController(abortSignal);
         const pricePreFetchPromise: Promise<bigint | undefined> = this.preFetchPrice(amountData, _abortController.signal);
         const usdPricePrefetchPromise: Promise<number | undefined> = this.preFetchUsdPrice(_abortController.signal);
-        const feeRatePromise: Promise<string | undefined> = this.preFetchFeeRate(signer, amountData, _hash, _abortController);
-        const _signDataPromise: Promise<T["PreFetchVerification"] | undefined> | undefined = this._contract.preFetchBlockDataForSignatures==null ?
-            this.preFetchSignData(Promise.resolve(true)) :
-            undefined;
+        const feeRatePromise = this.preFetchFeeRate(signer, amountData, _hash, _abortController, lpVersions);
+        const _signDataPromise = mapArrayToObject(lpVersions, (contractVersion: string) => {
+            return this._contract(contractVersion).preFetchBlockDataForSignatures==null ?
+                this.preFetchSignData(Promise.resolve(true), contractVersion) :
+                undefined;
+        });
 
         return lps.map(lp => {
             return {
                 intermediary: lp,
                 quote: (async () => {
                     if(lp.services[SwapType.TO_BTC]==null) throw new Error("LP service for processing to btc swaps not found!");
+                    const version = lp.getContractVersion(this.chainIdentifier);
 
                     const abortController = extendAbortController(_abortController.signal);
-                    const reputationPromise: Promise<SingleChainReputationType | undefined> = this.preFetchIntermediaryReputation(amountData, lp, abortController);
+                    const reputationPromise: Promise<SingleChainReputationType | undefined> = this.preFetchIntermediaryReputation(amountData, lp, abortController, version);
 
                     try {
                         const {signDataPromise, resp} = await tryWithRetries(async(retryCount) => {
@@ -269,13 +284,13 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
                                 token: amountData.token,
                                 offerer: signer,
                                 exactIn: amountData.exactIn,
-                                feeRate: throwIfUndefined(feeRatePromise),
+                                feeRate: throwIfUndefined(feeRatePromise[version]),
                                 additionalParams
                             }, this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined);
 
-                            let signDataPromise = _signDataPromise;
+                            let signDataPromise = _signDataPromise[version];
                             if(signDataPromise==null) {
-                                signDataPromise = this.preFetchSignData(signDataPrefetch);
+                                signDataPromise = this.preFetchSignData(signDataPrefetch, version);
                             } else signDataPrefetch.catch(() => {});
 
                             return {
@@ -284,9 +299,9 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
                             };
                         }, undefined, RequestError, abortController.signal);
 
-                        let hash: string = _hash ?? this._contract.getHashForOnchain(outputScript, resp.amount, _options.confirmations, nonce).toString("hex");
+                        let hash: string = _hash?.[version] ?? this._contract(version).getHashForOnchain(outputScript, resp.amount, _options.confirmations, nonce).toString("hex");
 
-                        const data: T["Data"] = new this._swapDataDeserializer(resp.data);
+                        const data: T["Data"] = new (this._swapDataDeserializer(version))(resp.data);
                         data.setOfferer(signer);
 
                         const inputWithoutFees = data.getAmount() - resp.swapFee - resp.networkFee;
@@ -299,7 +314,7 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
                                 lp.services[SwapType.TO_BTC], true, resp.amount, data.getAmount(),
                                 amountData.token, {networkFee: resp.networkFee, swapFeeBtc}, pricePreFetchPromise, usdPricePrefetchPromise, abortController.signal
                             ),
-                            this.verifyReturnedSignature(signer, data, resp, feeRatePromise, signDataPromise, abortController.signal),
+                            this.verifyReturnedSignature(signer, data, resp, feeRatePromise[version], signDataPromise, version, abortController.signal),
                             reputationPromise
                         ]);
                         abortController.signal.throwIfAborted();
@@ -312,7 +327,7 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
                             expiry: signatureExpiry,
                             swapFee: resp.swapFee,
                             swapFeeBtc,
-                            feeRate: (await feeRatePromise)!,
+                            feeRate: (await feeRatePromise[version])!,
                             signatureData: resp,
                             data,
                             networkFee: resp.networkFee,
@@ -323,7 +338,8 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
                             satsPerVByte: Number(resp.satsPervByte),
                             exactIn: amountData.exactIn,
                             requiredConfirmations: _options.confirmations,
-                            nonce
+                            nonce,
+                            contractVersion: version
                         } as ToBTCSwapInit<T["Data"]>);
                         return quote;
                     } catch (e) {
@@ -341,6 +357,7 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
     async recoverFromSwapDataAndState(
         init: {data: T["Data"], getInitTxId: () => Promise<string>, getTxBlock: () => Promise<{blockTime: number, blockHeight: number}>},
         state: SwapCommitState,
+        contractVersion: string,
         lp?: Intermediary
     ): Promise<ToBTCSwap<T> | null> {
         const data = init.data;
@@ -367,7 +384,8 @@ export class ToBTCWrapper<T extends ChainType> extends IToBTCWrapper<T, ToBTCDef
             data,
             networkFee: 0n,
             networkFeeBtc: 0n,
-            exactIn: true
+            exactIn: true,
+            contractVersion
         };
         const swap = new ToBTCSwap(this, swapInit);
         swap._commitTxId = await init.getInitTxId();

--- a/src/swaps/spv_swaps/SpvFromBTCSwap.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCSwap.ts
@@ -276,6 +276,8 @@ export class SpvFromBTCSwap<T extends ChainType>
      */
     private btcTxConfirmedAt?: number;
 
+    private _contract: T["SpvVaultContract"];
+
     constructor(wrapper: SpvFromBTCWrapper<T>, init: SpvFromBTCSwapInit);
     constructor(wrapper: SpvFromBTCWrapper<T>, obj: any);
     constructor(wrapper: SpvFromBTCWrapper<T>, initOrObject: SpvFromBTCSwapInit | any) {
@@ -342,10 +344,12 @@ export class SpvFromBTCSwap<T extends ChainType>
             this.gasPricingInfo = deserializePriceInfoType(initOrObject.gasPricingInfo);
             this.btcTxConfirmedAt = initOrObject.btcTxConfirmedAt;
             this.posted = initOrObject.posted;
-            if(initOrObject.data!=null) this._data = new this.wrapper._spvWithdrawalDataDeserializer(initOrObject.data);
+            if(initOrObject.data!=null) this._data = new (this.wrapper._spvWithdrawalDataDeserializer(this._contractVersion))(initOrObject.data);
         }
         this.tryCalculateSwapFee();
         this.logger = getLogger("SPVFromBTC("+this.getId()+"): ");
+
+        this._contract = wrapper._contract(this._contractVersion);
     }
 
     /**
@@ -782,7 +786,7 @@ export class SpvFromBTCSwap<T extends ChainType>
 
         const out2script = toOutputScript(this.wrapper._options.bitcoinNetwork, this.btcDestinationAddress);
 
-        const opReturnData = this.wrapper._contract.toOpReturnData(
+        const opReturnData = this._contract.toOpReturnData(
             this.recipient,
             [
                 this.outputTotalSwap / this.vaultTokenMultipliers[0],
@@ -937,7 +941,7 @@ export class SpvFromBTCSwap<T extends ChainType>
             psbt.finalizeIdx(i);
         }
         const btcTx = await this.wrapper._btcRpc.parseTransaction(Buffer.from(psbt.toBytes(true)).toString("hex"));
-        const data = await this.wrapper._contract.getWithdrawalData(btcTx);
+        const data = await this._contract.getWithdrawalData(btcTx);
 
         this.logger.debug("submitPsbt(): parsed withdrawal data: ", data);
 
@@ -974,7 +978,7 @@ export class SpvFromBTCSwap<T extends ChainType>
 
         //Verify tx is parsable by the contract
         try {
-            await this.wrapper._contract.checkWithdrawalTx(data);
+            await this._contract.checkWithdrawalTx(data);
         } catch (e: any) {
             throw new Error("Transaction not parsable by the contract: "+(e.message ?? e.toString()));
         }
@@ -1276,7 +1280,7 @@ export class SpvFromBTCSwap<T extends ChainType>
         if(!this.isClaimable()) throw new Error("Must be in BTC_TX_CONFIRMED state!");
         if(this._data==null) throw new Error("Expected swap to have withdrawal data filled!");
 
-        const vaultData = await this.wrapper._contract.getVaultData(this.vaultOwner, this.vaultId);
+        const vaultData = await this._contract.getVaultData(this.vaultOwner, this.vaultId);
         if(vaultData==null) throw new Error(`Vault data for ${this.vaultOwner}:${this.vaultId.toString(10)} not found (already closed???)!`);
 
         const btcTx = await this.wrapper._btcRpc.getTransaction(this._data.btcTx.txid);
@@ -1294,13 +1298,13 @@ export class SpvFromBTCSwap<T extends ChainType>
         //Parse transactions to withdrawal data
         const withdrawalData: T["SpvVaultWithdrawalData"][] = [];
         for(let tx of txs) {
-            withdrawalData.push(await this.wrapper._contract.getWithdrawalData(tx));
+            withdrawalData.push(await this._contract.getWithdrawalData(tx));
         }
 
-        return await this.wrapper._contract.txsClaim(
+        return await this._contract.txsClaim(
             address ?? this._getInitiator(), vaultData,
             withdrawalData.map(tx => {return {tx}}),
-            this.wrapper._synchronizer, true
+            this.wrapper._synchronizer(this._contractVersion), true
         );
     }
 
@@ -1338,7 +1342,7 @@ export class SpvFromBTCSwap<T extends ChainType>
                 this.logger.info("claim(): Transaction state is CLAIMED, swap was successfully claimed by the watchtower");
                 return this._claimTxId!;
             }
-            const withdrawalState = await this.wrapper._contract.getWithdrawalState(this._data, this._genesisSmartChainBlockHeight);
+            const withdrawalState = await this._contract.getWithdrawalState(this._data, this._genesisSmartChainBlockHeight);
             if(withdrawalState!=null && withdrawalState.type===SpvWithdrawalStateType.CLAIMED) {
                 this.logger.info("claim(): Transaction status is CLAIMED, swap was successfully claimed by the watchtower");
                 this._claimTxId = withdrawalState.txId;
@@ -1377,7 +1381,7 @@ export class SpvFromBTCSwap<T extends ChainType>
             try {
                 //Be smart about checking withdrawal state
                 if(await this._shouldCheckWithdrawalState()) {
-                    status = await this.wrapper._contract.getWithdrawalState(
+                    status = await this._contract.getWithdrawalState(
                         this._data, this._genesisSmartChainBlockHeight
                     ) ?? {type: SpvWithdrawalStateType.NOT_FOUND};
                 }
@@ -1657,7 +1661,7 @@ export class SpvFromBTCSwap<T extends ChainType>
 
         if(this._state===SpvFromBTCSwapState.BROADCASTED || this._state===SpvFromBTCSwapState.BTC_TX_CONFIRMED) {
             if(await this._shouldCheckWithdrawalState()) {
-                const status = await this.wrapper._contract.getWithdrawalState(this._data!, this._genesisSmartChainBlockHeight);
+                const status = await this._contract.getWithdrawalState(this._data!, this._genesisSmartChainBlockHeight);
                 this.logger.debug("syncStateFromChain(): status of "+this._data!.btcTx.txid, status);
                 switch(status?.type) {
                     case SpvWithdrawalStateType.FRONTED:
@@ -1753,8 +1757,8 @@ export class SpvFromBTCSwap<T extends ChainType>
      * @internal
      */
     async _shouldCheckWithdrawalState(frontingAddress?: string | null, vaultDataUtxo?: string | null) {
-        if(frontingAddress===undefined) frontingAddress = await this.wrapper._contract.getFronterAddress(this.vaultOwner, this.vaultId, this._data!);
-        if(vaultDataUtxo===undefined) vaultDataUtxo = await this.wrapper._contract.getVaultLatestUtxo(this.vaultOwner, this.vaultId);
+        if(frontingAddress===undefined) frontingAddress = await this._contract.getFronterAddress(this.vaultOwner, this.vaultId, this._data!);
+        if(vaultDataUtxo===undefined) vaultDataUtxo = await this._contract.getVaultLatestUtxo(this.vaultOwner, this.vaultId);
 
         if(frontingAddress != null) return true; //In case the swap is fronted there will for sure be a fronted event
         if(vaultDataUtxo == null) return true; //Vault UTXO is null (the vault closed)

--- a/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
@@ -643,8 +643,14 @@ export class SpvFromBTCWrapper<
             maxAllowedBitcoinFeeRate: options?.maxAllowedBitcoinFeeRate ?? options?.maxAllowedNetworkFeeRate ?? Infinity
         };
 
-        if(amountData.token===this._chain.getNativeCurrencyAddress() && _options.gasAmount!==0n)
-            throw new UserError("Cannot specify `gasAmount` for swaps to a native token!");
+        if(
+            _options.gasAmount!==0n &&
+            (
+                this._chain.shouldGetNativeTokenDrop!=null
+                    ? !this._chain.shouldGetNativeTokenDrop(amountData.token)
+                    : amountData.token===this._chain.getNativeCurrencyAddress()
+            )
+        ) throw new UserError("Cannot specify `gasAmount` for swaps to a native token!");
 
         const lpVersions = Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
 

--- a/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
@@ -21,7 +21,7 @@ import {UnifiedSwapEventListener} from "../../events/UnifiedSwapEventListener";
 import {ISwapPrice} from "../../prices/abstract/ISwapPrice";
 import {EventEmitter} from "events";
 import {Intermediary} from "../../intermediaries/Intermediary";
-import {extendAbortController, randomBytes, throwIfUndefined} from "../../utils/Utils";
+import {extendAbortController, mapArrayToObject, randomBytes, throwIfUndefined} from "../../utils/Utils";
 import {fromOutputScript, toCoinselectAddressType, toOutputScript} from "../../utils/BitcoinUtils";
 import {IntermediaryAPI, SpvFromBTCPrepareResponseType} from "../../intermediaries/apis/IntermediaryAPI";
 import {RequestError} from "../../errors/RequestError";
@@ -118,7 +118,12 @@ export class SpvFromBTCWrapper<
     /**
      * @internal
      */
-    protected readonly btcRelay: T["BtcRelay"];
+    protected readonly btcRelay: (version?: string) => BtcRelay<any, T["TX"], any> = (version?: string) => {
+        const _version = version ?? "v1";
+        const data = this.versionedContracts[_version];
+        if(data==null) throw new Error(`Invalid contract version ${_version} requested`);
+        return data.btcRelay;
+    };
     /**
      * @internal
      */
@@ -134,11 +139,21 @@ export class SpvFromBTCWrapper<
     /**
      * @internal
      */
-    readonly _synchronizer: RelaySynchronizer<any, T["TX"], any>;
+    readonly _synchronizer: (version?: string) => RelaySynchronizer<any, T["TX"], any> = (version?: string) => {
+        const _version = version ?? "v1";
+        const data = this.versionedSynchronizer[_version];
+        if(data==null) throw new Error(`Invalid contract version ${_version} requested`);
+        return data.synchronizer;
+    };
     /**
      * @internal
      */
-    readonly _contract: T["SpvVaultContract"];
+    readonly _contract: (version?: string) => T["SpvVaultContract"] = (version?: string) => {
+        const _version = version ?? "v1";
+        const data = this.versionedContracts[_version];
+        if(data==null) throw new Error(`Invalid contract version ${_version} requested`);
+        return data.spvVaultContract;
+    };
     /**
      * @internal
      */
@@ -146,7 +161,13 @@ export class SpvFromBTCWrapper<
     /**
      * @internal
      */
-    readonly _spvWithdrawalDataDeserializer: new (data: any) => T["SpvVaultWithdrawalData"];
+    readonly _spvWithdrawalDataDeserializer: (version?: string) => (new (data: any) => T["SpvVaultWithdrawalData"]) = (version?: string) => {
+        const _version = version ?? "v1";
+        const data = this.versionedContracts[_version];
+        if(data==null) throw new Error(`Invalid contract version ${_version} requested`);
+        return data.spvVaultWithdrawalDataConstructor;
+    };
+
     /**
      * @internal
      */
@@ -160,17 +181,29 @@ export class SpvFromBTCWrapper<
         SpvFromBTCSwapState.BTC_TX_CONFIRMED
     ];
 
+    private readonly versionedContracts: {
+        [version: string]: {
+            btcRelay: BtcRelay<any, T["TX"], any>,
+            spvVaultContract: T["SpvVaultContract"],
+            spvVaultWithdrawalDataConstructor: new (data: any) => T["SpvVaultWithdrawalData"]
+        }
+    } = {};
+
+    private readonly versionedSynchronizer: {
+        [version: string]: {
+            synchronizer: RelaySynchronizer<any, T["TX"], any>
+        }
+    } = {};
+
     /**
      * @param chainIdentifier
      * @param unifiedStorage Storage interface for the current environment
      * @param unifiedChainEvents On-chain event listener
      * @param chain
-     * @param contract Underlying contract handling the swaps
      * @param prices Pricing to use
      * @param tokens
-     * @param spvWithdrawalDataDeserializer Deserializer for SpvVaultWithdrawalData
-     * @param btcRelay
-     * @param synchronizer Btc relay synchronizer
+     * @param versionedContracts
+     * @param versionedSynchronizer
      * @param btcRpc Bitcoin RPC which also supports getting transactions by txoHash
      * @param options
      * @param events Instance to use for emitting events
@@ -180,12 +213,20 @@ export class SpvFromBTCWrapper<
         unifiedStorage: UnifiedSwapStorage<T>,
         unifiedChainEvents: UnifiedSwapEventListener<T>,
         chain: T["ChainInterface"],
-        contract: T["SpvVaultContract"],
         prices: ISwapPrice,
         tokens: WrapperCtorTokens,
-        spvWithdrawalDataDeserializer: new (data: any) => T["SpvVaultWithdrawalData"],
-        btcRelay: BtcRelay<any, T["TX"], any>,
-        synchronizer: RelaySynchronizer<any, T["TX"], any>,
+        versionedContracts: {
+            [version: string]: {
+                btcRelay: BtcRelay<any, T["TX"], any>,
+                spvVaultContract: T["SpvVaultContract"],
+                spvVaultWithdrawalDataConstructor: new (data: any) => T["SpvVaultWithdrawalData"]
+            }
+        },
+        versionedSynchronizer: {
+            [version: string]: {
+                synchronizer: RelaySynchronizer<any, T["TX"], any>
+            }
+        },
         btcRpc: BitcoinRpcWithAddressIndex<any>,
         options?: AllOptional<SpvFromBTCWrapperOptions>,
         events?: EventEmitter<{swapState: [ISwap]}>
@@ -204,10 +245,8 @@ export class SpvFromBTCWrapper<
             },
             events
         );
-        this._spvWithdrawalDataDeserializer = spvWithdrawalDataDeserializer;
-        this._contract = contract;
-        this.btcRelay = btcRelay;
-        this._synchronizer = synchronizer;
+        this.versionedContracts = versionedContracts;
+        this.versionedSynchronizer = versionedSynchronizer;
         this._btcRpc = btcRpc;
     }
 
@@ -311,6 +350,7 @@ export class SpvFromBTCWrapper<
      * @param pricePrefetch
      * @param nativeTokenPricePrefetch
      * @param abortController
+     * @param contractVersion
      * @private
      */
     private async preFetchCallerFeeShare(
@@ -321,7 +361,8 @@ export class SpvFromBTCWrapper<
         },
         pricePrefetch: Promise<bigint | undefined>,
         nativeTokenPricePrefetch: Promise<bigint | undefined> | undefined,
-        abortController: AbortController
+        abortController: AbortController,
+        contractVersion: string
     ): Promise<bigint | undefined> {
         if(options.unsafeZeroWatchtowerFee) return 0n;
         if(amountData.amount===0n) return 0n;
@@ -334,10 +375,10 @@ export class SpvFromBTCWrapper<
                 claimFeeRate,
                 nativeTokenPrice
             ] = await Promise.all([
-                this.btcRelay.getFeePerBlock(),
-                this.btcRelay.getTipData(),
+                this.btcRelay(contractVersion).getFeePerBlock(),
+                this.btcRelay(contractVersion).getTipData(),
                 this._btcRpc.getTipHeight(),
-                this._contract.getClaimFee(this._chain.randomAddress()),
+                this._contract(contractVersion).getClaimFee(this._chain.randomAddress()),
                 nativeTokenPricePrefetch ?? (amountData.token===this._chain.getNativeCurrencyAddress() ?
                     pricePrefetch :
                     this._prices.preFetchPrice(this.chainIdentifier, this._chain.getNativeCurrencyAddress(), abortController.signal))
@@ -412,6 +453,8 @@ export class SpvFromBTCWrapper<
         abortSignal.throwIfAborted();
         if(btcFeeRate!=null && resp.btcFeeRate > btcFeeRate) throw new IntermediaryError(`Required bitcoin fee rate returned from the LP is too high! Maximum accepted: ${btcFeeRate} sats/vB, required by LP: ${resp.btcFeeRate} sats/vB`);
 
+        const lpVersion = lp.getContractVersion(this.chainIdentifier);
+
         //Vault related
         let vaultScript: Uint8Array;
         let vaultAddressType: CoinselectAddressTypes;
@@ -459,7 +502,7 @@ export class SpvFromBTCWrapper<
                 //Fetch vault data
                 let vault: T["SpvVaultData"] | null;
                 try {
-                    vault = await this._contract.getVaultData(resp.address, resp.vaultId);
+                    vault = await this._contract(lpVersion).getVaultData(resp.address, resp.vaultId);
                 } catch (e) {
                     this.logger.error("Error getting spv vault (owner: "+resp.address+" vaultId: "+resp.vaultId.toString(10)+"): ", e);
                     throw new IntermediaryError("Spv swap vault not found", e);
@@ -529,7 +572,7 @@ export class SpvFromBTCWrapper<
                 if(_btcTx==null) throw new IntermediaryError("Invalid ancestor transaction (not found)");
                 btcTx = _btcTx;
             }
-            const withdrawalData = await this._contract.getWithdrawalData(btcTx);
+            const withdrawalData = await this._contract(lpVersion).getWithdrawalData(btcTx);
             abortSignal.throwIfAborted();
             pendingWithdrawals.unshift(withdrawalData);
             utxo = pendingWithdrawals[0].getSpentVaultUtxo();
@@ -556,7 +599,7 @@ export class SpvFromBTCWrapper<
         //Also verify that all the withdrawal txns are valid, this is an extra sanity check
         try {
             for(let withdrawal of pendingWithdrawals) {
-                await this._contract.checkWithdrawalTx(withdrawal);
+                await this._contract(lpVersion).checkWithdrawalTx(withdrawal);
             }
         } catch (e) {
             this.logger.error("Error calculating spv vault balance (owner: "+resp.address+" vaultId: "+resp.vaultId.toString(10)+"): ", e);
@@ -603,6 +646,8 @@ export class SpvFromBTCWrapper<
         if(amountData.token===this._chain.getNativeCurrencyAddress() && _options.gasAmount!==0n)
             throw new UserError("Cannot specify `gasAmount` for swaps to a native token!");
 
+        const lpVersions = Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
+
         const _abortController = extendAbortController(abortSignal);
         const pricePrefetchPromise: Promise<bigint | undefined> = this.preFetchPrice(amountData, _abortController.signal);
         const usdPricePrefetchPromise: Promise<number | undefined> = this.preFetchUsdPrice(_abortController.signal);
@@ -611,7 +656,9 @@ export class SpvFromBTCWrapper<
         const gasTokenPricePrefetchPromise: Promise<bigint | undefined> | undefined = _options.gasAmount===0n ?
             undefined :
             this.preFetchPrice({token: nativeTokenAddress}, _abortController.signal);
-        const callerFeePrefetchPromise = this.preFetchCallerFeeShare(amountData, _options, pricePrefetchPromise, gasTokenPricePrefetchPromise, _abortController);
+        const callerFeePrefetchPromise = mapArrayToObject(lpVersions, (contractVersion: string) => {
+            return this.preFetchCallerFeeShare(amountData, _options, pricePrefetchPromise, gasTokenPricePrefetchPromise, _abortController, contractVersion);
+        });
         const bitcoinFeeRatePromise: Promise<number | undefined> = _options.maxAllowedBitcoinFeeRate!=Infinity ?
             Promise.resolve(_options.maxAllowedBitcoinFeeRate) :
             this._btcRpc.getFeeRate().then(x => this._options.maxBtcFeeOffset + (x*this._options.maxBtcFeeMultiplier)).catch(e => {
@@ -624,6 +671,7 @@ export class SpvFromBTCWrapper<
                 intermediary: lp,
                 quote: tryWithRetries(async () => {
                     if(lp.services[SwapType.SPV_VAULT_FROM_BTC]==null) throw new Error("LP service for processing spv vault swaps not found!");
+                    const version = lp.getContractVersion(this.chainIdentifier);
 
                     const abortController = extendAbortController(_abortController.signal);
 
@@ -638,7 +686,7 @@ export class SpvFromBTCWrapper<
                                     exactOut: !amountData.exactIn,
                                     gasToken: nativeTokenAddress,
                                     gasAmount: _options.gasAmount,
-                                    callerFeeRate: throwIfUndefined(callerFeePrefetchPromise, "Caller fee prefetch failed!"),
+                                    callerFeeRate: throwIfUndefined(callerFeePrefetchPromise[version], "Caller fee prefetch failed!"),
                                     frontingFeeRate: 0n,
                                     stickyAddress: options?.stickyAddress,
                                     additionalParams
@@ -649,7 +697,7 @@ export class SpvFromBTCWrapper<
 
                         this.logger.debug("create("+lp.url+"): LP response: ", resp)
 
-                        const callerFeeShare = (await callerFeePrefetchPromise)!;
+                        const callerFeeShare = (await callerFeePrefetchPromise[version])!;
 
                         const [
                             pricingInfo,
@@ -712,7 +760,8 @@ export class SpvFromBTCWrapper<
                             genesisSmartChainBlockHeight: await throwIfUndefined(
                                 finalizedBlockHeightPrefetchPromise,
                                 "Finalize block height promise failed!"
-                            )
+                            ),
+                            contractVersion: version
                         };
                         const quote = new SpvFromBTCSwap<T>(this, swapInit);
                         return quote;
@@ -732,14 +781,14 @@ export class SpvFromBTCWrapper<
      * @param vault SPV vault processing the swap
      * @param lp Intermediary (LP) used as a counterparty for the swap
      */
-    public async recoverFromState(state: SpvWithdrawalClaimedState | SpvWithdrawalFrontedState, vault?: SpvVaultData | null, lp?: Intermediary): Promise<SpvFromBTCSwap<T> | null> {
+    public async recoverFromState(state: SpvWithdrawalClaimedState | SpvWithdrawalFrontedState, contractVersion: string, vault?: SpvVaultData | null, lp?: Intermediary): Promise<SpvFromBTCSwap<T> | null> {
         //Get the vault
-        vault ??= await this._contract.getVaultData(state.owner, state.vaultId);
+        vault ??= await this._contract(contractVersion).getVaultData(state.owner, state.vaultId);
         if(vault==null) return null;
         if(state.btcTxId==null) return null;
         const btcTx = await this._btcRpc.getTransaction(state.btcTxId);
         if(btcTx==null) return null;
-        const withdrawalData = await this._contract.getWithdrawalData(btcTx)
+        const withdrawalData = await this._contract(contractVersion).getWithdrawalData(btcTx)
             .catch(e => {
                 this.logger.warn(`Error parsing withdrawal data for tx ${btcTx.txid}: `, e);
                 return null;
@@ -806,7 +855,9 @@ export class SpvFromBTCWrapper<
             frontingFeeShare: withdrawalData.frontingFeeRate,
             executionFeeShare: withdrawalData.executionFeeRate,
 
-            genesisSmartChainBlockHeight: txBlock?.blockHeight ?? 0
+            genesisSmartChainBlockHeight: txBlock?.blockHeight ?? 0,
+
+            contractVersion
         };
         const quote = new SpvFromBTCSwap<T>(this, swapInit);
         quote._data = withdrawalData;
@@ -861,15 +912,21 @@ export class SpvFromBTCWrapper<
             amount: 600n
         });
 
-        const opReturnData = this._contract.toOpReturnData(
-            this._chain.randomAddress(),
-            includeGasToken ? [0xFFFFFFFFFFFFFFFFn, 0xFFFFFFFFFFFFFFFFn] : [0xFFFFFFFFFFFFFFFFn]
-        );
+        let longestOpReturnData: Buffer | undefined = undefined;
+        for(let contractVersion in this.versionedContracts) {
+            if(this.versionedContracts[contractVersion].spvVaultContract==null) continue;
+            const opReturnData = this._contract(contractVersion).toOpReturnData(
+                this._chain.randomAddress(),
+                includeGasToken ? [0xFFFFFFFFFFFFFFFFn, 0xFFFFFFFFFFFFFFFFn] : [0xFFFFFFFFFFFFFFFFn]
+            );
+            if(longestOpReturnData==null || longestOpReturnData.length < opReturnData.length) longestOpReturnData = opReturnData;
+        }
+        if(longestOpReturnData==null) throw new Error(`No contract version supporting the Spv Vault BTC -> ${this.chainIdentifier} swaps found!`);
 
         psbt.addOutput({
             script: Buffer.concat([
-                opReturnData.length <= 75 ? Buffer.from([0x6a, opReturnData.length]) : Buffer.from([0x6a, 0x4c, opReturnData.length]),
-                opReturnData
+                longestOpReturnData.length <= 75 ? Buffer.from([0x6a, longestOpReturnData.length]) : Buffer.from([0x6a, 0x4c, longestOpReturnData.length]),
+                longestOpReturnData
             ]),
             amount: 0n
         });
@@ -888,7 +945,7 @@ export class SpvFromBTCWrapper<
         const changedSwaps: Set<SpvFromBTCSwap<T>> = new Set();
         const removeSwaps: SpvFromBTCSwap<T>[] = [];
 
-        const broadcastedOrConfirmedSwaps: (SpvFromBTCSwap<T> & {_data: T["SpvVaultWithdrawalData"]})[] = [];
+        const broadcastedOrConfirmedSwaps: {[version: string]: (SpvFromBTCSwap<T> & {_data: T["SpvVaultWithdrawalData"]})[]} = {};
 
         for(let pastSwap of pastSwaps) {
             let changed: boolean = false;
@@ -927,56 +984,65 @@ export class SpvFromBTCWrapper<
             if(changed) changedSwaps.add(pastSwap);
 
             if(pastSwap._state===SpvFromBTCSwapState.BROADCASTED || pastSwap._state===SpvFromBTCSwapState.BTC_TX_CONFIRMED) {
-                if(pastSwap._data!=null) broadcastedOrConfirmedSwaps.push(pastSwap as (SpvFromBTCSwap<T> & {_data: T["SpvVaultWithdrawalData"]}));
+                if(pastSwap._data!=null) (broadcastedOrConfirmedSwaps[pastSwap._contractVersion ?? "v1"] ??= []).push(pastSwap as (SpvFromBTCSwap<T> & {_data: T["SpvVaultWithdrawalData"]}));
             }
         }
 
-        const checkWithdrawalStateSwaps: (SpvFromBTCSwap<T> & {_data: T["SpvVaultWithdrawalData"]})[] = [];
-        const _fronts = await this._contract.getFronterAddresses(broadcastedOrConfirmedSwaps.map(val => ({
-            ...val.getSpvVaultData(),
-            withdrawal: val._data!
-        })));
-        const _vaultUtxos = await this._contract.getVaultLatestUtxos(broadcastedOrConfirmedSwaps.map(val => val.getSpvVaultData()));
-        for(const pastSwap of broadcastedOrConfirmedSwaps) {
-            const fronterAddress = _fronts[pastSwap._data.getTxId()];
-            const vault = pastSwap.getSpvVaultData();
-            const latestVaultUtxo = _vaultUtxos[vault.owner]?.[vault.vaultId.toString(10)];
-            if(fronterAddress===undefined) this.logger.warn(`_checkPastSwaps(): No fronter address returned for ${pastSwap._data.getTxId()}`);
-            if(latestVaultUtxo===undefined) this.logger.warn(`_checkPastSwaps(): No last vault utxo returned for ${pastSwap._data.getTxId()}`);
-            if(await pastSwap._shouldCheckWithdrawalState(fronterAddress, latestVaultUtxo)) checkWithdrawalStateSwaps.push(pastSwap);
-        }
-
-        const withdrawalStates = await this._contract.getWithdrawalStates(
-            checkWithdrawalStateSwaps.map(val => ({
-                withdrawal: val._data,
-                scStartBlockheight: val._genesisSmartChainBlockHeight
-            }))
-        );
-        for(const pastSwap of checkWithdrawalStateSwaps) {
-            const status = withdrawalStates[pastSwap._data.getTxId()];
-            if(status==null) {
-                this.logger.warn(`_checkPastSwaps(): No withdrawal state returned for ${pastSwap._data.getTxId()}`);
+        for(let contractVersion in broadcastedOrConfirmedSwaps) {
+            if(this.versionedContracts[contractVersion]==null) {
+                this.logger.warn(`_checkPastSwaps(): No contract was found for ${this.chainIdentifier} version ${contractVersion}! Skipping these swaps!`);
                 continue;
             }
-            this.logger.debug("syncStateFromChain(): status of "+pastSwap._data.btcTx.txid, status?.type);
-            let changed = false;
-            switch(status.type) {
-                case SpvWithdrawalStateType.FRONTED:
-                    pastSwap._frontTxId = status.txId;
-                    pastSwap._state = SpvFromBTCSwapState.FRONTED;
-                    changed ||= true;
-                    break;
-                case SpvWithdrawalStateType.CLAIMED:
-                    pastSwap._claimTxId = status.txId;
-                    pastSwap._state = SpvFromBTCSwapState.CLAIMED;
-                    changed ||= true;
-                    break;
-                case SpvWithdrawalStateType.CLOSED:
-                    pastSwap._state = SpvFromBTCSwapState.CLOSED;
-                    changed ||= true;
-                    break;
+
+            const _broadcastedOrConfirmedSwaps = broadcastedOrConfirmedSwaps[contractVersion];
+
+            const checkWithdrawalStateSwaps: (SpvFromBTCSwap<T> & {_data: T["SpvVaultWithdrawalData"]})[] = [];
+            const _fronts = await this._contract(contractVersion).getFronterAddresses(_broadcastedOrConfirmedSwaps.map(val => ({
+                ...val.getSpvVaultData(),
+                withdrawal: val._data!
+            })));
+            const _vaultUtxos = await this._contract(contractVersion).getVaultLatestUtxos(_broadcastedOrConfirmedSwaps.map(val => val.getSpvVaultData()));
+            for(const pastSwap of _broadcastedOrConfirmedSwaps) {
+                const fronterAddress = _fronts[pastSwap._data.getTxId()];
+                const vault = pastSwap.getSpvVaultData();
+                const latestVaultUtxo = _vaultUtxos[vault.owner]?.[vault.vaultId.toString(10)];
+                if(fronterAddress===undefined) this.logger.warn(`_checkPastSwaps(): No fronter address returned for ${pastSwap._data.getTxId()}`);
+                if(latestVaultUtxo===undefined) this.logger.warn(`_checkPastSwaps(): No last vault utxo returned for ${pastSwap._data.getTxId()}`);
+                if(await pastSwap._shouldCheckWithdrawalState(fronterAddress, latestVaultUtxo)) checkWithdrawalStateSwaps.push(pastSwap);
             }
-            if(changed) changedSwaps.add(pastSwap);
+
+            const withdrawalStates = await this._contract(contractVersion).getWithdrawalStates(
+                checkWithdrawalStateSwaps.map(val => ({
+                    withdrawal: val._data,
+                    scStartBlockheight: val._genesisSmartChainBlockHeight
+                }))
+            );
+            for(const pastSwap of checkWithdrawalStateSwaps) {
+                const status = withdrawalStates[pastSwap._data.getTxId()];
+                if(status==null) {
+                    this.logger.warn(`_checkPastSwaps(): No withdrawal state returned for ${pastSwap._data.getTxId()}`);
+                    continue;
+                }
+                this.logger.debug("syncStateFromChain(): status of "+pastSwap._data.btcTx.txid, status?.type);
+                let changed = false;
+                switch(status.type) {
+                    case SpvWithdrawalStateType.FRONTED:
+                        pastSwap._frontTxId = status.txId;
+                        pastSwap._state = SpvFromBTCSwapState.FRONTED;
+                        changed ||= true;
+                        break;
+                    case SpvWithdrawalStateType.CLAIMED:
+                        pastSwap._claimTxId = status.txId;
+                        pastSwap._state = SpvFromBTCSwapState.CLAIMED;
+                        changed ||= true;
+                        break;
+                    case SpvWithdrawalStateType.CLOSED:
+                        pastSwap._state = SpvFromBTCSwapState.CLOSED;
+                        changed ||= true;
+                        break;
+                }
+                if(changed) changedSwaps.add(pastSwap);
+            }
         }
 
         return {

--- a/src/swaps/trusted/ln/LnForGasWrapper.ts
+++ b/src/swaps/trusted/ln/LnForGasWrapper.ts
@@ -81,7 +81,8 @@ export class LnForGasWrapper<T extends ChainType> extends ISwapWrapper<T, LnForG
             swapFee: resp.swapFee,
             swapFeeBtc: resp.swapFeeSats,
             token,
-            exactIn: false
+            exactIn: false,
+            contractVersion: "v1"
         };
         const quote = new LnForGasSwap(this, quoteInit);
         return quote;

--- a/src/swaps/trusted/onchain/OnchainForGasWrapper.ts
+++ b/src/swaps/trusted/onchain/OnchainForGasWrapper.ts
@@ -122,7 +122,8 @@ export class OnchainForGasWrapper<T extends ChainType> extends ISwapWrapper<T, O
             swapFee: resp.swapFee,
             swapFeeBtc: resp.swapFeeSats,
             exactIn: false,
-            token
+            token,
+            contractVersion: "v1"
         } as OnchainForGasSwapInit);
         return quote;
     }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -47,6 +47,20 @@ export function promiseAny<T>(promises: Promise<T>[]): Promise<T> {
 }
 
 /**
+ * Maps an array to object properties using the translation function
+ *
+ * @param array
+ * @param translator
+ */
+export function mapArrayToObject<T extends string[], O>(array: T, translator: (key: T[number]) => O): {[key in T[number]]: O} {
+    const obj: any = {};
+    array.forEach((item) => {
+        obj[item] = translator(item);
+    });
+    return obj;
+}
+
+/**
  * Maps a JS object to another JS object based on the translation function, the translation function is called for every
  *  property (value/key) of the old object and returns the new value of for this property
  *


### PR DESCRIPTION
Allows the SDK to use multiple version of the swap contracts for a given chain. This allows for smooth transition between contract version in the following manner:
1. New smart contract version is deployed
2. The new deployment addresses are added a to the chain library as a new version
3. SDK users update the chain library, which now supports both contract versions at the same time, there has to be enough time allocated for this migration to take place - i.e. several weeks
4. The LPs update to use the new smart contract version, since SDK accepts both versions there will be a seamless transition
5. The old version eventually gets deprecated from the chain library

Also adds a new `destinationTokenSupportsGasDrop()` function to `SwapperUtils` and uses the new callback/function-style check of whether a given token should allow gas drop.