### PR TITLE
Add swapper.sweepBitcoinWallet() fn which sweeps full bitcoin wallet balance

### DIFF
--- a/dist/bitcoin/coinselect2/accumulative.d.ts
+++ b/dist/bitcoin/coinselect2/accumulative.d.ts
@@ -2,5 +2,6 @@ import { CoinselectAddressTypes, CoinselectTxInput, CoinselectTxOutput } from ".
 export declare function accumulative(utxos: CoinselectTxInput[], outputs: CoinselectTxOutput[], feeRate: number, type: CoinselectAddressTypes, requiredInputs?: CoinselectTxInput[]): {
     inputs?: CoinselectTxInput[];
     outputs?: CoinselectTxOutput[];
+    effectiveFeeRate?: number;
     fee: number;
 };

--- a/dist/bitcoin/coinselect2/accumulative.js
+++ b/dist/bitcoin/coinselect2/accumulative.js
@@ -7,7 +7,7 @@ const logger = (0, Logger_1.getLogger)("CoinSelect: ");
 // add inputs until we reach or surpass the target value (or deplete)
 // worst-case: O(n)
 function accumulative(utxos, outputs, feeRate, type, requiredInputs) {
-    if (!isFinite(utils_1.utils.uintOrNaN(feeRate)))
+    if (!isFinite(utils_1.utils.numberOrNaN(feeRate)))
         throw new Error("Invalid feeRate passed!");
     const inputs = requiredInputs == null ? [] : [...requiredInputs];
     let bytesAccum = utils_1.utils.transactionBytes(inputs, outputs, type);

--- a/dist/bitcoin/coinselect2/blackjack.d.ts
+++ b/dist/bitcoin/coinselect2/blackjack.d.ts
@@ -2,5 +2,6 @@ import { CoinselectAddressTypes, CoinselectTxInput, CoinselectTxOutput } from ".
 export declare function blackjack(utxos: CoinselectTxInput[], outputs: CoinselectTxOutput[], feeRate: number, type: CoinselectAddressTypes, requiredInputs?: CoinselectTxInput[]): {
     inputs?: CoinselectTxInput[];
     outputs?: CoinselectTxOutput[];
+    effectiveFeeRate?: number;
     fee: number;
 };

--- a/dist/bitcoin/coinselect2/blackjack.js
+++ b/dist/bitcoin/coinselect2/blackjack.js
@@ -5,7 +5,7 @@ const utils_1 = require("./utils");
 // add inputs until we reach or surpass the target value (or deplete)
 // worst-case: O(n)
 function blackjack(utxos, outputs, feeRate, type, requiredInputs) {
-    if (!isFinite(utils_1.utils.uintOrNaN(feeRate)))
+    if (!isFinite(utils_1.utils.numberOrNaN(feeRate)))
         throw new Error("Invalid feeRate passed!");
     const inputs = requiredInputs == null ? [] : [...requiredInputs];
     let bytesAccum = utils_1.utils.transactionBytes(inputs, outputs, type);

--- a/dist/bitcoin/coinselect2/index.d.ts
+++ b/dist/bitcoin/coinselect2/index.d.ts
@@ -5,12 +5,13 @@ export { CoinselectAddressTypes, CoinselectTxInput, CoinselectTxOutput, DUST_THR
 export declare function coinSelect(utxos: CoinselectTxInput[], outputs: CoinselectTxOutput[], feeRate: number, type: CoinselectAddressTypes, requiredInputs?: CoinselectTxInput[]): {
     inputs?: CoinselectTxInput[];
     outputs?: CoinselectTxOutput[];
+    effectiveFeeRate?: number;
     fee: number;
 };
-export declare function maxSendable(utxos: CoinselectTxInput[], output: {
+export declare function maxSendable(utxos: Omit<CoinselectTxInput, "txId" | "address" | "vout" | "outputScript">[], output: {
     script: Buffer;
     type: CoinselectAddressTypes;
-}, feeRate: number, requiredInputs?: CoinselectTxInput[], additionalOutputs?: {
+}, feeRate: number, requiredInputs?: Omit<CoinselectTxInput, "txId" | "address" | "vout" | "outputScript">[], additionalOutputs?: {
     script: Buffer;
     value: number;
 }[]): {

--- a/dist/bitcoin/coinselect2/index.js
+++ b/dist/bitcoin/coinselect2/index.js
@@ -42,7 +42,7 @@ function maxSendable(utxos, output, feeRate, requiredInputs, additionalOutputs) 
         const utxoFee = feeRate * utxoBytes;
         let cpfpFee = 0;
         if (utxo.cpfp != null && utxo.cpfp.txEffectiveFeeRate < feeRate)
-            cpfpFee = utxo.cpfp.txVsize * (feeRate - utxo.cpfp.txEffectiveFeeRate);
+            cpfpFee = Math.ceil(utxo.cpfp.txVsize * (feeRate - utxo.cpfp.txEffectiveFeeRate));
         const utxoValue = utils_1.utils.uintOrNaN(utxo.value);
         // skip detrimental input
         if (utxoFee + cpfpFee > utxo.value) {

--- a/dist/bitcoin/coinselect2/index.js
+++ b/dist/bitcoin/coinselect2/index.js
@@ -28,7 +28,7 @@ function coinSelect(utxos, outputs, feeRate, type, requiredInputs) {
 }
 exports.coinSelect = coinSelect;
 function maxSendable(utxos, output, feeRate, requiredInputs, additionalOutputs) {
-    if (!isFinite(utils_1.utils.uintOrNaN(feeRate)))
+    if (!isFinite(utils_1.utils.numberOrNaN(feeRate)))
         throw new Error("Invalid feeRate passed!");
     const outputs = additionalOutputs ?? [];
     const inputs = requiredInputs ?? [];

--- a/dist/bitcoin/coinselect2/utils.d.ts
+++ b/dist/bitcoin/coinselect2/utils.d.ts
@@ -52,6 +52,7 @@ declare function transactionBytes(inputs: {
     script?: Buffer;
     type?: CoinselectAddressTypes;
 }[], changeType?: CoinselectAddressTypes): number;
+declare function numberOrNaN(v: number): number;
 declare function uintOrNaN(v: number): number;
 declare function sumForgiving(range: {
     value: number;
@@ -75,6 +76,7 @@ export declare const utils: {
     sumForgiving: typeof sumForgiving;
     transactionBytes: typeof transactionBytes;
     uintOrNaN: typeof uintOrNaN;
+    numberOrNaN: typeof numberOrNaN;
     isDetrimentalInput: typeof isDetrimentalInput;
 };
 export {};

--- a/dist/bitcoin/coinselect2/utils.d.ts
+++ b/dist/bitcoin/coinselect2/utils.d.ts
@@ -59,11 +59,13 @@ declare function sumForgiving(range: {
 declare function sumOrNaN(range: {
     value: number;
 }[]): number;
-declare function finalize(inputs: CoinselectTxInput[], outputs: CoinselectTxOutput[], feeRate: number, changeType: CoinselectAddressTypes, cpfpAddFee?: number): {
-    inputs?: CoinselectTxInput[];
+declare function finalize<T extends Omit<CoinselectTxInput, "txId" | "address" | "vout" | "outputScript">>(inputs: T[], outputs: CoinselectTxOutput[], feeRate: number, changeType: CoinselectAddressTypes | null, cpfpAddFee?: number): {
+    inputs?: T[];
     outputs?: CoinselectTxOutput[];
+    effectiveFeeRate?: number;
     fee: number;
 };
+declare function isDetrimentalInput(feeRate: number, utxo: Omit<CoinselectTxInput, "txId" | "address" | "vout" | "outputScript">): boolean;
 export declare const utils: {
     dustThreshold: typeof dustThreshold;
     finalize: typeof finalize;
@@ -73,5 +75,6 @@ export declare const utils: {
     sumForgiving: typeof sumForgiving;
     transactionBytes: typeof transactionBytes;
     uintOrNaN: typeof uintOrNaN;
+    isDetrimentalInput: typeof isDetrimentalInput;
 };
 export {};

--- a/dist/bitcoin/coinselect2/utils.js
+++ b/dist/bitcoin/coinselect2/utils.js
@@ -91,25 +91,49 @@ function sumOrNaN(range) {
     return range.reduce((a, x) => a + uintOrNaN(x.value), 0);
 }
 function finalize(inputs, outputs, feeRate, changeType, cpfpAddFee = 0) {
-    const bytesAccum = transactionBytes(inputs, outputs, changeType);
+    const bytesAccum = transactionBytes(inputs, outputs, changeType ?? undefined);
     logger.debug("finalize(): Transaction bytes: ", bytesAccum);
-    const feeAfterExtraOutput = (feeRate * (bytesAccum + outputBytes({ type: changeType }))) + cpfpAddFee;
-    logger.debug("finalize(): TX fee after adding change output: ", feeAfterExtraOutput);
-    const remainderAfterExtraOutput = Math.floor(sumOrNaN(inputs) - (sumOrNaN(outputs) + feeAfterExtraOutput));
-    logger.debug("finalize(): Leaves change (changeType=" + changeType + ") value: ", remainderAfterExtraOutput);
-    // is it worth a change output?
-    if (remainderAfterExtraOutput >= dustThreshold({ type: changeType })) {
-        outputs = outputs.concat({ value: remainderAfterExtraOutput, type: changeType });
+    if (changeType != null) {
+        const feeAfterExtraOutput = (feeRate * (bytesAccum + outputBytes({ type: changeType }))) + cpfpAddFee;
+        logger.debug("finalize(): TX fee after adding change output: ", feeAfterExtraOutput);
+        const remainderAfterExtraOutput = Math.floor(sumOrNaN(inputs) - (sumOrNaN(outputs) + feeAfterExtraOutput));
+        logger.debug("finalize(): Leaves change (changeType=" + changeType + ") value: ", remainderAfterExtraOutput);
+        // is it worth a change output?
+        if (remainderAfterExtraOutput >= dustThreshold({ type: changeType })) {
+            outputs = outputs.concat({ value: remainderAfterExtraOutput, type: changeType });
+        }
     }
     const fee = sumOrNaN(inputs) - sumOrNaN(outputs);
     logger.debug("finalize(): Re-calculated total fee: ", fee);
-    if (!isFinite(fee))
+    if (!isFinite(fee) || fee < 0)
         return { fee: (feeRate * bytesAccum) + cpfpAddFee };
+    let txVSize = exports.utils.transactionBytes(inputs, outputs);
+    let txFee = fee;
+    const cpfpSortedInputs = [...inputs].sort((a, b) => (b.cpfp?.txEffectiveFeeRate ?? 0) - (a.cpfp?.txEffectiveFeeRate ?? 0));
+    cpfpSortedInputs.forEach(input => {
+        if (input.cpfp == null)
+            return;
+        const currentEffectiveFeeRate = txFee / txVSize;
+        if (currentEffectiveFeeRate > input.cpfp.txEffectiveFeeRate) {
+            txVSize += input.cpfp.txVsize;
+            txFee += input.cpfp.txVsize * input.cpfp.txEffectiveFeeRate;
+        }
+    });
     return {
         inputs: inputs,
         outputs: outputs,
+        effectiveFeeRate: txFee / txVSize,
         fee: fee
     };
+}
+function isDetrimentalInput(feeRate, utxo) {
+    const utxoBytes = exports.utils.inputBytes(utxo);
+    const utxoFee = feeRate * utxoBytes;
+    let cpfpFee = 0;
+    if (utxo.cpfp != null && utxo.cpfp.txEffectiveFeeRate < feeRate)
+        cpfpFee = Math.ceil(utxo.cpfp.txVsize * (feeRate - utxo.cpfp.txEffectiveFeeRate));
+    // skip detrimental input
+    return utxoFee + cpfpFee > utxo.value;
 }
 exports.utils = {
     dustThreshold: dustThreshold,
@@ -119,5 +143,6 @@ exports.utils = {
     sumOrNaN: sumOrNaN,
     sumForgiving: sumForgiving,
     transactionBytes: transactionBytes,
-    uintOrNaN: uintOrNaN
+    uintOrNaN: uintOrNaN,
+    isDetrimentalInput
 };

--- a/dist/bitcoin/coinselect2/utils.js
+++ b/dist/bitcoin/coinselect2/utils.js
@@ -73,6 +73,15 @@ function transactionBytes(inputs, outputs, changeType) {
     }
     return Math.ceil(size);
 }
+function numberOrNaN(v) {
+    if (typeof v !== 'number')
+        return NaN;
+    if (!isFinite(v))
+        return NaN;
+    if (v < 0)
+        return NaN;
+    return v;
+}
 function uintOrNaN(v) {
     if (typeof v !== 'number')
         return NaN;
@@ -144,5 +153,6 @@ exports.utils = {
     sumForgiving: sumForgiving,
     transactionBytes: transactionBytes,
     uintOrNaN: uintOrNaN,
+    numberOrNaN: numberOrNaN,
     isDetrimentalInput
 };

--- a/dist/bitcoin/wallet/BitcoinWallet.d.ts
+++ b/dist/bitcoin/wallet/BitcoinWallet.d.ts
@@ -1,29 +1,8 @@
-/// <reference types="node" />
-/// <reference types="node" />
 import { CoinselectAddressTypes } from "../coinselect2";
 import { BTC_NETWORK } from "@scure/btc-signer/utils";
 import { Transaction } from "@scure/btc-signer";
-import { IBitcoinWallet } from "./IBitcoinWallet";
-import { Buffer } from "buffer";
+import { BitcoinWalletUtxo, BitcoinWalletUtxoBase, IBitcoinWallet } from "./IBitcoinWallet";
 import { BitcoinNetwork, BitcoinRpcWithAddressIndex } from "@atomiqlabs/base";
-/**
- * UTXO data structure for Bitcoin wallets
- *
- * @category Bitcoin
- */
-export type BitcoinWalletUtxo = {
-    vout: number;
-    txId: string;
-    value: number;
-    type: CoinselectAddressTypes;
-    outputScript: Buffer;
-    address: string;
-    cpfp?: {
-        txVsize: number;
-        txEffectiveFeeRate: number;
-    };
-    confirmed: boolean;
-};
 /**
  * Identifies the address type of a Bitcoin address
  *
@@ -96,7 +75,7 @@ export declare abstract class BitcoinWallet implements IBitcoinWallet {
         pubkey: string;
         address: string;
         addressType: CoinselectAddressTypes;
-    }[], psbt: Transaction, feeRate?: number): Promise<{
+    }[], psbt: Transaction, _feeRate?: number, utxos?: BitcoinWalletUtxo[], spendFully?: boolean): Promise<{
         fee: number;
         psbt?: Transaction;
         inputAddressIndexes?: {
@@ -106,13 +85,13 @@ export declare abstract class BitcoinWallet implements IBitcoinWallet {
     protected _getSpendableBalance(sendingAccounts: {
         address: string;
         addressType: CoinselectAddressTypes;
-    }[], psbt?: Transaction, feeRate?: number): Promise<{
+    }[], psbt?: Transaction, feeRate?: number, outputAddressType?: CoinselectAddressTypes, utxoPool?: BitcoinWalletUtxoBase[]): Promise<{
         balance: bigint;
         feeRate: number;
         totalFee: number;
     }>;
     abstract sendTransaction(address: string, amount: bigint, feeRate?: number): Promise<string>;
-    abstract fundPsbt(psbt: Transaction, feeRate?: number): Promise<Transaction>;
+    abstract fundPsbt(psbt: Transaction, feeRate?: number, utxos?: BitcoinWalletUtxo[], spendFully?: boolean): Promise<Transaction>;
     abstract signPsbt(psbt: Transaction, signInputs: number[]): Promise<Transaction>;
     abstract getTransactionFee(address: string, amount: bigint, feeRate?: number): Promise<number>;
     abstract getFundedPsbtFee(psbt: Transaction, feeRate?: number): Promise<number>;
@@ -127,4 +106,8 @@ export declare abstract class BitcoinWallet implements IBitcoinWallet {
         totalFee: number;
     }>;
     static bitcoinNetworkToObject(network: BitcoinNetwork): BTC_NETWORK;
+    static getSpendableBalance(utxoPool: BitcoinWalletUtxoBase[], feeRate: number, psbt?: Transaction, outputAddressType?: CoinselectAddressTypes): {
+        balance: bigint;
+        totalFee: number;
+    };
 }

--- a/dist/bitcoin/wallet/BitcoinWallet.js
+++ b/dist/bitcoin/wallet/BitcoinWallet.js
@@ -5,10 +5,10 @@ const coinselect2_1 = require("../coinselect2");
 const utils_1 = require("@scure/btc-signer/utils");
 const btc_signer_1 = require("@scure/btc-signer");
 const buffer_1 = require("buffer");
-const Utils_1 = require("../../utils/Utils");
 const BitcoinUtils_1 = require("../../utils/BitcoinUtils");
 const Logger_1 = require("../../utils/Logger");
 const base_1 = require("@atomiqlabs/base");
+const utils_2 = require("../coinselect2/utils");
 /**
  * Identifies the address type of a Bitcoin address
  *
@@ -135,10 +135,11 @@ class BitcoinWallet {
         });
         return this._fundPsbt(sendingAccounts, psbt, feeRate);
     }
-    async _fundPsbt(sendingAccounts, psbt, feeRate) {
-        if (feeRate == null)
-            feeRate = await this.getFeeRate();
-        const utxoPool = (await Promise.all(sendingAccounts.map(acc => this._getUtxoPool(acc.address, acc.addressType)))).flat();
+    async _fundPsbt(sendingAccounts, psbt, _feeRate, utxos, spendFully) {
+        const feeRate = _feeRate ?? await this.getFeeRate();
+        const utxoPool = utxos ?? (await Promise.all(sendingAccounts.map(acc => this._getUtxoPool(acc.address, acc.addressType)))).flat();
+        if (spendFully && utxoPool == null)
+            throw new Error("Cannot fully spend when no utxos are passed!");
         logger.debug("_fundPsbt(): fee rate: " + feeRate + " utxo pool: ", utxoPool);
         const accountPubkeys = {};
         sendingAccounts.forEach(acc => accountPubkeys[acc.address] = acc.pubkey);
@@ -177,12 +178,22 @@ class BitcoinWallet {
             });
         }
         logger.debug("_fundPsbt(): Coinselect targets: ", targets);
-        let coinselectResult = (0, coinselect2_1.coinSelect)(utxoPool, targets, feeRate, sendingAccounts[0].addressType, requiredInputs);
+        let coinselectResult = spendFully
+            ? utils_2.utils.finalize(requiredInputs.concat(utxoPool.filter(utxo => !utils_2.utils.isDetrimentalInput(feeRate, utxo))), targets, feeRate, null)
+            : (0, coinselect2_1.coinSelect)(utxoPool, targets, feeRate, sendingAccounts[0].addressType, requiredInputs);
         logger.debug("_fundPsbt(): Coinselect result: ", coinselectResult);
-        if (coinselectResult.inputs == null || coinselectResult.outputs == null) {
+        if (coinselectResult.inputs == null || coinselectResult.outputs == null || coinselectResult.effectiveFeeRate == null) {
             return {
                 fee: coinselectResult.fee
             };
+        }
+        if (spendFully && feeRate != null) {
+            const maximumAllowedFeeRate = (1.5 * feeRate) + 10;
+            if (coinselectResult.effectiveFeeRate > maximumAllowedFeeRate)
+                throw new Error(`Effective fee rate too high, feeRate: ${coinselectResult.effectiveFeeRate} sats/vB, maximum: ${maximumAllowedFeeRate} sats/vB!`);
+            const minimumAllowedFeeRate = 0.9 * feeRate;
+            if (coinselectResult.effectiveFeeRate < minimumAllowedFeeRate)
+                throw new Error(`Effective fee rate too low, feeRate: ${coinselectResult.effectiveFeeRate} sats/vB, minimum: ${minimumAllowedFeeRate} sats/vB!`);
         }
         // Remove in/outs that are already in the PSBT
         coinselectResult.inputs.splice(0, psbt.inputsLength);
@@ -264,9 +275,18 @@ class BitcoinWallet {
             inputAddressIndexes
         };
     }
-    async _getSpendableBalance(sendingAccounts, psbt, feeRate) {
+    async _getSpendableBalance(sendingAccounts, psbt, feeRate, outputAddressType, utxoPool) {
         feeRate ??= await this.getFeeRate();
-        const utxoPool = (await Promise.all(sendingAccounts.map(acc => this._getUtxoPool(acc.address, acc.addressType)))).flat();
+        utxoPool ??= (await Promise.all(sendingAccounts.map(acc => this._getUtxoPool(acc.address, acc.addressType)))).flat();
+        return {
+            ...BitcoinWallet.getSpendableBalance(utxoPool ?? (await Promise.all(sendingAccounts.map(acc => this._getUtxoPool(acc.address, acc.addressType)))).flat(), feeRate ?? await this.getFeeRate(), psbt, outputAddressType),
+            feeRate
+        };
+    }
+    static bitcoinNetworkToObject(network) {
+        return btcNetworkMapping[network];
+    }
+    static getSpendableBalance(utxoPool, feeRate, psbt, outputAddressType) {
         const requiredInputs = [];
         if (psbt != null)
             for (let i = 0; i < psbt.inputsLength; i++) {
@@ -303,20 +323,13 @@ class BitcoinWallet {
                     script: buffer_1.Buffer.from(output.script)
                 });
             }
-        const target = btc_signer_1.OutScript.encode({
-            type: "wsh",
-            hash: (0, Utils_1.randomBytes)(32)
-        });
-        let coinselectResult = (0, coinselect2_1.maxSendable)(utxoPool, { script: buffer_1.Buffer.from(target), type: "p2wsh" }, feeRate, requiredInputs, additionalOutputs);
+        const target = (0, BitcoinUtils_1.getDummyOutputScript)(outputAddressType ?? "p2wsh");
+        let coinselectResult = (0, coinselect2_1.maxSendable)(utxoPool, { script: buffer_1.Buffer.from(target), type: outputAddressType ?? "p2wsh" }, feeRate, requiredInputs, additionalOutputs);
         logger.debug("_getSpendableBalance(): Max spendable result: ", coinselectResult);
         return {
-            feeRate: feeRate,
             balance: BigInt(Math.floor(coinselectResult.value)),
             totalFee: coinselectResult.fee
         };
-    }
-    static bitcoinNetworkToObject(network) {
-        return btcNetworkMapping[network];
     }
 }
 exports.BitcoinWallet = BitcoinWallet;

--- a/dist/bitcoin/wallet/IBitcoinWallet.d.ts
+++ b/dist/bitcoin/wallet/IBitcoinWallet.d.ts
@@ -1,4 +1,32 @@
+/// <reference types="node" />
+/// <reference types="node" />
 import { Transaction } from "@scure/btc-signer";
+import { CoinselectAddressTypes } from "../coinselect2";
+/**
+ * UTXO data structure for Bitcoin wallets
+ *
+ * @category Bitcoin
+ */
+export type BitcoinWalletUtxo = {
+    vout: number;
+    txId: string;
+    value: number;
+    type: CoinselectAddressTypes;
+    outputScript: Buffer;
+    address: string;
+    cpfp?: {
+        txVsize: number;
+        txEffectiveFeeRate: number;
+    };
+    confirmed: boolean;
+};
+/**
+ * Base UTXO data structure used for maximum spendable balance calculation, doesn't contain all the fields necessary
+ *  for constructing the full transaction.
+ *
+ * @category Bitcoin
+ */
+export type BitcoinWalletUtxoBase = Omit<BitcoinWalletUtxo, "txId" | "vout" | "outputScript" | "address" | "confirmed">;
 /**
  * Type guard to check if an object implements {@link IBitcoinWallet}
  *
@@ -25,8 +53,12 @@ export interface IBitcoinWallet {
      *
      * @param psbt PSBT to add the inputs to
      * @param feeRate Optional fee rate in sats/vB to use for the transaction
+     * @param utxos Pre-fetched list of UTXOs to spend from
+     * @param spendFully Instructs the wallet to spend all the passed UTXOs in the transaction without creating any
+     *  change output, if the `feeRate` is passed, it will also enforce that the feeRate in sats/vB for the resulting
+     *  transaction is not more than 50% and 10 sats/vB larger (considering also the CPFP adjustments)
      */
-    fundPsbt(psbt: Transaction, feeRate?: number): Promise<Transaction>;
+    fundPsbt(psbt: Transaction, feeRate?: number, utxos?: BitcoinWalletUtxo[], spendFully?: boolean): Promise<Transaction>;
     /**
      * Signs inputs in the provided PSBT
      *
@@ -69,10 +101,16 @@ export interface IBitcoinWallet {
      *
      * @param psbt A PSBT to which additional inputs from wallet's UTXO set will be added and fee estimated
      * @param feeRate Optional fee rate in sats/vB to use for the transaction
+     * @param outputAddressType Expected output address type, if known
+     * @param utxos Optional pre-fetched UTXOs
      */
-    getSpendableBalance(psbt?: Transaction, feeRate?: number): Promise<{
+    getSpendableBalance(psbt?: Transaction, feeRate?: number, outputAddressType?: CoinselectAddressTypes, utxos?: BitcoinWalletUtxoBase[]): Promise<{
         balance: bigint;
         feeRate: number;
         totalFee: number;
     }>;
+    /**
+     * Returns a list of available UTXOs for the wallet
+     */
+    getUtxoPool?(): Promise<BitcoinWalletUtxo[]>;
 }

--- a/dist/bitcoin/wallet/SingleAddressBitcoinWallet.d.ts
+++ b/dist/bitcoin/wallet/SingleAddressBitcoinWallet.d.ts
@@ -6,6 +6,7 @@ import { Transaction } from "@scure/btc-signer";
 import { Buffer } from "buffer";
 import { BitcoinWallet } from "./BitcoinWallet";
 import { BitcoinNetwork, BitcoinRpcWithAddressIndex } from "@atomiqlabs/base";
+import { BitcoinWalletUtxo, BitcoinWalletUtxoBase } from "./IBitcoinWallet";
 /**
  * Bitcoin wallet implementation deriving a single address from a WIF encoded private key
  *
@@ -37,7 +38,7 @@ export declare class SingleAddressBitcoinWallet extends BitcoinWallet {
     /**
      * @inheritDoc
      */
-    fundPsbt(inputPsbt: Transaction, feeRate?: number): Promise<Transaction>;
+    fundPsbt(inputPsbt: Transaction, feeRate?: number, utxos?: BitcoinWalletUtxo[], spendFully?: boolean): Promise<Transaction>;
     /**
      * @inheritDoc
      */
@@ -68,11 +69,15 @@ export declare class SingleAddressBitcoinWallet extends BitcoinWallet {
     /**
      * @inheritDoc
      */
-    getSpendableBalance(psbt?: Transaction, feeRate?: number): Promise<{
+    getSpendableBalance(psbt?: Transaction, feeRate?: number, outputAddressType?: CoinselectAddressTypes, utxos?: BitcoinWalletUtxoBase[]): Promise<{
         balance: bigint;
         feeRate: number;
         totalFee: number;
     }>;
+    /**
+     * @inheritDoc
+     */
+    getUtxoPool(): Promise<BitcoinWalletUtxo[]>;
     /**
      * Generates a new random private key WIF that can be used to instantiate the bitcoin wallet instance
      *

--- a/dist/bitcoin/wallet/SingleAddressBitcoinWallet.js
+++ b/dist/bitcoin/wallet/SingleAddressBitcoinWallet.js
@@ -80,8 +80,8 @@ class SingleAddressBitcoinWallet extends BitcoinWallet_1.BitcoinWallet {
     /**
      * @inheritDoc
      */
-    async fundPsbt(inputPsbt, feeRate) {
-        const { psbt } = await super._fundPsbt(this.toBitcoinWalletAccounts(), inputPsbt, feeRate);
+    async fundPsbt(inputPsbt, feeRate, utxos, spendFully) {
+        const { psbt } = await super._fundPsbt(this.toBitcoinWalletAccounts(), inputPsbt, feeRate, utxos, spendFully);
         if (psbt == null) {
             throw new Error("Not enough balance!");
         }
@@ -133,8 +133,14 @@ class SingleAddressBitcoinWallet extends BitcoinWallet_1.BitcoinWallet {
     /**
      * @inheritDoc
      */
-    getSpendableBalance(psbt, feeRate) {
-        return this._getSpendableBalance([{ address: this.address, addressType: this.addressType }], psbt, feeRate);
+    getSpendableBalance(psbt, feeRate, outputAddressType, utxos) {
+        return this._getSpendableBalance([{ address: this.address, addressType: this.addressType }], psbt, feeRate, outputAddressType, utxos);
+    }
+    /**
+     * @inheritDoc
+     */
+    async getUtxoPool() {
+        return this._getUtxoPool(this.address, this.addressType);
     }
     /**
      * Generates a new random private key WIF that can be used to instantiate the bitcoin wallet instance

--- a/dist/intermediaries/apis/IntermediaryAPI.d.ts
+++ b/dist/intermediaries/apis/IntermediaryAPI.d.ts
@@ -234,17 +234,27 @@ declare const SpvFromBTCPrepareResponseSchema: {
     readonly callerFeeShare: FieldTypeEnum.BigInt;
     readonly frontingFeeShare: FieldTypeEnum.BigInt;
     readonly executionFeeShare: FieldTypeEnum.BigInt;
+    readonly usedUtxoInputCalculation: FieldTypeEnum.BooleanOptional;
 };
 export type SpvFromBTCPrepareResponseType = RequestSchemaResult<typeof SpvFromBTCPrepareResponseSchema>;
 export type SpvFromBTCPrepare = SwapInit & {
     address: string;
-    amount: bigint;
+    amount: Promise<bigint>;
     gasAmount: bigint;
     gasToken: string;
     exactOut: boolean;
     callerFeeRate: Promise<bigint>;
     frontingFeeRate: bigint;
     stickyAddress?: boolean;
+    amountUtxos?: Promise<{
+        value: number;
+        vSize: number;
+        cpfp?: {
+            effectiveVSize: number;
+            effectiveFeeRate: number;
+        };
+    }[] | undefined>;
+    amountFeeRate?: Promise<number | undefined>;
 };
 declare const SpvFromBTCInitResponseSchema: {
     readonly txId: FieldTypeEnum.String;

--- a/dist/intermediaries/apis/IntermediaryAPI.js
+++ b/dist/intermediaries/apis/IntermediaryAPI.js
@@ -123,7 +123,8 @@ const SpvFromBTCPrepareResponseSchema = {
     gasSwapFee: SchemaVerifier_1.FieldTypeEnum.BigInt,
     callerFeeShare: SchemaVerifier_1.FieldTypeEnum.BigInt,
     frontingFeeShare: SchemaVerifier_1.FieldTypeEnum.BigInt,
-    executionFeeShare: SchemaVerifier_1.FieldTypeEnum.BigInt
+    executionFeeShare: SchemaVerifier_1.FieldTypeEnum.BigInt,
+    usedUtxoInputCalculation: SchemaVerifier_1.FieldTypeEnum.BooleanOptional
 };
 const SpvFromBTCInitResponseSchema = {
     txId: SchemaVerifier_1.FieldTypeEnum.String
@@ -534,17 +535,31 @@ class IntermediaryAPI {
      * @throws {RequestError} If non-200 http response code is returned
      */
     static prepareSpvFromBTC(chainIdentifier, baseUrl, init, timeout, abortSignal, streamRequest) {
+        //We need to make sure we only send the amount parameter after the amountUtxos and amountFeeRate resolve
+        // this is needed, because in the LP code to maintain backwards compatibility the amountUtxos and amountFeeRate
+        // params are checked immediately after the amount param (and other params) are received, if amount were sent
+        // first without the amountUtxos or amountFeeRate populated these fields would've been skipped altogether
+        const amountPromise = (async () => {
+            if (init.amountUtxos != null)
+                await init.amountUtxos;
+            if (init.amountFeeRate != null)
+                await init.amountFeeRate;
+            const amount = await init.amount;
+            return amount.toString(10);
+        })();
         const responseBodyPromise = (0, StreamingFetchPromise_1.streamingFetchPromise)(baseUrl + "/frombtc_spv/getQuote?chain=" + encodeURIComponent(chainIdentifier), {
             exactOut: init.exactOut,
             ...init.additionalParams,
             address: init.address,
-            amount: init.amount.toString(10),
+            amount: amountPromise,
             token: init.token,
             gasAmount: init.gasAmount.toString(10),
             gasToken: init.gasToken,
             frontingFeeRate: init.frontingFeeRate.toString(10),
             callerFeeRate: init.callerFeeRate.then(val => val.toString(10)),
-            stickyAddress: init.stickyAddress
+            stickyAddress: init.stickyAddress,
+            amountUtxos: init.amountUtxos,
+            amountFeeRate: init.amountFeeRate
         }, {
             code: SchemaVerifier_1.FieldTypeEnum.Number,
             msg: SchemaVerifier_1.FieldTypeEnum.String,

--- a/dist/swapper/Swapper.d.ts
+++ b/dist/swapper/Swapper.d.ts
@@ -39,6 +39,8 @@ import { LNURLPay } from "../types/lnurl/LNURLPay";
 import { NotNever } from "../utils/TypeUtils";
 import { LightningInvoiceCreateService } from "../types/wallets/LightningInvoiceCreateService";
 import { SwapSide } from "../enums/SwapSide";
+import { BitcoinWalletUtxo, IBitcoinWallet } from "../bitcoin/wallet/IBitcoinWallet";
+import { MinimalBitcoinWalletInterface } from "../types/wallets/MinimalBitcoinWalletInterface";
 /**
  * Configuration options for the Swapper
  * @category Core
@@ -346,7 +348,7 @@ export declare class Swapper<T extends MultiChain> extends EventEmitter<{
      * @param additionalParams Additional parameters sent to the LP when creating the swap
      * @param options Additional options for the swap
      */
-    createFromBTCSwapNew<ChainIdentifier extends ChainIds<T>>(chainIdentifier: ChainIdentifier, recipient: string, tokenAddress: string, amount: bigint, exactOut?: boolean, additionalParams?: Record<string, any> | undefined, options?: SpvFromBTCOptions): Promise<SpvFromBTCSwap<T[ChainIdentifier]>>;
+    createFromBTCSwapNew<ChainIdentifier extends ChainIds<T>>(chainIdentifier: ChainIdentifier, recipient: string, tokenAddress: string, amount: bigint | null, exactOut?: boolean, additionalParams?: Record<string, any> | undefined, options?: SpvFromBTCOptions): Promise<SpvFromBTCSwap<T[ChainIdentifier]>>;
     /**
      * Creates LEGACY Bitcoin -> Smart chain ({@link SwapType.FROM_BTC}) swap
      *
@@ -505,6 +507,44 @@ export declare class Swapper<T extends MultiChain> extends EventEmitter<{
     swap<C extends ChainIds<T>>(srcToken: Token<C> | string, dstToken: Token<C> | string, amount: bigint | string | undefined, exactIn: boolean | SwapAmountType, src: undefined | string | LNURLWithdraw, dst: string | LNURLPay | LightningInvoiceCreateService, options?: FromBTCLNOptions | SpvFromBTCOptions | FromBTCOptions | ToBTCOptions | (ToBTCLNOptions & {
         comment?: string;
     }) | FromBTCLNAutoOptions): Promise<ISwap<T[C]>>;
+    /**
+     * A helper function to sweep all the funds from a given wallet in a single swap, after getting the quote you can
+     *  execute the swap by passing the returned `feeRate` and `utxos` to the {@link SpvFromBTCSwap.execute},
+     *  {@link SpvFromBTCSwap.getFundedPsbt} or {@link SpvFromBTCSwap.sendBitcoinTransaction} functions along
+     *  with `spendFully=true`.
+     *
+     * @example
+     * Create the swap first using this function
+     * ```ts
+     * const {swap, utxos, btcFeeRate} = await swapper.sweepBitcoinWallet(wallet, Tokens.CITREA.CBTC, dstAddress);
+     * ```
+     * Then execute it using one of these execution paths - ensure that you supply the returned `utxos`, `btcFeeRate`
+     *  params and also set `spendFully` to `true`!
+     *
+     * a) Execute and pass the returned utxos and btcFeeRate:
+     * ```ts
+     * await swap.execute(wallet, undefined, {feeRate: btcFeeRate, utxos: utxos, spendFully: true});
+     * ```
+     *
+     * b) Get funded PSBT to sign externally:
+     * ```ts
+     * const {psbt, psbtHex, psbtBase64, signInputs} = await swap.getFundedPsbt(wallet, btcFeeRate, undefined, utxos, true);
+     * // Sign the psbt at the specified signInputs indices
+     * const signedPsbt = ...;
+     * // Then submit back to the SDK
+     * await swap.submitPsbt(signedPsbt);
+     * ```
+     *
+     * c) Only sign and send the signed PSBT with the provided wallet:
+     * ```ts
+     * await swap.sendBitcoinTransaction(wallet, btcFeeRate, utxos, true);
+     * ```
+     */
+    sweepBitcoinWallet<C extends ChainIds<T>>(srcWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, _dstToken: SCToken<C> | string, dstAddress: string, options?: SpvFromBTCOptions): Promise<{
+        swap: SpvFromBTCSwap<T[C]>;
+        utxos: BitcoinWalletUtxo[];
+        btcFeeRate: number;
+    }>;
     /**
      * Returns all swaps
      */

--- a/dist/swapper/Swapper.js
+++ b/dist/swapper/Swapper.js
@@ -951,7 +951,7 @@ class Swapper extends events_1.EventEmitter {
         if (wallet.getUtxoPool == null)
             throw new Error("Wallet needs to support the `getUtxoPool()` function!");
         const walletUtxosPromise = wallet.getUtxoPool();
-        const bitcoinFeeRatePromise = wallet.getFeeRate();
+        const bitcoinFeeRatePromise = options?.bitcoinFeeRate ?? wallet.getFeeRate();
         const swap = await this.createFromBTCSwapNew(dstToken.chainId, dstAddress, dstToken.address, null, false, undefined, {
             ...options,
             sourceWalletUtxos: walletUtxosPromise,

--- a/dist/swapper/Swapper.js
+++ b/dist/swapper/Swapper.js
@@ -35,6 +35,7 @@ const LNURLPay_1 = require("../types/lnurl/LNURLPay");
 const RetryUtils_1 = require("../utils/RetryUtils");
 const IEscrowSwap_1 = require("../swaps/escrow_swaps/IEscrowSwap");
 const LightningInvoiceCreateService_1 = require("../types/wallets/LightningInvoiceCreateService");
+const BitcoinWalletUtils_1 = require("../utils/BitcoinWalletUtils");
 /**
  * Core orchestrator for all atomiq swap operations
  *
@@ -343,7 +344,7 @@ class Swapper extends events_1.EventEmitter {
             throw new Error("Invalid chain identifier! Unknown chain: " + chainIdentifier);
         let candidates;
         const inBtc = swapType === SwapType_1.SwapType.TO_BTCLN || swapType === SwapType_1.SwapType.TO_BTC ? !amountData.exactIn : amountData.exactIn;
-        if (!inBtc) {
+        if (!inBtc || amountData.amount == null) {
             //Get candidates not based on the amount
             candidates = this.intermediaryDiscovery.getSwapCandidates(chainIdentifier, swapType, amountData.token);
         }
@@ -355,7 +356,7 @@ class Swapper extends events_1.EventEmitter {
             this.logger.warn("createSwap(): No valid intermediary found to execute the swap with, reloading intermediary database...");
             await this.intermediaryDiscovery.reloadIntermediaries();
             swapLimitsChanged = true;
-            if (!inBtc) {
+            if (!inBtc || amountData.amount == null) {
                 //Get candidates not based on the amount
                 candidates = this.intermediaryDiscovery.getSwapCandidates(chainIdentifier, swapType, amountData.token);
             }
@@ -441,10 +442,12 @@ class Swapper extends events_1.EventEmitter {
                         }
                         if (min != null && max != null) {
                             let msg = "Swap amount too high or too low! Try swapping a different amount.";
-                            if (min > amountData.amount)
-                                msg = "Swap amount too low! Try swapping a higher amount.";
-                            if (max < amountData.amount)
-                                msg = "Swap amount too high! Try swapping a lower amount.";
+                            if (amountData.amount != null) {
+                                if (min > amountData.amount)
+                                    msg = "Swap amount too low! Try swapping a higher amount.";
+                                if (max < amountData.amount)
+                                    msg = "Swap amount too high! Try swapping a lower amount.";
+                            }
                             reject(new RequestError_1.OutOfBoundsError(msg, 400, min, max));
                             return;
                         }
@@ -612,7 +615,7 @@ class Swapper extends events_1.EventEmitter {
             throw new Error("Invalid " + chainIdentifier + " address");
         recipient = this._chains[chainIdentifier].chainInterface.normalizeAddress(recipient);
         const amountData = {
-            amount,
+            amount: amount ?? undefined,
             token: tokenAddress,
             exactIn: !exactOut
         };
@@ -906,6 +909,59 @@ class Swapper extends events_1.EventEmitter {
             }
         }
         throw new Error("Unsupported swap type");
+    }
+    /**
+     * A helper function to sweep all the funds from a given wallet in a single swap, after getting the quote you can
+     *  execute the swap by passing the returned `feeRate` and `utxos` to the {@link SpvFromBTCSwap.execute},
+     *  {@link SpvFromBTCSwap.getFundedPsbt} or {@link SpvFromBTCSwap.sendBitcoinTransaction} functions along
+     *  with `spendFully=true`.
+     *
+     * @example
+     * Create the swap first using this function
+     * ```ts
+     * const {swap, utxos, btcFeeRate} = await swapper.sweepBitcoinWallet(wallet, Tokens.CITREA.CBTC, dstAddress);
+     * ```
+     * Then execute it using one of these execution paths - ensure that you supply the returned `utxos`, `btcFeeRate`
+     *  params and also set `spendFully` to `true`!
+     *
+     * a) Execute and pass the returned utxos and btcFeeRate:
+     * ```ts
+     * await swap.execute(wallet, undefined, {feeRate: btcFeeRate, utxos: utxos, spendFully: true});
+     * ```
+     *
+     * b) Get funded PSBT to sign externally:
+     * ```ts
+     * const {psbt, psbtHex, psbtBase64, signInputs} = await swap.getFundedPsbt(wallet, btcFeeRate, undefined, utxos, true);
+     * // Sign the psbt at the specified signInputs indices
+     * const signedPsbt = ...;
+     * // Then submit back to the SDK
+     * await swap.submitPsbt(signedPsbt);
+     * ```
+     *
+     * c) Only sign and send the signed PSBT with the provided wallet:
+     * ```ts
+     * await swap.sendBitcoinTransaction(wallet, btcFeeRate, utxos, true);
+     * ```
+     */
+    async sweepBitcoinWallet(srcWallet, _dstToken, dstAddress, options) {
+        const dstToken = typeof (_dstToken) === "string" ? this.getToken(_dstToken) : _dstToken;
+        if (!(0, Token_1.isSCToken)(dstToken))
+            throw new Error("Destination token must be a smart chain token!");
+        const wallet = (0, BitcoinWalletUtils_1.toBitcoinWallet)(srcWallet, this._bitcoinRpc, this.bitcoinNetwork);
+        if (wallet.getUtxoPool == null)
+            throw new Error("Wallet needs to support the `getUtxoPool()` function!");
+        const walletUtxosPromise = wallet.getUtxoPool();
+        const bitcoinFeeRatePromise = wallet.getFeeRate();
+        const swap = await this.createFromBTCSwapNew(dstToken.chainId, dstAddress, dstToken.address, null, false, undefined, {
+            ...options,
+            sourceWalletUtxos: walletUtxosPromise,
+            bitcoinFeeRate: bitcoinFeeRatePromise
+        });
+        return {
+            swap,
+            utxos: await walletUtxosPromise,
+            btcFeeRate: Math.max(swap.minimumBtcFeeRate, await bitcoinFeeRatePromise)
+        };
     }
     async getAllSwaps(chainId, signer) {
         const queryParams = [];

--- a/dist/swaps/spv_swaps/SpvFromBTCSwap.d.ts
+++ b/dist/swaps/spv_swaps/SpvFromBTCSwap.d.ts
@@ -4,7 +4,7 @@ import { SwapType } from "../../enums/SwapType";
 import { SpvFromBTCTypeDefinition, SpvFromBTCWrapper } from "./SpvFromBTCWrapper";
 import { Transaction } from "@scure/btc-signer";
 import { Fee } from "../../types/fees/Fee";
-import { IBitcoinWallet } from "../../bitcoin/wallet/IBitcoinWallet";
+import { BitcoinWalletUtxo, IBitcoinWallet } from "../../bitcoin/wallet/IBitcoinWallet";
 import { IBTCWalletSwap } from "../IBTCWalletSwap";
 import { ISwapWithGasDrop } from "../ISwapWithGasDrop";
 import { MinimalBitcoinWalletInterface, MinimalBitcoinWalletInterfaceWithSigner } from "../../types/wallets/MinimalBitcoinWalletInterface";
@@ -423,6 +423,10 @@ export declare class SpvFromBTCSwap<T extends ChainType> extends ISwap<T, SpvFro
      * @param _bitcoinWallet Sender's bitcoin wallet
      * @param feeRate Optional fee rate in sats/vB for the transaction
      * @param additionalOutputs additional outputs to add to the PSBT - can be used to collect fees from users
+     * @param utxos Pre-fetched list of UTXOs to spend from
+     * @param spendFully Instructs the wallet to spend all the passed UTXOs in the transaction without creating any
+     *  change output, if the `feeRate` is passed, it will also enforce that the feeRate in sats/vB for the resulting
+     *  transaction is not more than 50% and 10 sats/vB larger (considering also the CPFP adjustments)
      */
     getFundedPsbt(_bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface, feeRate?: number, additionalOutputs?: ({
         amount: bigint;
@@ -430,7 +434,7 @@ export declare class SpvFromBTCSwap<T extends ChainType> extends ISwap<T, SpvFro
     } | {
         amount: bigint;
         address: string;
-    })[]): Promise<{
+    })[], utxos?: BitcoinWalletUtxo[], spendFully?: boolean): Promise<{
         psbt: Transaction;
         psbtHex: string;
         psbtBase64: string;
@@ -447,7 +451,7 @@ export declare class SpvFromBTCSwap<T extends ChainType> extends ISwap<T, SpvFro
     /**
      * @inheritDoc
      */
-    sendBitcoinTransaction(wallet: IBitcoinWallet | MinimalBitcoinWalletInterfaceWithSigner, feeRate?: number): Promise<string>;
+    sendBitcoinTransaction(wallet: IBitcoinWallet | MinimalBitcoinWalletInterfaceWithSigner, feeRate?: number, utxos?: BitcoinWalletUtxo[], spendFully?: boolean): Promise<string>;
     /**
      * Executes the swap with the provided bitcoin wallet
      *
@@ -469,6 +473,8 @@ export declare class SpvFromBTCSwap<T extends ChainType> extends ISwap<T, SpvFro
         abortSignal?: AbortSignal;
         btcTxCheckIntervalSeconds?: number;
         maxWaitTillAutomaticSettlementSeconds?: number;
+        utxos?: BitcoinWalletUtxo[];
+        spendFully?: boolean;
     }): Promise<boolean>;
     /**
      * @inheritDoc

--- a/dist/swaps/spv_swaps/SpvFromBTCSwap.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCSwap.js
@@ -637,8 +637,12 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
      * @param _bitcoinWallet Sender's bitcoin wallet
      * @param feeRate Optional fee rate in sats/vB for the transaction
      * @param additionalOutputs additional outputs to add to the PSBT - can be used to collect fees from users
+     * @param utxos Pre-fetched list of UTXOs to spend from
+     * @param spendFully Instructs the wallet to spend all the passed UTXOs in the transaction without creating any
+     *  change output, if the `feeRate` is passed, it will also enforce that the feeRate in sats/vB for the resulting
+     *  transaction is not more than 50% and 10 sats/vB larger (considering also the CPFP adjustments)
      */
-    async getFundedPsbt(_bitcoinWallet, feeRate, additionalOutputs) {
+    async getFundedPsbt(_bitcoinWallet, feeRate, additionalOutputs, utxos, spendFully) {
         const bitcoinWallet = (0, BitcoinWalletUtils_1.toBitcoinWallet)(_bitcoinWallet, this.wrapper._btcRpc, this.wrapper._options.bitcoinNetwork);
         if (feeRate != null) {
             if (feeRate < this.minimumBtcFeeRate)
@@ -655,7 +659,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
                     script: output.outputScript ?? (0, BitcoinUtils_1.toOutputScript)(this.wrapper._options.bitcoinNetwork, output.address)
                 });
             });
-        psbt = await bitcoinWallet.fundPsbt(psbt, feeRate);
+        psbt = await bitcoinWallet.fundPsbt(psbt, feeRate, utxos, spendFully);
         psbt.updateInput(1, { sequence: in1sequence });
         //Sign every input except the first one
         const signInputs = [];
@@ -759,8 +763,8 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
     /**
      * @inheritDoc
      */
-    async sendBitcoinTransaction(wallet, feeRate) {
-        const { psbt, psbtBase64, psbtHex, signInputs } = await this.getFundedPsbt(wallet, feeRate);
+    async sendBitcoinTransaction(wallet, feeRate, utxos, spendFully) {
+        const { psbt, psbtBase64, psbtHex, signInputs } = await this.getFundedPsbt(wallet, feeRate, undefined, utxos, spendFully);
         let signedPsbt;
         if ((0, IBitcoinWallet_1.isIBitcoinWallet)(wallet)) {
             signedPsbt = await wallet.signPsbt(psbt, signInputs);
@@ -795,7 +799,7 @@ class SpvFromBTCSwap extends ISwap_1.ISwap {
         if (this._state === SpvFromBTCSwapState.CLAIMED || this._state === SpvFromBTCSwapState.FRONTED)
             throw new Error("Swap already settled or fronted!");
         if (this._state === SpvFromBTCSwapState.CREATED) {
-            const txId = await this.sendBitcoinTransaction(wallet, options?.feeRate);
+            const txId = await this.sendBitcoinTransaction(wallet, options?.feeRate, options?.utxos, options?.spendFully);
             if (callbacks?.onSourceTransactionSent != null)
                 callbacks.onSourceTransactionSent(txId);
         }

--- a/dist/swaps/spv_swaps/SpvFromBTCWrapper.d.ts
+++ b/dist/swaps/spv_swaps/SpvFromBTCWrapper.d.ts
@@ -9,11 +9,12 @@ import { UnifiedSwapEventListener } from "../../events/UnifiedSwapEventListener"
 import { ISwapPrice } from "../../prices/abstract/ISwapPrice";
 import { EventEmitter } from "events";
 import { Intermediary } from "../../intermediaries/Intermediary";
+import { CoinselectAddressTypes } from "../../bitcoin/coinselect2";
 import { Transaction } from "@scure/btc-signer";
 import { ISwap } from "../ISwap";
 import { IClaimableSwapWrapper } from "../IClaimableSwapWrapper";
-import { AmountData } from "../../types/AmountData";
 import { AllOptional } from "../../utils/TypeUtils";
+import { BitcoinWalletUtxoBase } from "../../bitcoin/wallet/IBitcoinWallet";
 export type SpvFromBTCOptions = {
     /**
      * Optional additional native token to receive as an output of the swap (e.g. STRK on Starknet or cBTC on Citrea).
@@ -54,6 +55,16 @@ export type SpvFromBTCOptions = {
      */
     stickyAddress?: boolean;
     /**
+     * A bitcoin wallet UTXOs to fully use as an input for this swap, use this option along with passing `amount` as
+     *  `undefined` when you want to swap the full BTC balance of the wallet in a single swap
+     */
+    sourceWalletUtxos?: BitcoinWalletUtxoBase[] | Promise<BitcoinWalletUtxoBase[]>;
+    /**
+     * Bitcoin fee rate to use when deriving `maxAllowedBitcoinFeeRate` and when calculating the input amount based
+     *  on the `sourceWalletUtxos`
+     */
+    bitcoinFeeRate?: Promise<number> | number;
+    /**
      * @deprecated Use `maxAllowedBitcoinFeeRate` instead!
      */
     maxAllowedNetworkFeeRate?: number;
@@ -68,6 +79,8 @@ export type SpvFromBTCWrapperOptions = ISwapWrapperOptions & {
     maxBtcFeeOffset: number;
 };
 export type SpvFromBTCTypeDefinition<T extends ChainType> = SwapTypeDefinition<T, SpvFromBTCWrapper<T>, SpvFromBTCSwap<T>>;
+export declare const REQUIRED_SPV_SWAP_VAULT_ADDRESS_TYPE: CoinselectAddressTypes;
+export declare const REQUIRED_SPV_SWAP_LP_ADDRESS_TYPE: CoinselectAddressTypes;
 /**
  * New spv vault (UTXO-controlled vault) based swaps for Bitcoin -> Smart chain swaps not requiring
  *  any initiation on the destination chain, and with the added possibility for the user to receive
@@ -162,13 +175,25 @@ export declare class SpvFromBTCWrapper<T extends ChainType> extends ISwapWrapper
      *
      * @param amountData
      * @param options Options as passed to the swap creation function
-     * @param pricePrefetch
-     * @param nativeTokenPricePrefetch
      * @param abortController
      * @param contractVersion
      * @private
      */
-    private preFetchCallerFeeShare;
+    private preFetchCallerFeeInNativeToken;
+    /**
+     * Pre-fetches caller (watchtower) bounty data for the swap. Doesn't throw, instead returns null and aborts the
+     *  provided abortController
+     *
+     * @param amountPrefetch
+     * @param totalFeeInNativeTokenPrefetch
+     * @param amountData
+     * @param options Options as passed to the swap creation function
+     * @param pricePrefetch
+     * @param nativeTokenPricePrefetch
+     * @param abortSignal
+     * @private
+     */
+    private computeCallerFeeShare;
     /**
      * Verifies response returned from intermediary
      *
@@ -177,12 +202,15 @@ export declare class SpvFromBTCWrapper<T extends ChainType> extends ISwapWrapper
      * @param lp Intermediary
      * @param options Options as passed to the swap creation function
      * @param callerFeeShare
-     * @param bitcoinFeeRatePromise Maximum accepted fee rate from the LPs
+     * @param maxBitcoinFeeRatePromise Maximum accepted fee rate from the LPs
+     * @param bitcoinFeeRatePromise
      * @param abortSignal
      * @private
      * @throws {IntermediaryError} in case the response is invalid
      */
     private verifyReturnedData;
+    private amountPrefetch;
+    private bitcoinFeeRatePrefetch;
     /**
      * Returns a newly created Bitcoin -> Smart chain swap using the SPV vault (UTXO-controlled vault) swap protocol,
      *  with the passed amount. Also allows specifying additional "gas drop" native token that the receipient receives
@@ -195,7 +223,11 @@ export declare class SpvFromBTCWrapper<T extends ChainType> extends ISwapWrapper
      * @param additionalParams Optional additional parameters sent to the LP when creating the swap
      * @param abortSignal Abort signal
      */
-    create(recipient: string, amountData: AmountData, lps: Intermediary[], options?: SpvFromBTCOptions, additionalParams?: Record<string, any>, abortSignal?: AbortSignal): {
+    create(recipient: string, amountData: {
+        amount?: bigint;
+        token: string;
+        exactIn: boolean;
+    }, lps: Intermediary[], options?: SpvFromBTCOptions, additionalParams?: Record<string, any>, abortSignal?: AbortSignal): {
         quote: Promise<SpvFromBTCSwap<T>>;
         intermediary: Intermediary;
     }[];

--- a/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
@@ -500,8 +500,6 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             if (walletUtxos.length === 0)
                 throw new UserError_1.UserError("Wallet doesn't have any BTC balance");
             const spendableBalance = await BitcoinWallet_1.BitcoinWallet.getSpendableBalance(walletUtxos, bitcoinFeeRate, this.getDummySwapPsbt(includeGas), exports.REQUIRED_SPV_SWAP_LP_ADDRESS_TYPE);
-            if (spendableBalance.balance <= 0n)
-                throw new UserError_1.UserError("Wallet doesn't have enough BTC balance to cover transaction fees");
             return spendableBalance.balance;
         }
         catch (e) {
@@ -679,6 +677,12 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
                         return quote;
                     }
                     catch (e) {
+                        if (e instanceof RequestError_1.OutOfBoundsError) {
+                            const amountResult = await amountPromise.catch(() => undefined);
+                            if (_options.sourceWalletUtxos != null && amountResult != null && amountResult <= 0n) {
+                                e = new UserError_1.UserError("Wallet doesn't have enough BTC balance to cover transaction fees");
+                            }
+                        }
                         abortController.abort(e);
                         throw e;
                     }

--- a/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
+++ b/dist/swaps/spv_swaps/SpvFromBTCWrapper.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.SpvFromBTCWrapper = void 0;
+exports.SpvFromBTCWrapper = exports.REQUIRED_SPV_SWAP_LP_ADDRESS_TYPE = exports.REQUIRED_SPV_SWAP_VAULT_ADDRESS_TYPE = void 0;
 const ISwapWrapper_1 = require("../ISwapWrapper");
 const base_1 = require("@atomiqlabs/base");
 const SpvFromBTCSwap_1 = require("./SpvFromBTCSwap");
@@ -15,6 +15,10 @@ const IntermediaryError_1 = require("../../errors/IntermediaryError");
 const btc_signer_1 = require("@scure/btc-signer");
 const RetryUtils_1 = require("../../utils/RetryUtils");
 const UserError_1 = require("../../errors/UserError");
+const utils_2 = require("../../bitcoin/coinselect2/utils");
+const BitcoinWallet_1 = require("../../bitcoin/wallet/BitcoinWallet");
+exports.REQUIRED_SPV_SWAP_VAULT_ADDRESS_TYPE = "p2tr";
+exports.REQUIRED_SPV_SWAP_LP_ADDRESS_TYPE = "p2wpkh";
 /**
  * New spv vault (UTXO-controlled vault) based swaps for Bitcoin -> Smart chain swaps not requiring
  *  any initiation on the destination chain, and with the added possibility for the user to receive
@@ -209,26 +213,21 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
      *
      * @param amountData
      * @param options Options as passed to the swap creation function
-     * @param pricePrefetch
-     * @param nativeTokenPricePrefetch
      * @param abortController
      * @param contractVersion
      * @private
      */
-    async preFetchCallerFeeShare(amountData, options, pricePrefetch, nativeTokenPricePrefetch, abortController, contractVersion) {
+    async preFetchCallerFeeInNativeToken(amountData, options, abortController, contractVersion) {
         if (options.unsafeZeroWatchtowerFee)
             return 0n;
         if (amountData.amount === 0n)
             return 0n;
         try {
-            const [feePerBlock, btcRelayData, currentBtcBlock, claimFeeRate, nativeTokenPrice] = await Promise.all([
+            const [feePerBlock, btcRelayData, currentBtcBlock, claimFeeRate] = await Promise.all([
                 this.btcRelay(contractVersion).getFeePerBlock(),
                 this.btcRelay(contractVersion).getTipData(),
                 this._btcRpc.getTipHeight(),
-                this._contract(contractVersion).getClaimFee(this._chain.randomAddress()),
-                nativeTokenPricePrefetch ?? (amountData.token === this._chain.getNativeCurrencyAddress() ?
-                    pricePrefetch :
-                    this._prices.preFetchPrice(this.chainIdentifier, this._chain.getNativeCurrencyAddress(), abortController.signal))
+                this._contract(contractVersion).getClaimFee(this._chain.randomAddress())
             ]);
             if (btcRelayData == null)
                 throw new Error("Btc relay doesn't seem to be initialized!");
@@ -236,34 +235,57 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             const blockDelta = Math.max(currentBtcBlock - currentBtcRelayBlock + this._options.maxConfirmations, 0);
             const totalFeeInNativeToken = ((BigInt(blockDelta) * feePerBlock) +
                 (claimFeeRate * BigInt(this._options.maxTransactionsDelta))) * BigInt(Math.floor(options.feeSafetyFactor * 1000000)) / 1000000n;
-            let payoutAmount;
-            if (amountData.exactIn) {
-                //Convert input amount in BTC to
-                const amountInNativeToken = await this._prices.getFromBtcSwapAmount(this.chainIdentifier, amountData.amount, this._chain.getNativeCurrencyAddress(), abortController.signal, nativeTokenPrice);
-                payoutAmount = amountInNativeToken - totalFeeInNativeToken;
-            }
-            else {
-                if (amountData.token === this._chain.getNativeCurrencyAddress()) {
-                    //Both amounts in same currency
-                    payoutAmount = amountData.amount;
-                }
-                else {
-                    //Need to convert both to native currency
-                    const btcAmount = await this._prices.getToBtcSwapAmount(this.chainIdentifier, amountData.amount, amountData.token, abortController.signal, await pricePrefetch);
-                    payoutAmount = await this._prices.getFromBtcSwapAmount(this.chainIdentifier, btcAmount, this._chain.getNativeCurrencyAddress(), abortController.signal, nativeTokenPrice);
-                }
-            }
-            this.logger.debug("preFetchCallerFeeShare(): Caller fee in native token: " + totalFeeInNativeToken.toString(10) + " total payout in native token: " + payoutAmount.toString(10));
-            const callerFeeShare = ((totalFeeInNativeToken * 100000n) + payoutAmount - 1n) / payoutAmount; //Make sure to round up here
-            if (callerFeeShare < 0n)
-                return 0n;
-            if (callerFeeShare >= 2n ** 20n)
-                return 2n ** 20n - 1n;
-            return callerFeeShare;
+            return totalFeeInNativeToken;
         }
         catch (e) {
             abortController.abort(e);
         }
+    }
+    /**
+     * Pre-fetches caller (watchtower) bounty data for the swap. Doesn't throw, instead returns null and aborts the
+     *  provided abortController
+     *
+     * @param amountPrefetch
+     * @param totalFeeInNativeTokenPrefetch
+     * @param amountData
+     * @param options Options as passed to the swap creation function
+     * @param pricePrefetch
+     * @param nativeTokenPricePrefetch
+     * @param abortSignal
+     * @private
+     */
+    async computeCallerFeeShare(amountPrefetch, totalFeeInNativeTokenPrefetch, amountData, options, pricePrefetch, nativeTokenPricePrefetch, abortSignal) {
+        if (options.unsafeZeroWatchtowerFee)
+            return 0n;
+        const amount = await (0, Utils_1.throwIfUndefined)(amountPrefetch, "Cannot get swap amount!");
+        if (amount === 0n)
+            return 0n;
+        const totalFeeInNativeToken = await (0, Utils_1.throwIfUndefined)(totalFeeInNativeTokenPrefetch, "Cannot get total fee in native token!");
+        const nativeTokenPrice = await nativeTokenPricePrefetch;
+        let payoutAmount;
+        if (amountData.exactIn) {
+            //Convert input amount in BTC to
+            const amountInNativeToken = await this._prices.getFromBtcSwapAmount(this.chainIdentifier, amount, this._chain.getNativeCurrencyAddress(), abortSignal, nativeTokenPrice);
+            payoutAmount = amountInNativeToken - totalFeeInNativeToken;
+        }
+        else {
+            if (amountData.token === this._chain.getNativeCurrencyAddress()) {
+                //Both amounts in same currency
+                payoutAmount = amount;
+            }
+            else {
+                //Need to convert both to native currency
+                const btcAmount = await this._prices.getToBtcSwapAmount(this.chainIdentifier, amount, amountData.token, abortSignal, await pricePrefetch);
+                payoutAmount = await this._prices.getFromBtcSwapAmount(this.chainIdentifier, btcAmount, this._chain.getNativeCurrencyAddress(), abortSignal, nativeTokenPrice);
+            }
+        }
+        this.logger.debug("computeCallerFeeShare(): Caller fee in native token: " + totalFeeInNativeToken.toString(10) + " total payout in native token: " + payoutAmount.toString(10));
+        const callerFeeShare = ((totalFeeInNativeToken * 100000n) + payoutAmount - 1n) / payoutAmount; //Make sure to round up here
+        if (callerFeeShare < 0n)
+            return 0n;
+        if (callerFeeShare >= 2n ** 20n)
+            return 2n ** 20n - 1n;
+        return callerFeeShare;
     }
     /**
      * Verifies response returned from intermediary
@@ -273,13 +295,14 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
      * @param lp Intermediary
      * @param options Options as passed to the swap creation function
      * @param callerFeeShare
-     * @param bitcoinFeeRatePromise Maximum accepted fee rate from the LPs
+     * @param maxBitcoinFeeRatePromise Maximum accepted fee rate from the LPs
+     * @param bitcoinFeeRatePromise
      * @param abortSignal
      * @private
      * @throws {IntermediaryError} in case the response is invalid
      */
-    async verifyReturnedData(resp, amountData, lp, options, callerFeeShare, bitcoinFeeRatePromise, abortSignal) {
-        const btcFeeRate = await (0, Utils_1.throwIfUndefined)(bitcoinFeeRatePromise, "Bitcoin fee rate promise failed!");
+    async verifyReturnedData(resp, amountData, lp, options, callerFeeShare, maxBitcoinFeeRatePromise, bitcoinFeeRatePromise, abortSignal) {
+        const btcFeeRate = await (0, Utils_1.throwIfUndefined)(maxBitcoinFeeRatePromise, "Bitcoin fee rate promise failed!");
         abortSignal.throwIfAborted();
         if (btcFeeRate != null && resp.btcFeeRate > btcFeeRate)
             throw new IntermediaryError_1.IntermediaryError(`Required bitcoin fee rate returned from the LP is too high! Maximum accepted: ${btcFeeRate} sats/vB, required by LP: ${resp.btcFeeRate} sats/vB`);
@@ -288,11 +311,13 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
         let vaultScript;
         let vaultAddressType;
         let btcAddressScript;
+        let btcAddressType;
         //Ensure valid btc addresses returned
         try {
             vaultScript = (0, BitcoinUtils_1.toOutputScript)(this._options.bitcoinNetwork, resp.vaultBtcAddress);
             vaultAddressType = (0, BitcoinUtils_1.toCoinselectAddressType)(vaultScript);
             btcAddressScript = (0, BitcoinUtils_1.toOutputScript)(this._options.bitcoinNetwork, resp.btcAddress);
+            btcAddressType = (0, BitcoinUtils_1.toCoinselectAddressType)(btcAddressScript);
         }
         catch (e) {
             throw new IntermediaryError_1.IntermediaryError("Invalid btc address data returned", e);
@@ -302,7 +327,8 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             resp.vaultId < 0n || //Ensure vaultId is not negative
             vaultScript == null || //Make sure vault script is parsable and of known type
             btcAddressScript == null || //Make sure btc address script is parsable and of known type
-            vaultAddressType === "p2pkh" || vaultAddressType === "p2sh-p2wpkh" || //Constrain the vault script type to witness types
+            btcAddressType !== exports.REQUIRED_SPV_SWAP_LP_ADDRESS_TYPE || //Constrain the btc address script type
+            vaultAddressType !== exports.REQUIRED_SPV_SWAP_VAULT_ADDRESS_TYPE || //Constrain the vault script type
             decodedUtxo.length !== 2 || decodedUtxo[0].length !== 64 || isNaN(parseInt(decodedUtxo[1])) || //Check valid UTXO
             resp.btcFeeRate < 1 || resp.btcFeeRate > 10000 //Sanity check on the returned BTC fee rate
         )
@@ -345,8 +371,24 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
                 const tokenData = vault.getTokenData();
                 //Amounts - make sure the amounts match
                 if (amountData.exactIn) {
-                    if (resp.btcAmount !== amountData.amount)
-                        throw new IntermediaryError_1.IntermediaryError("Invalid amount returned");
+                    if (!resp.usedUtxoInputCalculation) {
+                        //Legacy calculation
+                        if (resp.btcAmount !== amountData.amount)
+                            throw new IntermediaryError_1.IntermediaryError("Invalid amount returned");
+                    }
+                    else {
+                        //Implies the raw UTXOs were passed for amount derivation
+                        //Verify the derivation was done correctly
+                        if (options.sourceWalletUtxos == null)
+                            throw new IntermediaryError_1.IntermediaryError("Invalid usedUtxoInputCalcuation return value");
+                        if (bitcoinFeeRatePromise == null)
+                            throw new Error("bitcoinFeeRatePromise must be passed for UTXO-based input amount calculation checks");
+                        const walletUtxos = await options.sourceWalletUtxos;
+                        const bitcoinFeeRate = await (0, Utils_1.throwIfUndefined)(bitcoinFeeRatePromise, "Failed to fetch bitcoin fee rate!");
+                        const { balance } = BitcoinWallet_1.BitcoinWallet.getSpendableBalance(walletUtxos, Math.max(resp.btcFeeRate, bitcoinFeeRate), this.getDummySwapPsbt(options.gasAmount !== 0n), exports.REQUIRED_SPV_SWAP_LP_ADDRESS_TYPE);
+                        if (resp.btcAmount !== balance)
+                            throw new IntermediaryError_1.IntermediaryError(`Invalid amount returned, expected: ${balance.toString(10)}, got: ${resp.btcAmount.toString(10)}`);
+                    }
                 }
                 else {
                     //Check the difference between amount adjusted due to scaling to raw amount
@@ -447,6 +489,60 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             vaultUtxoValue
         };
     }
+    async amountPrefetch(amountData, bitcoinFeeRatePromise, walletUtxosPromise, includeGas, abortController) {
+        if (amountData.amount != null)
+            return amountData.amount;
+        try {
+            const bitcoinFeeRate = await (0, Utils_1.throwIfUndefined)(bitcoinFeeRatePromise, "Cannot fetch Bitcoin fee rate!");
+            if (walletUtxosPromise == null)
+                throw new UserError_1.UserError("Cannot use empty amount without passing UTXOs!");
+            const walletUtxos = await walletUtxosPromise;
+            if (walletUtxos.length === 0)
+                throw new UserError_1.UserError("Wallet doesn't have any BTC balance");
+            const spendableBalance = await BitcoinWallet_1.BitcoinWallet.getSpendableBalance(walletUtxos, bitcoinFeeRate, this.getDummySwapPsbt(includeGas), exports.REQUIRED_SPV_SWAP_LP_ADDRESS_TYPE);
+            if (spendableBalance.balance <= 0n)
+                throw new UserError_1.UserError("Wallet doesn't have enough BTC balance to cover transaction fees");
+            return spendableBalance.balance;
+        }
+        catch (e) {
+            abortController.abort(e);
+        }
+    }
+    bitcoinFeeRatePrefetch(options, abortController) {
+        let bitcoinFeeRatePromise;
+        if (options?.sourceWalletUtxos != null) {
+            if (options.bitcoinFeeRate != null) {
+                bitcoinFeeRatePromise = options.bitcoinFeeRate.then(value => {
+                    if (options.maxAllowedBitcoinFeeRate != Infinity && options.maxAllowedBitcoinFeeRate < value)
+                        throw new Error("Passed `maxAllowedBitcoinFeeRate` cannot be lower than `bitcoinFeeRate`");
+                    return value;
+                });
+            }
+            else {
+                bitcoinFeeRatePromise = this._btcRpc.getFeeRate().then(value => {
+                    if (options.maxAllowedBitcoinFeeRate != Infinity && value > options.maxAllowedBitcoinFeeRate)
+                        return options.maxAllowedBitcoinFeeRate;
+                    return value;
+                });
+            }
+            bitcoinFeeRatePromise = bitcoinFeeRatePromise.catch(e => {
+                abortController.abort(e);
+                return undefined;
+            });
+        }
+        const maxBitcoinFeeRatePromise = options.maxAllowedBitcoinFeeRate != Infinity
+            ? Promise.resolve(options.maxAllowedBitcoinFeeRate)
+            : (0, Utils_1.throwIfUndefined)(bitcoinFeeRatePromise ?? options.bitcoinFeeRate ?? this._btcRpc.getFeeRate())
+                .then(x => this._options.maxBtcFeeOffset + (x * this._options.maxBtcFeeMultiplier))
+                .catch(e => {
+                abortController.abort(e);
+                return undefined;
+            });
+        return {
+            bitcoinFeeRatePromise,
+            maxBitcoinFeeRatePromise
+        };
+    }
     /**
      * Returns a newly created Bitcoin -> Smart chain swap using the SPV vault (UTXO-controlled vault) swap protocol,
      *  with the passed amount. Also allows specifying additional "gas drop" native token that the receipient receives
@@ -464,13 +560,25 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             gasAmount: this.parseGasAmount(options?.gasAmount),
             unsafeZeroWatchtowerFee: options?.unsafeZeroWatchtowerFee ?? false,
             feeSafetyFactor: options?.feeSafetyFactor ?? 1.25,
-            maxAllowedBitcoinFeeRate: options?.maxAllowedBitcoinFeeRate ?? options?.maxAllowedNetworkFeeRate ?? Infinity
+            maxAllowedBitcoinFeeRate: options?.maxAllowedBitcoinFeeRate ?? options?.maxAllowedNetworkFeeRate ?? Infinity,
+            sourceWalletUtxos: options?.sourceWalletUtxos == undefined
+                ? undefined
+                : options?.sourceWalletUtxos instanceof Promise ? options.sourceWalletUtxos : Promise.resolve(options.sourceWalletUtxos),
+            bitcoinFeeRate: options?.bitcoinFeeRate == undefined
+                ? undefined
+                : options?.bitcoinFeeRate instanceof Promise ? options.bitcoinFeeRate : Promise.resolve(options.bitcoinFeeRate),
         };
         if (_options.gasAmount !== 0n &&
             (this._chain.shouldGetNativeTokenDrop != null
                 ? !this._chain.shouldGetNativeTokenDrop(amountData.token)
                 : amountData.token === this._chain.getNativeCurrencyAddress()))
             throw new UserError_1.UserError("Cannot specify `gasAmount` for swaps to a native token!");
+        if (amountData.amount == null && options?.sourceWalletUtxos == null)
+            throw new UserError_1.UserError("Source wallet UTXOs need to be passed when amount is null!");
+        if (amountData.amount == null && !amountData.exactIn)
+            throw new UserError_1.UserError("Amount can be null only for exactIn swaps!");
+        if (amountData.amount != null && options?.sourceWalletUtxos != null)
+            throw new UserError_1.UserError("Source wallet UTXOs cannot be passed while specifying an input amount!");
         const lpVersions = Intermediary_1.Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
         const _abortController = (0, Utils_1.extendAbortController)(abortSignal);
         const pricePrefetchPromise = this.preFetchPrice(amountData, _abortController.signal);
@@ -481,14 +589,10 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             undefined :
             this.preFetchPrice({ token: nativeTokenAddress }, _abortController.signal);
         const callerFeePrefetchPromise = (0, Utils_1.mapArrayToObject)(lpVersions, (contractVersion) => {
-            return this.preFetchCallerFeeShare(amountData, _options, pricePrefetchPromise, gasTokenPricePrefetchPromise, _abortController, contractVersion);
+            return this.preFetchCallerFeeInNativeToken(amountData, _options, _abortController, contractVersion);
         });
-        const bitcoinFeeRatePromise = _options.maxAllowedBitcoinFeeRate != Infinity ?
-            Promise.resolve(_options.maxAllowedBitcoinFeeRate) :
-            this._btcRpc.getFeeRate().then(x => this._options.maxBtcFeeOffset + (x * this._options.maxBtcFeeMultiplier)).catch(e => {
-                _abortController.abort(e);
-                return undefined;
-            });
+        const { maxBitcoinFeeRatePromise, bitcoinFeeRatePromise } = this.bitcoinFeeRatePrefetch(_options, _abortController);
+        const amountPromise = this.amountPrefetch(amountData, maxBitcoinFeeRatePromise, _options.sourceWalletUtxos, _options.gasAmount !== 0n, _abortController);
         return lps.map(lp => {
             return {
                 intermediary: lp,
@@ -497,29 +601,46 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
                         throw new Error("LP service for processing spv vault swaps not found!");
                     const version = lp.getContractVersion(this.chainIdentifier);
                     const abortController = (0, Utils_1.extendAbortController)(_abortController.signal);
+                    const callerFeeRatePromise = this.computeCallerFeeShare(amountPromise, callerFeePrefetchPromise[version], amountData, _options, pricePrefetchPromise, gasTokenPricePrefetchPromise, abortController.signal);
                     try {
                         const resp = await (0, RetryUtils_1.tryWithRetries)(async (retryCount) => {
                             return await IntermediaryAPI_1.IntermediaryAPI.prepareSpvFromBTC(this.chainIdentifier, lp.url, {
                                 address: recipient,
-                                amount: amountData.amount,
+                                amount: (0, Utils_1.throwIfUndefined)(amountPromise, "Failed to compute swap amount"),
                                 token: amountData.token.toString(),
                                 exactOut: !amountData.exactIn,
                                 gasToken: nativeTokenAddress,
                                 gasAmount: _options.gasAmount,
-                                callerFeeRate: (0, Utils_1.throwIfUndefined)(callerFeePrefetchPromise[version], "Caller fee prefetch failed!"),
+                                callerFeeRate: (0, Utils_1.throwIfUndefined)(callerFeeRatePromise, "Caller fee prefetch failed!"),
                                 frontingFeeRate: 0n,
                                 stickyAddress: options?.stickyAddress,
+                                amountUtxos: _options.sourceWalletUtxos != null
+                                    ? _options.sourceWalletUtxos.then(utxos => {
+                                        if (utxos.length === 0)
+                                            return undefined;
+                                        return utxos.map(utxo => ({
+                                            value: utxo.value,
+                                            vSize: utils_2.utils.inputBytes({ type: utxo.type }),
+                                            cpfp: utxo.cpfp == null ? undefined : { effectiveVSize: utxo.cpfp?.txVsize, effectiveFeeRate: utxo.cpfp?.txEffectiveFeeRate }
+                                        }));
+                                    })
+                                    : undefined,
+                                amountFeeRate: bitcoinFeeRatePromise,
                                 additionalParams
                             }, this._options.postRequestTimeout, abortController.signal, retryCount > 0 ? false : undefined);
                         }, undefined, e => e instanceof RequestError_1.RequestError, abortController.signal);
                         this.logger.debug("create(" + lp.url + "): LP response: ", resp);
-                        const callerFeeShare = (await callerFeePrefetchPromise[version]);
+                        const callerFeeShare = await callerFeeRatePromise;
+                        const amount = await (0, Utils_1.throwIfUndefined)(amountPromise);
                         const [pricingInfo, gasPricingInfo, { vault, vaultUtxoValue }] = await Promise.all([
                             this.verifyReturnedPrice(lp.services[SwapType_1.SwapType.SPV_VAULT_FROM_BTC], false, resp.btcAmountSwap, resp.total * (100000n + callerFeeShare) / 100000n, amountData.token, { swapFeeBtc: resp.swapFeeBtc }, pricePrefetchPromise, usdPricePrefetchPromise, abortController.signal),
                             _options.gasAmount === 0n ? Promise.resolve(undefined) : this.verifyReturnedPrice({ ...lp.services[SwapType_1.SwapType.SPV_VAULT_FROM_BTC], swapBaseFee: 0 }, //Base fee should be charged only on the amount, not on gas
                             false, resp.btcAmountGas, resp.totalGas * (100000n + callerFeeShare) / 100000n, nativeTokenAddress, { swapFeeBtc: resp.gasSwapFeeBtc }, gasTokenPricePrefetchPromise, usdPricePrefetchPromise, abortController.signal),
-                            this.verifyReturnedData(resp, amountData, lp, _options, callerFeeShare, bitcoinFeeRatePromise, abortController.signal)
+                            this.verifyReturnedData(resp, { ...amountData, amount }, lp, _options, callerFeeShare, maxBitcoinFeeRatePromise, bitcoinFeeRatePromise, abortController.signal)
                         ]);
+                        let minimumBtcFeeRate = resp.btcFeeRate;
+                        if (bitcoinFeeRatePromise != null)
+                            minimumBtcFeeRate = Math.max(minimumBtcFeeRate, await (0, Utils_1.throwIfUndefined)(bitcoinFeeRatePromise));
                         const swapInit = {
                             pricingInfo,
                             url: lp.url,
@@ -540,7 +661,7 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
                             btcAmount: resp.btcAmount,
                             btcAmountSwap: resp.btcAmountSwap,
                             btcAmountGas: resp.btcAmountGas,
-                            minimumBtcFeeRate: resp.btcFeeRate,
+                            minimumBtcFeeRate,
                             outputTotalSwap: resp.total,
                             outputSwapToken: amountData.token,
                             outputTotalGas: resp.totalGas,
@@ -682,7 +803,7 @@ class SpvFromBTCWrapper extends ISwapWrapper_1.ISwapWrapper {
             allowLegacyWitnessUtxo: true,
             allowUnknownOutputs: true
         });
-        const randomVaultOutScript = btc_signer_1.OutScript.encode({ type: "tr", pubkey: Buffer.from("0101010101010101010101010101010101010101010101010101010101010101", "hex") });
+        const randomVaultOutScript = (0, BitcoinUtils_1.getDummyOutputScript)(exports.REQUIRED_SPV_SWAP_VAULT_ADDRESS_TYPE);
         psbt.addInput({
             txid: (0, Utils_1.randomBytes)(32),
             index: 0,

--- a/dist/utils/BitcoinUtils.d.ts
+++ b/dist/utils/BitcoinUtils.d.ts
@@ -7,6 +7,8 @@ import { CoinselectAddressTypes } from "../bitcoin/coinselect2";
 export declare function fromOutputScript(network: BTC_NETWORK, outputScriptHex: string): string;
 export declare function toOutputScript(network: BTC_NETWORK, address: string): Buffer;
 export declare function toCoinselectAddressType(outputScript: Uint8Array): CoinselectAddressTypes;
+export declare function getDummyOutputScript(type: CoinselectAddressTypes): Uint8Array;
+export declare function getDummyAddress(network: BTC_NETWORK, type: CoinselectAddressTypes): string;
 /**
  * General parsers for PSBTs, can parse hex or base64 encoded PSBTs
  * @param _psbt

--- a/dist/utils/BitcoinUtils.js
+++ b/dist/utils/BitcoinUtils.js
@@ -1,9 +1,10 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.parsePsbtTransaction = exports.toCoinselectAddressType = exports.toOutputScript = exports.fromOutputScript = void 0;
+exports.parsePsbtTransaction = exports.getDummyAddress = exports.getDummyOutputScript = exports.toCoinselectAddressType = exports.toOutputScript = exports.fromOutputScript = void 0;
 const utils_1 = require("@scure/btc-signer/utils");
 const buffer_1 = require("buffer");
 const btc_signer_1 = require("@scure/btc-signer");
+const Utils_1 = require("./Utils");
 function fromOutputScript(network, outputScriptHex) {
     return (0, btc_signer_1.Address)(network).encode(btc_signer_1.OutScript.decode(buffer_1.Buffer.from(outputScriptHex, "hex")));
 }
@@ -71,6 +72,44 @@ function toCoinselectAddressType(outputScript) {
     throw new Error("Unrecognized address type!");
 }
 exports.toCoinselectAddressType = toCoinselectAddressType;
+function getDummySpec(type) {
+    switch (type) {
+        case "p2pkh":
+            return {
+                type: "pkh",
+                hash: (0, Utils_1.randomBytes)(20)
+            };
+        case "p2sh-p2wpkh":
+            return {
+                type: "sh",
+                hash: (0, Utils_1.randomBytes)(20)
+            };
+        case "p2wpkh":
+            return {
+                type: "wpkh",
+                hash: (0, Utils_1.randomBytes)(20)
+            };
+        case "p2wsh":
+            return {
+                type: "wsh",
+                hash: (0, Utils_1.randomBytes)(32)
+            };
+        case "p2tr":
+            return {
+                type: "tr",
+                pubkey: buffer_1.Buffer.from("0101010101010101010101010101010101010101010101010101010101010101", "hex")
+            };
+    }
+    throw new Error("Unrecognized address type!");
+}
+function getDummyOutputScript(type) {
+    return btc_signer_1.OutScript.encode(getDummySpec(type));
+}
+exports.getDummyOutputScript = getDummyOutputScript;
+function getDummyAddress(network, type) {
+    return (0, btc_signer_1.Address)(network).encode(getDummySpec(type));
+}
+exports.getDummyAddress = getDummyAddress;
 /**
  * General parsers for PSBTs, can parse hex or base64 encoded PSBTs
  * @param _psbt

--- a/dist/utils/BitcoinWalletUtils.d.ts
+++ b/dist/utils/BitcoinWalletUtils.d.ts
@@ -1,7 +1,7 @@
 import { IBitcoinWallet } from "../bitcoin/wallet/IBitcoinWallet";
 import { BTC_NETWORK } from "@scure/btc-signer/utils";
-import { BitcoinRpcWithAddressIndex } from "@atomiqlabs/base";
+import { BitcoinNetwork, BitcoinRpcWithAddressIndex } from "@atomiqlabs/base";
 export declare function toBitcoinWallet(_bitcoinWallet: IBitcoinWallet | {
     address: string;
     publicKey: string;
-}, btcRpc: BitcoinRpcWithAddressIndex<any>, bitcoinNetwork: BTC_NETWORK): IBitcoinWallet;
+}, btcRpc: BitcoinRpcWithAddressIndex<any>, bitcoinNetwork: BTC_NETWORK | BitcoinNetwork): IBitcoinWallet;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.8.1",
+  "version": "8.8.2",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.8.2",
+  "version": "8.8.3",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.7.7",
+  "version": "8.8.0",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/sdk",
-  "version": "8.8.0",
+  "version": "8.8.1",
   "description": "atomiq labs SDK for cross-chain swaps between smart chains and bitcoin",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/src/bitcoin/coinselect2/accumulative.ts
+++ b/src/bitcoin/coinselect2/accumulative.ts
@@ -18,7 +18,7 @@ export function accumulative (
     effectiveFeeRate?: number,
     fee: number
 } {
-    if (!isFinite(utils.uintOrNaN(feeRate))) throw new Error("Invalid feeRate passed!");
+    if (!isFinite(utils.numberOrNaN(feeRate))) throw new Error("Invalid feeRate passed!");
 
     const inputs = requiredInputs==null ? [] : [...requiredInputs];
     let bytesAccum = utils.transactionBytes(inputs, outputs, type);

--- a/src/bitcoin/coinselect2/accumulative.ts
+++ b/src/bitcoin/coinselect2/accumulative.ts
@@ -15,6 +15,7 @@ export function accumulative (
 ): {
     inputs?: CoinselectTxInput[],
     outputs?: CoinselectTxOutput[],
+    effectiveFeeRate?: number,
     fee: number
 } {
     if (!isFinite(utils.uintOrNaN(feeRate))) throw new Error("Invalid feeRate passed!");

--- a/src/bitcoin/coinselect2/blackjack.ts
+++ b/src/bitcoin/coinselect2/blackjack.ts
@@ -11,6 +11,7 @@ export function blackjack (
 ): {
     inputs?: CoinselectTxInput[],
     outputs?: CoinselectTxOutput[],
+    effectiveFeeRate?: number,
     fee: number
 } {
     if (!isFinite(utils.uintOrNaN(feeRate))) throw new Error("Invalid feeRate passed!");

--- a/src/bitcoin/coinselect2/blackjack.ts
+++ b/src/bitcoin/coinselect2/blackjack.ts
@@ -14,7 +14,7 @@ export function blackjack (
     effectiveFeeRate?: number,
     fee: number
 } {
-    if (!isFinite(utils.uintOrNaN(feeRate))) throw new Error("Invalid feeRate passed!");
+    if (!isFinite(utils.numberOrNaN(feeRate))) throw new Error("Invalid feeRate passed!");
 
     const inputs = requiredInputs==null ? [] : [...requiredInputs];
     let bytesAccum = utils.transactionBytes(inputs, outputs, type);

--- a/src/bitcoin/coinselect2/index.ts
+++ b/src/bitcoin/coinselect2/index.ts
@@ -48,7 +48,7 @@ export function maxSendable (
     value: number,
     fee: number
 } {
-    if (!isFinite(utils.uintOrNaN(feeRate))) throw new Error("Invalid feeRate passed!");
+    if (!isFinite(utils.numberOrNaN(feeRate))) throw new Error("Invalid feeRate passed!");
 
     const outputs = additionalOutputs ?? [];
     const inputs = requiredInputs ?? [];

--- a/src/bitcoin/coinselect2/index.ts
+++ b/src/bitcoin/coinselect2/index.ts
@@ -20,6 +20,7 @@ export function coinSelect (
 ): {
     inputs?: CoinselectTxInput[],
     outputs?: CoinselectTxOutput[],
+    effectiveFeeRate?: number,
     fee: number
 } {
     // order by descending value, minus the inputs approximate fee
@@ -38,10 +39,10 @@ export function coinSelect (
 }
 
 export function maxSendable (
-    utxos: CoinselectTxInput[],
+    utxos: Omit<CoinselectTxInput, "txId" | "address" | "vout" | "outputScript">[],
     output: {script: Buffer, type: CoinselectAddressTypes},
     feeRate: number,
-    requiredInputs?: CoinselectTxInput[],
+    requiredInputs?: Omit<CoinselectTxInput, "txId" | "address" | "vout" | "outputScript">[],
     additionalOutputs?: {script: Buffer, value: number}[],
 ): {
     value: number,
@@ -61,7 +62,7 @@ export function maxSendable (
         const utxoBytes = utils.inputBytes(utxo);
         const utxoFee = feeRate * utxoBytes;
         let cpfpFee = 0;
-        if(utxo.cpfp!=null && utxo.cpfp.txEffectiveFeeRate<feeRate) cpfpFee = utxo.cpfp.txVsize*(feeRate - utxo.cpfp.txEffectiveFeeRate);
+        if(utxo.cpfp!=null && utxo.cpfp.txEffectiveFeeRate<feeRate) cpfpFee = Math.ceil(utxo.cpfp.txVsize*(feeRate - utxo.cpfp.txEffectiveFeeRate));
         const utxoValue = utils.uintOrNaN(utxo.value);
 
         // skip detrimental input

--- a/src/bitcoin/coinselect2/utils.ts
+++ b/src/bitcoin/coinselect2/utils.ts
@@ -148,39 +148,71 @@ function sumOrNaN(range: {value: number}[]): number {
   return range.reduce((a, x)  => a + uintOrNaN(x.value), 0);
 }
 
-function finalize(
-    inputs: CoinselectTxInput[],
+function finalize<T extends Omit<CoinselectTxInput, "txId" | "address" | "vout" | "outputScript">>(
+    inputs: T[],
     outputs: CoinselectTxOutput[],
     feeRate: number,
-    changeType: CoinselectAddressTypes,
+    changeType: CoinselectAddressTypes | null,
     cpfpAddFee: number = 0
 ): {
-    inputs?: CoinselectTxInput[],
+    inputs?: T[],
     outputs?: CoinselectTxOutput[],
+    effectiveFeeRate?: number,
     fee: number
 } {
-  const bytesAccum = transactionBytes(inputs, outputs, changeType);
+  const bytesAccum = transactionBytes(inputs, outputs, changeType ?? undefined);
   logger.debug("finalize(): Transaction bytes: ", bytesAccum);
 
-  const feeAfterExtraOutput = (feeRate * (bytesAccum + outputBytes({type: changeType}))) + cpfpAddFee;
-  logger.debug("finalize(): TX fee after adding change output: ", feeAfterExtraOutput);
-  const remainderAfterExtraOutput = Math.floor(sumOrNaN(inputs) - (sumOrNaN(outputs) + feeAfterExtraOutput));
-  logger.debug("finalize(): Leaves change (changeType="+changeType+") value: ", remainderAfterExtraOutput);
+  if(changeType!=null) {
+      const feeAfterExtraOutput = (feeRate * (bytesAccum + outputBytes({type: changeType}))) + cpfpAddFee;
+      logger.debug("finalize(): TX fee after adding change output: ", feeAfterExtraOutput);
+      const remainderAfterExtraOutput = Math.floor(sumOrNaN(inputs) - (sumOrNaN(outputs) + feeAfterExtraOutput));
+      logger.debug("finalize(): Leaves change (changeType="+changeType+") value: ", remainderAfterExtraOutput);
 
-  // is it worth a change output?
-  if (remainderAfterExtraOutput >= dustThreshold({type: changeType})) {
-    outputs = outputs.concat({ value: remainderAfterExtraOutput, type: changeType })
+      // is it worth a change output?
+      if (remainderAfterExtraOutput >= dustThreshold({type: changeType})) {
+          outputs = outputs.concat({ value: remainderAfterExtraOutput, type: changeType })
+      }
   }
 
   const fee = sumOrNaN(inputs) - sumOrNaN(outputs);
   logger.debug("finalize(): Re-calculated total fee: ", fee);
-  if (!isFinite(fee)) return { fee: (feeRate * bytesAccum) + cpfpAddFee }
+  if (!isFinite(fee) || fee<0) return { fee: (feeRate * bytesAccum) + cpfpAddFee }
+
+  let txVSize = utils.transactionBytes(inputs, outputs);
+  let txFee = fee;
+  const cpfpSortedInputs = [...inputs].sort(
+      (a, b) => (b.cpfp?.txEffectiveFeeRate ?? 0) - (a.cpfp?.txEffectiveFeeRate ?? 0)
+  );
+  cpfpSortedInputs.forEach(input => {
+    if(input.cpfp==null) return;
+      const currentEffectiveFeeRate = txFee / txVSize;
+      if(currentEffectiveFeeRate > input.cpfp.txEffectiveFeeRate) {
+        txVSize += input.cpfp.txVsize;
+        txFee += input.cpfp.txVsize * input.cpfp.txEffectiveFeeRate;
+      }
+    }
+  );
 
   return {
     inputs: inputs,
     outputs: outputs,
+    effectiveFeeRate: txFee / txVSize,
     fee: fee
   }
+}
+
+function isDetrimentalInput(
+    feeRate: number,
+    utxo: Omit<CoinselectTxInput, "txId" | "address" | "vout" | "outputScript">
+) {
+    const utxoBytes = utils.inputBytes(utxo);
+    const utxoFee = feeRate * utxoBytes;
+    let cpfpFee = 0;
+    if(utxo.cpfp!=null && utxo.cpfp.txEffectiveFeeRate<feeRate) cpfpFee = Math.ceil(utxo.cpfp.txVsize*(feeRate - utxo.cpfp.txEffectiveFeeRate));
+
+    // skip detrimental input
+    return utxoFee + cpfpFee > utxo.value;
 }
 
 export const utils = {
@@ -191,5 +223,6 @@ export const utils = {
   sumOrNaN: sumOrNaN,
   sumForgiving: sumForgiving,
   transactionBytes: transactionBytes,
-  uintOrNaN: uintOrNaN
+  uintOrNaN: uintOrNaN,
+  isDetrimentalInput
 };

--- a/src/bitcoin/coinselect2/utils.ts
+++ b/src/bitcoin/coinselect2/utils.ts
@@ -132,6 +132,13 @@ function transactionBytes (
     return Math.ceil(size);
 }
 
+function numberOrNaN(v: number): number {
+    if (typeof v !== 'number') return NaN;
+    if (!isFinite(v)) return NaN;
+    if (v < 0) return NaN;
+    return v;
+}
+
 function uintOrNaN(v: number): number {
   if (typeof v !== 'number') return NaN;
   if (!isFinite(v)) return NaN;
@@ -224,5 +231,6 @@ export const utils = {
   sumForgiving: sumForgiving,
   transactionBytes: transactionBytes,
   uintOrNaN: uintOrNaN,
+  numberOrNaN: numberOrNaN,
   isDetrimentalInput
 };

--- a/src/bitcoin/wallet/BitcoinWallet.ts
+++ b/src/bitcoin/wallet/BitcoinWallet.ts
@@ -1,32 +1,14 @@
 import {coinSelect, maxSendable, CoinselectAddressTypes, CoinselectTxInput} from "../coinselect2";
 import {BTC_NETWORK, NETWORK, TEST_NETWORK} from "@scure/btc-signer/utils"
 import {p2wpkh, OutScript, Transaction, p2tr, Address} from "@scure/btc-signer";
-import {IBitcoinWallet} from "./IBitcoinWallet";
+import {BitcoinWalletUtxo, BitcoinWalletUtxoBase, IBitcoinWallet} from "./IBitcoinWallet";
 import {Buffer} from "buffer";
 import {randomBytes} from "../../utils/Utils";
-import {toCoinselectAddressType, toOutputScript} from "../../utils/BitcoinUtils";
+import {getDummyOutputScript, toCoinselectAddressType, toOutputScript} from "../../utils/BitcoinUtils";
 import {TransactionInputUpdate} from "@scure/btc-signer/psbt";
 import {getLogger} from "../../utils/Logger";
 import {BitcoinNetwork, BitcoinRpcWithAddressIndex} from "@atomiqlabs/base";
-
-/**
- * UTXO data structure for Bitcoin wallets
- *
- * @category Bitcoin
- */
-export type BitcoinWalletUtxo = {
-    vout: number,
-    txId: string,
-    value: number,
-    type: CoinselectAddressTypes,
-    outputScript: Buffer,
-    address: string,
-    cpfp?: {
-        txVsize: number,
-        txEffectiveFeeRate: number
-    },
-    confirmed: boolean
-};
+import {utils} from "../coinselect2/utils";
 
 /**
  * Identifies the address type of a Bitcoin address
@@ -200,15 +182,18 @@ export abstract class BitcoinWallet implements IBitcoinWallet {
             addressType: CoinselectAddressTypes,
         }[],
         psbt: Transaction,
-        feeRate?: number
+        _feeRate?: number,
+        utxos?: BitcoinWalletUtxo[],
+        spendFully?: boolean
     ): Promise<{
         fee: number,
         psbt?: Transaction,
         inputAddressIndexes?: {[address: string]: number[]}
     }> {
-        if(feeRate==null) feeRate = await this.getFeeRate();
+        const feeRate = _feeRate ?? await this.getFeeRate();
+        const utxoPool: BitcoinWalletUtxo[] = utxos ?? (await Promise.all(sendingAccounts.map(acc => this._getUtxoPool(acc.address, acc.addressType)))).flat();
 
-        const utxoPool: BitcoinWalletUtxo[] = (await Promise.all(sendingAccounts.map(acc => this._getUtxoPool(acc.address, acc.addressType)))).flat();
+        if(spendFully && utxoPool==null) throw new Error("Cannot fully spend when no utxos are passed!");
 
         logger.debug("_fundPsbt(): fee rate: "+feeRate+" utxo pool: ", utxoPool);
 
@@ -247,13 +232,24 @@ export abstract class BitcoinWallet implements IBitcoinWallet {
         }
         logger.debug("_fundPsbt(): Coinselect targets: ", targets);
 
-        let coinselectResult = coinSelect(utxoPool, targets, feeRate, sendingAccounts[0].addressType, requiredInputs);
+        let coinselectResult = spendFully
+            ? utils.finalize(requiredInputs.concat(utxoPool.filter(utxo => !utils.isDetrimentalInput(feeRate, utxo))), targets, feeRate, null)
+            : coinSelect(utxoPool, targets, feeRate, sendingAccounts[0].addressType, requiredInputs);
         logger.debug("_fundPsbt(): Coinselect result: ", coinselectResult);
 
-        if(coinselectResult.inputs==null || coinselectResult.outputs==null) {
+        if(coinselectResult.inputs==null || coinselectResult.outputs==null || coinselectResult.effectiveFeeRate==null) {
             return {
                 fee: coinselectResult.fee
             };
+        }
+
+        if(spendFully && feeRate!=null) {
+            const maximumAllowedFeeRate = (1.5*feeRate) + 10;
+            if(coinselectResult.effectiveFeeRate > maximumAllowedFeeRate)
+                throw new Error(`Effective fee rate too high, feeRate: ${coinselectResult.effectiveFeeRate} sats/vB, maximum: ${maximumAllowedFeeRate} sats/vB!`);
+            const minimumAllowedFeeRate = 0.9*feeRate;
+            if(coinselectResult.effectiveFeeRate < minimumAllowedFeeRate)
+                throw new Error(`Effective fee rate too low, feeRate: ${coinselectResult.effectiveFeeRate} sats/vB, minimum: ${minimumAllowedFeeRate} sats/vB!`);
         }
 
         // Remove in/outs that are already in the PSBT
@@ -346,16 +342,59 @@ export abstract class BitcoinWallet implements IBitcoinWallet {
             addressType: CoinselectAddressTypes,
         }[],
         psbt?: Transaction,
-        feeRate?: number
+        feeRate?: number,
+        outputAddressType?: CoinselectAddressTypes,
+        utxoPool?: BitcoinWalletUtxoBase[]
     ): Promise<{
         balance: bigint,
         feeRate: number,
         totalFee: number
     }> {
         feeRate ??= await this.getFeeRate();
+        utxoPool ??= (await Promise.all(sendingAccounts.map(acc => this._getUtxoPool(acc.address, acc.addressType)))).flat();
 
-        const utxoPool: BitcoinWalletUtxo[] = (await Promise.all(sendingAccounts.map(acc => this._getUtxoPool(acc.address, acc.addressType)))).flat();
+        return {
+            ...BitcoinWallet.getSpendableBalance(
+                utxoPool ?? (await Promise.all(sendingAccounts.map(acc => this._getUtxoPool(acc.address, acc.addressType)))).flat(),
+                feeRate ?? await this.getFeeRate(),
+                psbt,
+                outputAddressType
+            ),
+            feeRate
+        };
+    }
 
+    abstract sendTransaction(address: string, amount: bigint, feeRate?: number): Promise<string>;
+    abstract fundPsbt(psbt: Transaction, feeRate?: number, utxos?: BitcoinWalletUtxo[], spendFully?: boolean): Promise<Transaction>;
+    abstract signPsbt(psbt: Transaction, signInputs: number[]): Promise<Transaction>;
+
+    abstract getTransactionFee(address: string, amount: bigint, feeRate?: number): Promise<number>;
+    abstract getFundedPsbtFee(psbt: Transaction, feeRate?: number): Promise<number>;
+
+    abstract getReceiveAddress(): string;
+    abstract getBalance(): Promise<{
+        confirmedBalance: bigint,
+        unconfirmedBalance: bigint
+    }>;
+    abstract getSpendableBalance(psbt?: Transaction, feeRate?: number): Promise<{
+        balance: bigint,
+        feeRate: number,
+        totalFee: number
+    }>;
+
+    static bitcoinNetworkToObject(network: BitcoinNetwork): BTC_NETWORK {
+        return btcNetworkMapping[network];
+    }
+
+    static getSpendableBalance(
+        utxoPool: BitcoinWalletUtxoBase[],
+        feeRate: number,
+        psbt?: Transaction,
+        outputAddressType?: CoinselectAddressTypes
+    ): {
+        balance: bigint,
+        totalFee: number
+    } {
         const requiredInputs: CoinselectTxInput[] = [];
         if(psbt!=null) for(let i=0;i<psbt.inputsLength;i++) {
             const input = psbt.getInput(i);
@@ -387,42 +426,15 @@ export abstract class BitcoinWallet implements IBitcoinWallet {
             })
         }
 
-        const target = OutScript.encode({
-            type: "wsh",
-            hash: randomBytes(32)
-        });
-
-        let coinselectResult = maxSendable(utxoPool, {script: Buffer.from(target), type: "p2wsh"}, feeRate, requiredInputs, additionalOutputs);
+        const target: Uint8Array = getDummyOutputScript(outputAddressType ?? "p2wsh");
+        let coinselectResult = maxSendable(utxoPool, {script: Buffer.from(target), type: outputAddressType ?? "p2wsh"}, feeRate, requiredInputs, additionalOutputs);
 
         logger.debug("_getSpendableBalance(): Max spendable result: ", coinselectResult);
 
         return {
-            feeRate: feeRate,
             balance: BigInt(Math.floor(coinselectResult.value)),
             totalFee: coinselectResult.fee
         }
-    }
-
-    abstract sendTransaction(address: string, amount: bigint, feeRate?: number): Promise<string>;
-    abstract fundPsbt(psbt: Transaction, feeRate?: number): Promise<Transaction>;
-    abstract signPsbt(psbt: Transaction, signInputs: number[]): Promise<Transaction>;
-
-    abstract getTransactionFee(address: string, amount: bigint, feeRate?: number): Promise<number>;
-    abstract getFundedPsbtFee(psbt: Transaction, feeRate?: number): Promise<number>;
-
-    abstract getReceiveAddress(): string;
-    abstract getBalance(): Promise<{
-        confirmedBalance: bigint,
-        unconfirmedBalance: bigint
-    }>;
-    abstract getSpendableBalance(psbt?: Transaction, feeRate?: number): Promise<{
-        balance: bigint,
-        feeRate: number,
-        totalFee: number
-    }>;
-
-    static bitcoinNetworkToObject(network: BitcoinNetwork): BTC_NETWORK {
-        return btcNetworkMapping[network];
     }
 
 }

--- a/src/bitcoin/wallet/IBitcoinWallet.ts
+++ b/src/bitcoin/wallet/IBitcoinWallet.ts
@@ -1,4 +1,33 @@
-import {Transaction} from "@scure/btc-signer";
+import {Address, Transaction} from "@scure/btc-signer";
+import {BTC_NETWORK} from "@scure/btc-signer/utils";
+import {CoinselectAddressTypes} from "../coinselect2";
+
+/**
+ * UTXO data structure for Bitcoin wallets
+ *
+ * @category Bitcoin
+ */
+export type BitcoinWalletUtxo = {
+    vout: number,
+    txId: string,
+    value: number,
+    type: CoinselectAddressTypes,
+    outputScript: Buffer,
+    address: string,
+    cpfp?: {
+        txVsize: number,
+        txEffectiveFeeRate: number
+    },
+    confirmed: boolean
+};
+
+/**
+ * Base UTXO data structure used for maximum spendable balance calculation, doesn't contain all the fields necessary
+ *  for constructing the full transaction.
+ *
+ * @category Bitcoin
+ */
+export type BitcoinWalletUtxoBase = Omit<BitcoinWalletUtxo, "txId" | "vout" | "outputScript" | "address" | "confirmed">;
 
 /**
  * Type guard to check if an object implements {@link IBitcoinWallet}
@@ -39,8 +68,12 @@ export interface IBitcoinWallet {
      *
      * @param psbt PSBT to add the inputs to
      * @param feeRate Optional fee rate in sats/vB to use for the transaction
+     * @param utxos Pre-fetched list of UTXOs to spend from
+     * @param spendFully Instructs the wallet to spend all the passed UTXOs in the transaction without creating any
+     *  change output, if the `feeRate` is passed, it will also enforce that the feeRate in sats/vB for the resulting
+     *  transaction is not more than 50% and 10 sats/vB larger (considering also the CPFP adjustments)
      */
-    fundPsbt(psbt: Transaction, feeRate?: number): Promise<Transaction>;
+    fundPsbt(psbt: Transaction, feeRate?: number, utxos?: BitcoinWalletUtxo[], spendFully?: boolean): Promise<Transaction>;
 
     /**
      * Signs inputs in the provided PSBT
@@ -90,10 +123,18 @@ export interface IBitcoinWallet {
      *
      * @param psbt A PSBT to which additional inputs from wallet's UTXO set will be added and fee estimated
      * @param feeRate Optional fee rate in sats/vB to use for the transaction
+     * @param outputAddressType Expected output address type, if known
+     * @param utxos Optional pre-fetched UTXOs
      */
-    getSpendableBalance(psbt?: Transaction, feeRate?: number): Promise<{
+    getSpendableBalance(psbt?: Transaction, feeRate?: number, outputAddressType?: CoinselectAddressTypes, utxos?: BitcoinWalletUtxoBase[]): Promise<{
         balance: bigint,
         feeRate: number,
         totalFee: number
     }>;
+
+    /**
+     * Returns a list of available UTXOs for the wallet
+     */
+    getUtxoPool?(): Promise<BitcoinWalletUtxo[]>;
+
 }

--- a/src/bitcoin/wallet/SingleAddressBitcoinWallet.ts
+++ b/src/bitcoin/wallet/SingleAddressBitcoinWallet.ts
@@ -8,6 +8,7 @@ import {HDKey} from "@scure/bip32";
 import {entropyToMnemonic, generateMnemonic, mnemonicToSeed} from "@scure/bip39";
 import {wordlist} from "@scure/bip39/wordlists/english.js";
 import {sha256} from "@noble/hashes/sha2";
+import {BitcoinWalletUtxo, BitcoinWalletUtxoBase} from "./IBitcoinWallet";
 
 const logger = getLogger("SingleAddressBitcoinWallet: ");
 
@@ -88,8 +89,8 @@ export class SingleAddressBitcoinWallet extends BitcoinWallet {
     /**
      * @inheritDoc
      */
-    async fundPsbt(inputPsbt: Transaction, feeRate?: number): Promise<Transaction> {
-        const {psbt} = await super._fundPsbt(this.toBitcoinWalletAccounts(), inputPsbt, feeRate);
+    async fundPsbt(inputPsbt: Transaction, feeRate?: number, utxos?: BitcoinWalletUtxo[], spendFully?: boolean): Promise<Transaction> {
+        const {psbt} = await super._fundPsbt(this.toBitcoinWalletAccounts(), inputPsbt, feeRate, utxos, spendFully);
         if(psbt==null) {
             throw new Error("Not enough balance!");
         }
@@ -150,12 +151,19 @@ export class SingleAddressBitcoinWallet extends BitcoinWallet {
     /**
      * @inheritDoc
      */
-    getSpendableBalance(psbt?: Transaction, feeRate?: number): Promise<{
+    getSpendableBalance(psbt?: Transaction, feeRate?: number, outputAddressType?: CoinselectAddressTypes, utxos?: BitcoinWalletUtxoBase[]): Promise<{
         balance: bigint,
         feeRate: number,
         totalFee: number
     }> {
-        return this._getSpendableBalance([{address: this.address, addressType: this.addressType}], psbt, feeRate);
+        return this._getSpendableBalance([{address: this.address, addressType: this.addressType}], psbt, feeRate, outputAddressType, utxos);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    async getUtxoPool(): Promise<BitcoinWalletUtxo[]> {
+        return this._getUtxoPool(this.address, this.addressType);
     }
 
     /**

--- a/src/intermediaries/apis/IntermediaryAPI.ts
+++ b/src/intermediaries/apis/IntermediaryAPI.ts
@@ -298,20 +298,24 @@ const SpvFromBTCPrepareResponseSchema = {
 
     callerFeeShare: FieldTypeEnum.BigInt,
     frontingFeeShare: FieldTypeEnum.BigInt,
-    executionFeeShare: FieldTypeEnum.BigInt
+    executionFeeShare: FieldTypeEnum.BigInt,
+
+    usedUtxoInputCalculation: FieldTypeEnum.BooleanOptional
 } as const;
 
 export type SpvFromBTCPrepareResponseType = RequestSchemaResult<typeof SpvFromBTCPrepareResponseSchema>;
 
 export type SpvFromBTCPrepare = SwapInit & {
     address: string,
-    amount: bigint,
+    amount: Promise<bigint>,
     gasAmount: bigint,
     gasToken: string,
     exactOut: boolean,
     callerFeeRate: Promise<bigint>,
     frontingFeeRate: bigint,
-    stickyAddress?: boolean
+    stickyAddress?: boolean,
+    amountUtxos?: Promise<{ value: number, vSize: number, cpfp?: { effectiveVSize: number, effectiveFeeRate: number }}[] | undefined>,
+    amountFeeRate?: Promise<number | undefined>
 }
 
 const SpvFromBTCInitResponseSchema = {
@@ -870,17 +874,29 @@ export class IntermediaryAPI {
         abortSignal?: AbortSignal,
         streamRequest?: boolean
     ): Promise<SpvFromBTCPrepareResponseType> {
+        //We need to make sure we only send the amount parameter after the amountUtxos and amountFeeRate resolve
+        // this is needed, because in the LP code to maintain backwards compatibility the amountUtxos and amountFeeRate
+        // params are checked immediately after the amount param (and other params) are received, if amount were sent
+        // first without the amountUtxos or amountFeeRate populated these fields would've been skipped altogether
+        const amountPromise = (async () => {
+            if(init.amountUtxos!=null) await init.amountUtxos;
+            if(init.amountFeeRate!=null) await init.amountFeeRate;
+            const amount = await init.amount;
+            return amount.toString(10);
+        })();
         const responseBodyPromise = streamingFetchPromise(baseUrl+"/frombtc_spv/getQuote?chain="+encodeURIComponent(chainIdentifier), {
             exactOut: init.exactOut,
             ...init.additionalParams,
             address: init.address,
-            amount: init.amount.toString(10),
+            amount: amountPromise,
             token: init.token,
             gasAmount: init.gasAmount.toString(10),
             gasToken: init.gasToken,
             frontingFeeRate: init.frontingFeeRate.toString(10),
             callerFeeRate: init.callerFeeRate.then(val => val.toString(10)),
-            stickyAddress: init.stickyAddress
+            stickyAddress: init.stickyAddress,
+            amountUtxos: init.amountUtxos,
+            amountFeeRate: init.amountFeeRate
         }, {
             code: FieldTypeEnum.Number,
             msg: FieldTypeEnum.String,

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -65,6 +65,9 @@ import {NotNever} from "../utils/TypeUtils";
 import {IEscrowSwap} from "../swaps/escrow_swaps/IEscrowSwap";
 import {LightningInvoiceCreateService, isLightningInvoiceCreateService} from "../types/wallets/LightningInvoiceCreateService";
 import {SwapSide} from "../enums/SwapSide";
+import {BitcoinWalletUtxo, BitcoinWalletUtxoBase, IBitcoinWallet} from "../bitcoin/wallet/IBitcoinWallet";
+import {MinimalBitcoinWalletInterface} from "../types/wallets/MinimalBitcoinWalletInterface";
+import {toBitcoinWallet} from "../utils/BitcoinWalletUtils";
 
 /**
  * Configuration options for the Swapper
@@ -745,7 +748,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
             quote: Promise<S>,
             intermediary: Intermediary
         }[]>,
-        amountData: AmountData,
+        amountData: { amount?: bigint, token: string, exactIn: boolean },
         swapType: SwapType,
         maxWaitTimeMS: number = 2000
     ): Promise<S> {
@@ -755,7 +758,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
 
         const inBtc: boolean = swapType===SwapType.TO_BTCLN || swapType===SwapType.TO_BTC ? !amountData.exactIn : amountData.exactIn;
 
-        if(!inBtc) {
+        if(!inBtc || amountData.amount==null) {
             //Get candidates not based on the amount
             candidates = this.intermediaryDiscovery.getSwapCandidates(chainIdentifier, swapType, amountData.token);
         } else {
@@ -769,7 +772,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
             await this.intermediaryDiscovery.reloadIntermediaries();
             swapLimitsChanged = true;
 
-            if(!inBtc) {
+            if(!inBtc || amountData.amount==null) {
                 //Get candidates not based on the amount
                 candidates = this.intermediaryDiscovery.getSwapCandidates(chainIdentifier, swapType, amountData.token);
             } else {
@@ -859,8 +862,10 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
                         }
                         if(min!=null && max!=null) {
                             let msg = "Swap amount too high or too low! Try swapping a different amount.";
-                            if(min > amountData.amount) msg = "Swap amount too low! Try swapping a higher amount.";
-                            if(max < amountData.amount) msg = "Swap amount too high! Try swapping a lower amount.";
+                            if(amountData.amount!=null) {
+                                if(min > amountData.amount) msg = "Swap amount too low! Try swapping a higher amount.";
+                                if(max < amountData.amount) msg = "Swap amount too high! Try swapping a lower amount.";
+                            }
                             reject(new OutOfBoundsError(msg, 400, min, max));
                             return;
                         }
@@ -1102,7 +1107,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         chainIdentifier: ChainIdentifier,
         recipient: string,
         tokenAddress: string,
-        amount: bigint,
+        amount: bigint | null,
         exactOut: boolean = false,
         additionalParams: Record<string, any> | undefined = this.options.defaultAdditionalParameters,
         options?: SpvFromBTCOptions
@@ -1112,7 +1117,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         if(!this._chains[chainIdentifier].chainInterface.isValidAddress(recipient, true)) throw new Error("Invalid "+chainIdentifier+" address");
         recipient = this._chains[chainIdentifier].chainInterface.normalizeAddress(recipient);
         const amountData = {
-            amount,
+            amount: amount ?? undefined,
             token: tokenAddress,
             exactIn: !exactOut
         };
@@ -1574,6 +1579,73 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
             }
         }
         throw new Error("Unsupported swap type");
+    }
+
+    /**
+     * A helper function to sweep all the funds from a given wallet in a single swap, after getting the quote you can
+     *  execute the swap by passing the returned `feeRate` and `utxos` to the {@link SpvFromBTCSwap.execute},
+     *  {@link SpvFromBTCSwap.getFundedPsbt} or {@link SpvFromBTCSwap.sendBitcoinTransaction} functions along
+     *  with `spendFully=true`.
+     *
+     * @example
+     * Create the swap first using this function
+     * ```ts
+     * const {swap, utxos, btcFeeRate} = await swapper.sweepBitcoinWallet(wallet, Tokens.CITREA.CBTC, dstAddress);
+     * ```
+     * Then execute it using one of these execution paths - ensure that you supply the returned `utxos`, `btcFeeRate`
+     *  params and also set `spendFully` to `true`!
+     *
+     * a) Execute and pass the returned utxos and btcFeeRate:
+     * ```ts
+     * await swap.execute(wallet, undefined, {feeRate: btcFeeRate, utxos: utxos, spendFully: true});
+     * ```
+     *
+     * b) Get funded PSBT to sign externally:
+     * ```ts
+     * const {psbt, psbtHex, psbtBase64, signInputs} = await swap.getFundedPsbt(wallet, btcFeeRate, undefined, utxos, true);
+     * // Sign the psbt at the specified signInputs indices
+     * const signedPsbt = ...;
+     * // Then submit back to the SDK
+     * await swap.submitPsbt(signedPsbt);
+     * ```
+     *
+     * c) Only sign and send the signed PSBT with the provided wallet:
+     * ```ts
+     * await swap.sendBitcoinTransaction(wallet, btcFeeRate, utxos, true);
+     * ```
+     */
+    async sweepBitcoinWallet<C extends ChainIds<T>>(
+        srcWallet: IBitcoinWallet | MinimalBitcoinWalletInterface,
+        _dstToken: SCToken<C> | string,
+        dstAddress: string,
+        options?: SpvFromBTCOptions
+    ): Promise<{
+        swap: SpvFromBTCSwap<T[C]>,
+        utxos: BitcoinWalletUtxo[],
+        btcFeeRate: number
+    }> {
+        const dstToken = typeof(_dstToken)==="string" ? this.getToken(_dstToken) as Token<C> : _dstToken;
+        if(!isSCToken<C>(dstToken)) throw new Error("Destination token must be a smart chain token!");
+
+        const wallet = toBitcoinWallet(srcWallet, this._bitcoinRpc, this.bitcoinNetwork);
+        if(wallet.getUtxoPool==null) throw new Error("Wallet needs to support the `getUtxoPool()` function!");
+
+        const walletUtxosPromise = wallet.getUtxoPool();
+        const bitcoinFeeRatePromise = wallet.getFeeRate();
+
+        const swap = await this.createFromBTCSwapNew(
+            dstToken.chainId, dstAddress, dstToken.address, null, false, undefined, {
+                ...options,
+                sourceWalletUtxos: walletUtxosPromise,
+                bitcoinFeeRate: bitcoinFeeRatePromise
+            }
+        );
+
+        return {
+            swap,
+            utxos: await walletUtxosPromise,
+            btcFeeRate: Math.max(swap.minimumBtcFeeRate, await bitcoinFeeRatePromise)
+        };
     }
 
     /**

--- a/src/swapper/Swapper.ts
+++ b/src/swapper/Swapper.ts
@@ -1631,7 +1631,7 @@ export class Swapper<T extends MultiChain> extends EventEmitter<{
         if(wallet.getUtxoPool==null) throw new Error("Wallet needs to support the `getUtxoPool()` function!");
 
         const walletUtxosPromise = wallet.getUtxoPool();
-        const bitcoinFeeRatePromise = wallet.getFeeRate();
+        const bitcoinFeeRatePromise = options?.bitcoinFeeRate ?? wallet.getFeeRate();
 
         const swap = await this.createFromBTCSwapNew(
             dstToken.chainId, dstAddress, dstToken.address, null, false, undefined, {

--- a/src/swaps/spv_swaps/SpvFromBTCSwap.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCSwap.ts
@@ -16,7 +16,7 @@ import {parsePsbtTransaction, toCoinselectAddressType, toOutputScript} from "../
 import {getInputType, Transaction} from "@scure/btc-signer";
 import {Buffer} from "buffer";
 import {Fee} from "../../types/fees/Fee";
-import {IBitcoinWallet, isIBitcoinWallet} from "../../bitcoin/wallet/IBitcoinWallet";
+import {BitcoinWalletUtxo, IBitcoinWallet, isIBitcoinWallet} from "../../bitcoin/wallet/IBitcoinWallet";
 import {IntermediaryAPI} from "../../intermediaries/apis/IntermediaryAPI";
 import {IBTCWalletSwap} from "../IBTCWalletSwap";
 import {ISwapWithGasDrop} from "../ISwapWithGasDrop";
@@ -877,11 +877,17 @@ export class SpvFromBTCSwap<T extends ChainType>
      * @param _bitcoinWallet Sender's bitcoin wallet
      * @param feeRate Optional fee rate in sats/vB for the transaction
      * @param additionalOutputs additional outputs to add to the PSBT - can be used to collect fees from users
+     * @param utxos Pre-fetched list of UTXOs to spend from
+     * @param spendFully Instructs the wallet to spend all the passed UTXOs in the transaction without creating any
+     *  change output, if the `feeRate` is passed, it will also enforce that the feeRate in sats/vB for the resulting
+     *  transaction is not more than 50% and 10 sats/vB larger (considering also the CPFP adjustments)
      */
     async getFundedPsbt(
         _bitcoinWallet: IBitcoinWallet | MinimalBitcoinWalletInterface,
         feeRate?: number,
-        additionalOutputs?: ({amount: bigint, outputScript: Uint8Array} | {amount: bigint, address: string})[]
+        additionalOutputs?: ({amount: bigint, outputScript: Uint8Array} | {amount: bigint, address: string})[],
+        utxos?: BitcoinWalletUtxo[],
+        spendFully?: boolean
     ): Promise<{
         psbt: Transaction,
         psbtHex: string,
@@ -901,7 +907,7 @@ export class SpvFromBTCSwap<T extends ChainType>
                 script: (output as {outputScript: Uint8Array}).outputScript ?? toOutputScript(this.wrapper._options.bitcoinNetwork, (output as {address: string}).address)
             });
         });
-        psbt = await bitcoinWallet.fundPsbt(psbt, feeRate);
+        psbt = await bitcoinWallet.fundPsbt(psbt, feeRate, utxos, spendFully);
         psbt.updateInput(1, {sequence: in1sequence});
         //Sign every input except the first one
         const signInputs: number[] = [];
@@ -1024,8 +1030,13 @@ export class SpvFromBTCSwap<T extends ChainType>
     /**
      * @inheritDoc
      */
-    async sendBitcoinTransaction(wallet: IBitcoinWallet | MinimalBitcoinWalletInterfaceWithSigner, feeRate?: number): Promise<string> {
-        const {psbt, psbtBase64, psbtHex, signInputs} = await this.getFundedPsbt(wallet, feeRate);
+    async sendBitcoinTransaction(
+        wallet: IBitcoinWallet | MinimalBitcoinWalletInterfaceWithSigner,
+        feeRate?: number,
+        utxos?: BitcoinWalletUtxo[],
+        spendFully?: boolean
+    ): Promise<string> {
+        const {psbt, psbtBase64, psbtHex, signInputs} = await this.getFundedPsbt(wallet, feeRate, undefined, utxos, spendFully);
         let signedPsbt: Transaction | string;
         if(isIBitcoinWallet(wallet)) {
             signedPsbt = await wallet.signPsbt(psbt, signInputs);
@@ -1060,7 +1071,9 @@ export class SpvFromBTCSwap<T extends ChainType>
             feeRate?: number,
             abortSignal?: AbortSignal,
             btcTxCheckIntervalSeconds?: number,
-            maxWaitTillAutomaticSettlementSeconds?: number
+            maxWaitTillAutomaticSettlementSeconds?: number,
+            utxos?: BitcoinWalletUtxo[],
+            spendFully?: boolean
         }
     ): Promise<boolean> {
         if(this._state===SpvFromBTCSwapState.CLOSED) throw new Error("Swap encountered a catastrophic failure!");
@@ -1070,7 +1083,7 @@ export class SpvFromBTCSwap<T extends ChainType>
         if(this._state===SpvFromBTCSwapState.CLAIMED || this._state===SpvFromBTCSwapState.FRONTED) throw new Error("Swap already settled or fronted!");
 
         if(this._state===SpvFromBTCSwapState.CREATED) {
-            const txId = await this.sendBitcoinTransaction(wallet, options?.feeRate);
+            const txId = await this.sendBitcoinTransaction(wallet, options?.feeRate, options?.utxos, options?.spendFully);
             if(callbacks?.onSourceTransactionSent!=null) callbacks.onSourceTransactionSent(txId);
         }
         if(this._state===SpvFromBTCSwapState.POSTED || this._state===SpvFromBTCSwapState.BROADCASTED) {

--- a/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
@@ -22,7 +22,12 @@ import {ISwapPrice} from "../../prices/abstract/ISwapPrice";
 import {EventEmitter} from "events";
 import {Intermediary} from "../../intermediaries/Intermediary";
 import {extendAbortController, mapArrayToObject, randomBytes, throwIfUndefined} from "../../utils/Utils";
-import {fromOutputScript, toCoinselectAddressType, toOutputScript} from "../../utils/BitcoinUtils";
+import {
+    fromOutputScript,
+    getDummyOutputScript,
+    toCoinselectAddressType,
+    toOutputScript
+} from "../../utils/BitcoinUtils";
 import {IntermediaryAPI, SpvFromBTCPrepareResponseType} from "../../intermediaries/apis/IntermediaryAPI";
 import {RequestError} from "../../errors/RequestError";
 import {IntermediaryError} from "../../errors/IntermediaryError";
@@ -33,8 +38,10 @@ import {IClaimableSwapWrapper} from "../IClaimableSwapWrapper";
 import {AmountData} from "../../types/AmountData";
 import {tryWithRetries} from "../../utils/RetryUtils";
 import {AllOptional} from "../../utils/TypeUtils";
-import {fromHumanReadableString} from "../../utils/TokenUtils";
 import {UserError} from "../../errors/UserError";
+import {BitcoinWalletUtxo, BitcoinWalletUtxoBase, IBitcoinWallet} from "../../bitcoin/wallet/IBitcoinWallet";
+import {utils} from "../../bitcoin/coinselect2/utils";
+import {BitcoinWallet} from "../../bitcoin/wallet/BitcoinWallet";
 
 export type SpvFromBTCOptions = {
     /**
@@ -75,6 +82,16 @@ export type SpvFromBTCOptions = {
      *  whitelist-only wallets
      */
     stickyAddress?: boolean,
+    /**
+     * A bitcoin wallet UTXOs to fully use as an input for this swap, use this option along with passing `amount` as
+     *  `undefined` when you want to swap the full BTC balance of the wallet in a single swap
+     */
+    sourceWalletUtxos?: BitcoinWalletUtxoBase[] | Promise<BitcoinWalletUtxoBase[]>,
+    /**
+     * Bitcoin fee rate to use when deriving `maxAllowedBitcoinFeeRate` and when calculating the input amount based
+     *  on the `sourceWalletUtxos`
+     */
+    bitcoinFeeRate?: Promise<number> | number,
 
     /**
      * @deprecated Use `maxAllowedBitcoinFeeRate` instead!
@@ -93,6 +110,9 @@ export type SpvFromBTCWrapperOptions = ISwapWrapperOptions & {
 };
 
 export type SpvFromBTCTypeDefinition<T extends ChainType> = SwapTypeDefinition<T, SpvFromBTCWrapper<T>, SpvFromBTCSwap<T>>;
+
+export const REQUIRED_SPV_SWAP_VAULT_ADDRESS_TYPE: CoinselectAddressTypes = "p2tr";
+export const REQUIRED_SPV_SWAP_LP_ADDRESS_TYPE: CoinselectAddressTypes = "p2wpkh";
 
 /**
  * New spv vault (UTXO-controlled vault) based swaps for Bitcoin -> Smart chain swaps not requiring
@@ -347,20 +367,16 @@ export class SpvFromBTCWrapper<
      *
      * @param amountData
      * @param options Options as passed to the swap creation function
-     * @param pricePrefetch
-     * @param nativeTokenPricePrefetch
      * @param abortController
      * @param contractVersion
      * @private
      */
-    private async preFetchCallerFeeShare(
-        amountData: AmountData,
+    private async preFetchCallerFeeInNativeToken(
+        amountData: {amount?: bigint},
         options: {
             unsafeZeroWatchtowerFee: boolean,
             feeSafetyFactor: number
         },
-        pricePrefetch: Promise<bigint | undefined>,
-        nativeTokenPricePrefetch: Promise<bigint | undefined> | undefined,
         abortController: AbortController,
         contractVersion: string
     ): Promise<bigint | undefined> {
@@ -372,16 +388,12 @@ export class SpvFromBTCWrapper<
                 feePerBlock,
                 btcRelayData,
                 currentBtcBlock,
-                claimFeeRate,
-                nativeTokenPrice
+                claimFeeRate
             ] = await Promise.all([
                 this.btcRelay(contractVersion).getFeePerBlock(),
                 this.btcRelay(contractVersion).getTipData(),
                 this._btcRpc.getTipHeight(),
-                this._contract(contractVersion).getClaimFee(this._chain.randomAddress()),
-                nativeTokenPricePrefetch ?? (amountData.token===this._chain.getNativeCurrencyAddress() ?
-                    pricePrefetch :
-                    this._prices.preFetchPrice(this.chainIdentifier, this._chain.getNativeCurrencyAddress(), abortController.signal))
+                this._contract(contractVersion).getClaimFee(this._chain.randomAddress())
             ]);
 
             if(btcRelayData==null) throw new Error("Btc relay doesn't seem to be initialized!");
@@ -394,33 +406,65 @@ export class SpvFromBTCWrapper<
                 (claimFeeRate * BigInt(this._options.maxTransactionsDelta))
             ) * BigInt(Math.floor(options.feeSafetyFactor*1000000)) / 1_000_000n;
 
-            let payoutAmount: bigint;
-            if(amountData.exactIn) {
-                //Convert input amount in BTC to
-                const amountInNativeToken = await this._prices.getFromBtcSwapAmount(this.chainIdentifier, amountData.amount, this._chain.getNativeCurrencyAddress(), abortController.signal, nativeTokenPrice);
-                payoutAmount = amountInNativeToken - totalFeeInNativeToken;
-            } else {
-                if(amountData.token===this._chain.getNativeCurrencyAddress()) {
-                    //Both amounts in same currency
-                    payoutAmount = amountData.amount;
-                } else {
-                    //Need to convert both to native currency
-                    const btcAmount = await this._prices.getToBtcSwapAmount(this.chainIdentifier, amountData.amount, amountData.token, abortController.signal, await pricePrefetch);
-                    payoutAmount = await this._prices.getFromBtcSwapAmount(this.chainIdentifier, btcAmount, this._chain.getNativeCurrencyAddress(), abortController.signal, nativeTokenPrice);
-                }
-            }
-
-            this.logger.debug("preFetchCallerFeeShare(): Caller fee in native token: "+totalFeeInNativeToken.toString(10)+" total payout in native token: "+payoutAmount.toString(10));
-
-            const callerFeeShare = ((totalFeeInNativeToken * 100_000n) + payoutAmount - 1n) / payoutAmount; //Make sure to round up here
-            if(callerFeeShare < 0n) return 0n;
-            if(callerFeeShare >= 2n**20n) return 2n**20n - 1n;
-            return callerFeeShare;
+            return totalFeeInNativeToken;
         } catch (e) {
             abortController.abort(e);
         }
     }
 
+    /**
+     * Pre-fetches caller (watchtower) bounty data for the swap. Doesn't throw, instead returns null and aborts the
+     *  provided abortController
+     *
+     * @param amountPrefetch
+     * @param totalFeeInNativeTokenPrefetch
+     * @param amountData
+     * @param options Options as passed to the swap creation function
+     * @param pricePrefetch
+     * @param nativeTokenPricePrefetch
+     * @param abortSignal
+     * @private
+     */
+    private async computeCallerFeeShare(
+        amountPrefetch: Promise<bigint | undefined>,
+        totalFeeInNativeTokenPrefetch: Promise<bigint | undefined>,
+        amountData: {exactIn: boolean, token: string},
+        options: {unsafeZeroWatchtowerFee: boolean},
+        pricePrefetch: Promise<bigint | undefined>,
+        nativeTokenPricePrefetch: Promise<bigint | undefined> | undefined,
+        abortSignal?: AbortSignal
+    ): Promise<bigint> {
+        if(options.unsafeZeroWatchtowerFee) return 0n;
+
+        const amount = await throwIfUndefined(amountPrefetch, "Cannot get swap amount!");
+        if(amount===0n) return 0n;
+
+        const totalFeeInNativeToken = await throwIfUndefined(totalFeeInNativeTokenPrefetch, "Cannot get total fee in native token!");
+        const nativeTokenPrice = await nativeTokenPricePrefetch;
+
+        let payoutAmount: bigint;
+        if(amountData.exactIn) {
+            //Convert input amount in BTC to
+            const amountInNativeToken = await this._prices.getFromBtcSwapAmount(this.chainIdentifier, amount, this._chain.getNativeCurrencyAddress(), abortSignal, nativeTokenPrice);
+            payoutAmount = amountInNativeToken - totalFeeInNativeToken;
+        } else {
+            if(amountData.token===this._chain.getNativeCurrencyAddress()) {
+                //Both amounts in same currency
+                payoutAmount = amount;
+            } else {
+                //Need to convert both to native currency
+                const btcAmount = await this._prices.getToBtcSwapAmount(this.chainIdentifier, amount, amountData.token, abortSignal, await pricePrefetch);
+                payoutAmount = await this._prices.getFromBtcSwapAmount(this.chainIdentifier, btcAmount, this._chain.getNativeCurrencyAddress(), abortSignal, nativeTokenPrice);
+            }
+        }
+
+        this.logger.debug("computeCallerFeeShare(): Caller fee in native token: "+totalFeeInNativeToken.toString(10)+" total payout in native token: "+payoutAmount.toString(10));
+
+        const callerFeeShare = ((totalFeeInNativeToken * 100_000n) + payoutAmount - 1n) / payoutAmount; //Make sure to round up here
+        if(callerFeeShare < 0n) return 0n;
+        if(callerFeeShare >= 2n**20n) return 2n**20n - 1n;
+        return callerFeeShare;
+    }
 
     /**
      * Verifies response returned from intermediary
@@ -430,7 +474,8 @@ export class SpvFromBTCWrapper<
      * @param lp Intermediary
      * @param options Options as passed to the swap creation function
      * @param callerFeeShare
-     * @param bitcoinFeeRatePromise Maximum accepted fee rate from the LPs
+     * @param maxBitcoinFeeRatePromise Maximum accepted fee rate from the LPs
+     * @param bitcoinFeeRatePromise
      * @param abortSignal
      * @private
      * @throws {IntermediaryError} in case the response is invalid
@@ -440,16 +485,18 @@ export class SpvFromBTCWrapper<
         amountData: AmountData,
         lp: Intermediary,
         options: {
-            gasAmount: bigint
+            gasAmount: bigint,
+            sourceWalletUtxos?: Promise<BitcoinWalletUtxoBase[]>
         },
         callerFeeShare: bigint,
-        bitcoinFeeRatePromise: Promise<number | undefined>,
+        maxBitcoinFeeRatePromise: Promise<number | undefined>,
+        bitcoinFeeRatePromise: Promise<number | undefined> | undefined,
         abortSignal: AbortSignal
     ): Promise<{
         vault: T["SpvVaultData"],
         vaultUtxoValue: number
     }> {
-        const btcFeeRate = await throwIfUndefined(bitcoinFeeRatePromise, "Bitcoin fee rate promise failed!");
+        const btcFeeRate = await throwIfUndefined(maxBitcoinFeeRatePromise, "Bitcoin fee rate promise failed!");
         abortSignal.throwIfAborted();
         if(btcFeeRate!=null && resp.btcFeeRate > btcFeeRate) throw new IntermediaryError(`Required bitcoin fee rate returned from the LP is too high! Maximum accepted: ${btcFeeRate} sats/vB, required by LP: ${resp.btcFeeRate} sats/vB`);
 
@@ -459,11 +506,13 @@ export class SpvFromBTCWrapper<
         let vaultScript: Uint8Array;
         let vaultAddressType: CoinselectAddressTypes;
         let btcAddressScript: Uint8Array;
+        let btcAddressType: CoinselectAddressTypes;
         //Ensure valid btc addresses returned
         try {
             vaultScript = toOutputScript(this._options.bitcoinNetwork, resp.vaultBtcAddress);
             vaultAddressType = toCoinselectAddressType(vaultScript);
             btcAddressScript = toOutputScript(this._options.bitcoinNetwork, resp.btcAddress);
+            btcAddressType = toCoinselectAddressType(btcAddressScript);
         } catch (e) {
             throw new IntermediaryError("Invalid btc address data returned", e);
         }
@@ -473,7 +522,8 @@ export class SpvFromBTCWrapper<
             resp.vaultId < 0n || //Ensure vaultId is not negative
             vaultScript==null || //Make sure vault script is parsable and of known type
             btcAddressScript==null || //Make sure btc address script is parsable and of known type
-            vaultAddressType==="p2pkh" || vaultAddressType==="p2sh-p2wpkh" || //Constrain the vault script type to witness types
+            btcAddressType!==REQUIRED_SPV_SWAP_LP_ADDRESS_TYPE || //Constrain the btc address script type
+            vaultAddressType!==REQUIRED_SPV_SWAP_VAULT_ADDRESS_TYPE || //Constrain the vault script type
             decodedUtxo.length!==2 || decodedUtxo[0].length!==64 || isNaN(parseInt(decodedUtxo[1])) || //Check valid UTXO
             resp.btcFeeRate < 1 || resp.btcFeeRate > 10000 //Sanity check on the returned BTC fee rate
         ) throw new IntermediaryError("Invalid vault data returned!");
@@ -517,7 +567,22 @@ export class SpvFromBTCWrapper<
 
                 //Amounts - make sure the amounts match
                 if(amountData.exactIn) {
-                    if(resp.btcAmount !== amountData.amount) throw new IntermediaryError("Invalid amount returned");
+                    if(!resp.usedUtxoInputCalculation) {
+                        //Legacy calculation
+                        if(resp.btcAmount !== amountData.amount) throw new IntermediaryError("Invalid amount returned");
+                    } else {
+                        //Implies the raw UTXOs were passed for amount derivation
+                        //Verify the derivation was done correctly
+                        if(options.sourceWalletUtxos==null) throw new IntermediaryError("Invalid usedUtxoInputCalcuation return value");
+                        if(bitcoinFeeRatePromise==null) throw new Error("bitcoinFeeRatePromise must be passed for UTXO-based input amount calculation checks");
+                        const walletUtxos = await options.sourceWalletUtxos;
+                        const bitcoinFeeRate = await throwIfUndefined(bitcoinFeeRatePromise, "Failed to fetch bitcoin fee rate!");
+                        const {balance} = BitcoinWallet.getSpendableBalance(
+                            walletUtxos, Math.max(resp.btcFeeRate, bitcoinFeeRate),
+                            this.getDummySwapPsbt(options.gasAmount!==0n), REQUIRED_SPV_SWAP_LP_ADDRESS_TYPE
+                        );
+                        if(resp.btcAmount !== balance) throw new IntermediaryError(`Invalid amount returned, expected: ${balance.toString(10)}, got: ${resp.btcAmount.toString(10)}`);
+                    }
                 } else {
                     //Check the difference between amount adjusted due to scaling to raw amount
                     const adjustedAmount = amountData.amount / tokenData[0].multiplier * tokenData[0].multiplier;
@@ -613,6 +678,74 @@ export class SpvFromBTCWrapper<
         };
     }
 
+    private async amountPrefetch(
+        amountData: {token: string, exactIn: boolean, amount?: bigint},
+        bitcoinFeeRatePromise: Promise<number | undefined>,
+        walletUtxosPromise: Promise<BitcoinWalletUtxoBase[]> | undefined,
+        includeGas: boolean,
+        abortController: AbortController
+    ): Promise<bigint | undefined> {
+        if(amountData.amount!=null) return amountData.amount;
+        try {
+            const bitcoinFeeRate = await throwIfUndefined(bitcoinFeeRatePromise, "Cannot fetch Bitcoin fee rate!");
+            if(walletUtxosPromise==null) throw new UserError("Cannot use empty amount without passing UTXOs!");
+            const walletUtxos = await walletUtxosPromise;
+            if(walletUtxos.length===0)
+                throw new UserError("Wallet doesn't have any BTC balance");
+            const spendableBalance = await BitcoinWallet.getSpendableBalance(
+                walletUtxos, bitcoinFeeRate,
+                this.getDummySwapPsbt(includeGas), REQUIRED_SPV_SWAP_LP_ADDRESS_TYPE
+            );
+            if(spendableBalance.balance<=0n)
+                throw new UserError("Wallet doesn't have enough BTC balance to cover transaction fees");
+            return spendableBalance.balance;
+        } catch (e) {
+            abortController.abort(e);
+        }
+    }
+
+    private bitcoinFeeRatePrefetch(
+        options: {
+            maxAllowedBitcoinFeeRate: number,
+            sourceWalletUtxos?: Promise<BitcoinWalletUtxoBase[]>,
+            bitcoinFeeRate?: Promise<number>
+        },
+        abortController: AbortController
+    ) {
+        let bitcoinFeeRatePromise: Promise<number | undefined> | undefined;
+        if(options?.sourceWalletUtxos!=null) {
+            if(options.bitcoinFeeRate!=null) {
+                bitcoinFeeRatePromise = options.bitcoinFeeRate.then(value => {
+                    if(options.maxAllowedBitcoinFeeRate!=Infinity && options.maxAllowedBitcoinFeeRate<value)
+                        throw new Error("Passed `maxAllowedBitcoinFeeRate` cannot be lower than `bitcoinFeeRate`");
+                    return value;
+                });
+            } else {
+                bitcoinFeeRatePromise = this._btcRpc.getFeeRate().then(value => {
+                    if(options.maxAllowedBitcoinFeeRate!=Infinity && value > options.maxAllowedBitcoinFeeRate) return options.maxAllowedBitcoinFeeRate;
+                    return value;
+                });
+            }
+            bitcoinFeeRatePromise = bitcoinFeeRatePromise.catch(e => {
+                abortController.abort(e);
+                return undefined;
+            });
+        }
+        const maxBitcoinFeeRatePromise: Promise<number | undefined> = options.maxAllowedBitcoinFeeRate!=Infinity
+            ? Promise.resolve(options.maxAllowedBitcoinFeeRate)
+            : throwIfUndefined(bitcoinFeeRatePromise ?? options.bitcoinFeeRate ?? this._btcRpc.getFeeRate())
+                .then(x => this._options.maxBtcFeeOffset + (x*this._options.maxBtcFeeMultiplier))
+                .catch(e => {
+                    abortController.abort(e);
+                    return undefined;
+                });
+
+        return {
+            bitcoinFeeRatePromise,
+            maxBitcoinFeeRatePromise
+        }
+    }
+
     /**
      * Returns a newly created Bitcoin -> Smart chain swap using the SPV vault (UTXO-controlled vault) swap protocol,
      *  with the passed amount. Also allows specifying additional "gas drop" native token that the receipient receives
@@ -627,7 +760,7 @@ export class SpvFromBTCWrapper<
      */
     public create(
         recipient: string,
-        amountData: AmountData,
+        amountData: { amount?: bigint, token: string, exactIn: boolean },
         lps: Intermediary[],
         options?: SpvFromBTCOptions,
         additionalParams?: Record<string, any>,
@@ -640,7 +773,13 @@ export class SpvFromBTCWrapper<
             gasAmount: this.parseGasAmount(options?.gasAmount),
             unsafeZeroWatchtowerFee: options?.unsafeZeroWatchtowerFee ?? false,
             feeSafetyFactor: options?.feeSafetyFactor ?? 1.25,
-            maxAllowedBitcoinFeeRate: options?.maxAllowedBitcoinFeeRate ?? options?.maxAllowedNetworkFeeRate ?? Infinity
+            maxAllowedBitcoinFeeRate: options?.maxAllowedBitcoinFeeRate ?? options?.maxAllowedNetworkFeeRate ?? Infinity,
+            sourceWalletUtxos: options?.sourceWalletUtxos==undefined
+                ? undefined
+                : options?.sourceWalletUtxos instanceof Promise ? options.sourceWalletUtxos : Promise.resolve(options.sourceWalletUtxos),
+            bitcoinFeeRate: options?.bitcoinFeeRate==undefined
+                ? undefined
+                : options?.bitcoinFeeRate instanceof Promise ? options.bitcoinFeeRate : Promise.resolve(options.bitcoinFeeRate),
         };
 
         if(
@@ -651,6 +790,13 @@ export class SpvFromBTCWrapper<
                     : amountData.token===this._chain.getNativeCurrencyAddress()
             )
         ) throw new UserError("Cannot specify `gasAmount` for swaps to a native token!");
+
+        if(amountData.amount==null && options?.sourceWalletUtxos==null)
+            throw new UserError("Source wallet UTXOs need to be passed when amount is null!");
+        if(amountData.amount==null && !amountData.exactIn)
+            throw new UserError("Amount can be null only for exactIn swaps!");
+        if(amountData.amount!=null && options?.sourceWalletUtxos!=null)
+            throw new UserError("Source wallet UTXOs cannot be passed while specifying an input amount!");
 
         const lpVersions = Intermediary.getContractVersionsForLps(this.chainIdentifier, lps);
 
@@ -663,14 +809,12 @@ export class SpvFromBTCWrapper<
             undefined :
             this.preFetchPrice({token: nativeTokenAddress}, _abortController.signal);
         const callerFeePrefetchPromise = mapArrayToObject(lpVersions, (contractVersion: string) => {
-            return this.preFetchCallerFeeShare(amountData, _options, pricePrefetchPromise, gasTokenPricePrefetchPromise, _abortController, contractVersion);
+            return this.preFetchCallerFeeInNativeToken(amountData, _options, _abortController, contractVersion);
         });
-        const bitcoinFeeRatePromise: Promise<number | undefined> = _options.maxAllowedBitcoinFeeRate!=Infinity ?
-            Promise.resolve(_options.maxAllowedBitcoinFeeRate) :
-            this._btcRpc.getFeeRate().then(x => this._options.maxBtcFeeOffset + (x*this._options.maxBtcFeeMultiplier)).catch(e => {
-                _abortController.abort(e);
-                return undefined;
-            });
+        const {maxBitcoinFeeRatePromise, bitcoinFeeRatePromise} = this.bitcoinFeeRatePrefetch(_options, _abortController);
+        const amountPromise = this.amountPrefetch(
+            amountData, maxBitcoinFeeRatePromise, _options.sourceWalletUtxos, _options.gasAmount!==0n, _abortController
+        );
 
         return lps.map(lp => {
             return {
@@ -680,6 +824,15 @@ export class SpvFromBTCWrapper<
                     const version = lp.getContractVersion(this.chainIdentifier);
 
                     const abortController = extendAbortController(_abortController.signal);
+                    const callerFeeRatePromise = this.computeCallerFeeShare(
+                        amountPromise,
+                        callerFeePrefetchPromise[version],
+                        amountData,
+                        _options,
+                        pricePrefetchPromise,
+                        gasTokenPricePrefetchPromise,
+                        abortController.signal
+                    );
 
                     try {
                         const resp = await tryWithRetries(async(retryCount: number) => {
@@ -687,14 +840,25 @@ export class SpvFromBTCWrapper<
                                 this.chainIdentifier, lp.url,
                                 {
                                     address: recipient,
-                                    amount: amountData.amount,
+                                    amount: throwIfUndefined(amountPromise, "Failed to compute swap amount"),
                                     token: amountData.token.toString(),
                                     exactOut: !amountData.exactIn,
                                     gasToken: nativeTokenAddress,
                                     gasAmount: _options.gasAmount,
-                                    callerFeeRate: throwIfUndefined(callerFeePrefetchPromise[version], "Caller fee prefetch failed!"),
+                                    callerFeeRate: throwIfUndefined(callerFeeRatePromise, "Caller fee prefetch failed!"),
                                     frontingFeeRate: 0n,
                                     stickyAddress: options?.stickyAddress,
+                                    amountUtxos: _options.sourceWalletUtxos!=null
+                                        ? _options.sourceWalletUtxos.then(utxos => {
+                                            if(utxos.length===0) return undefined;
+                                            return utxos.map(utxo => ({
+                                                value: utxo.value,
+                                                vSize: utils.inputBytes({type: utxo.type}),
+                                                cpfp: utxo.cpfp==null ? undefined : {effectiveVSize: utxo.cpfp?.txVsize, effectiveFeeRate: utxo.cpfp?.txEffectiveFeeRate}
+                                            }));
+                                        })
+                                        : undefined,
+                                    amountFeeRate: bitcoinFeeRatePromise,
                                     additionalParams
                                 },
                                 this._options.postRequestTimeout, abortController.signal, retryCount>0 ? false : undefined
@@ -703,7 +867,8 @@ export class SpvFromBTCWrapper<
 
                         this.logger.debug("create("+lp.url+"): LP response: ", resp)
 
-                        const callerFeeShare = (await callerFeePrefetchPromise[version])!;
+                        const callerFeeShare = await callerFeeRatePromise;
+                        const amount = await throwIfUndefined(amountPromise);
 
                         const [
                             pricingInfo,
@@ -722,8 +887,15 @@ export class SpvFromBTCWrapper<
                                 resp.totalGas * (100_000n + callerFeeShare) / 100_000n,
                                 nativeTokenAddress, {swapFeeBtc: resp.gasSwapFeeBtc}, gasTokenPricePrefetchPromise, usdPricePrefetchPromise, abortController.signal
                             ),
-                            this.verifyReturnedData(resp, amountData, lp, _options, callerFeeShare, bitcoinFeeRatePromise, abortController.signal)
+                            this.verifyReturnedData(
+                                resp,
+                                {...amountData, amount},
+                                lp, _options, callerFeeShare, maxBitcoinFeeRatePromise, bitcoinFeeRatePromise, abortController.signal
+                            )
                         ]);
+
+                        let minimumBtcFeeRate: number = resp.btcFeeRate;
+                        if(bitcoinFeeRatePromise!=null) minimumBtcFeeRate = Math.max(minimumBtcFeeRate, await throwIfUndefined(bitcoinFeeRatePromise));
 
                         const swapInit: SpvFromBTCSwapInit = {
                             pricingInfo,
@@ -749,7 +921,7 @@ export class SpvFromBTCWrapper<
                             btcAmount: resp.btcAmount,
                             btcAmountSwap: resp.btcAmountSwap,
                             btcAmountGas: resp.btcAmountGas,
-                            minimumBtcFeeRate: resp.btcFeeRate,
+                            minimumBtcFeeRate,
 
                             outputTotalSwap: resp.total,
                             outputSwapToken: amountData.token,
@@ -902,7 +1074,7 @@ export class SpvFromBTCWrapper<
             allowUnknownOutputs: true
         });
 
-        const randomVaultOutScript = OutScript.encode({type: "tr", pubkey: Buffer.from("0101010101010101010101010101010101010101010101010101010101010101", "hex")});
+        const randomVaultOutScript = getDummyOutputScript(REQUIRED_SPV_SWAP_VAULT_ADDRESS_TYPE);
 
         psbt.addInput({
             txid: randomBytes(32),

--- a/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
+++ b/src/swaps/spv_swaps/SpvFromBTCWrapper.ts
@@ -29,7 +29,7 @@ import {
     toOutputScript
 } from "../../utils/BitcoinUtils";
 import {IntermediaryAPI, SpvFromBTCPrepareResponseType} from "../../intermediaries/apis/IntermediaryAPI";
-import {RequestError} from "../../errors/RequestError";
+import {OutOfBoundsError, RequestError} from "../../errors/RequestError";
 import {IntermediaryError} from "../../errors/IntermediaryError";
 import {CoinselectAddressTypes} from "../../bitcoin/coinselect2";
 import {OutScript, Transaction} from "@scure/btc-signer";
@@ -696,8 +696,6 @@ export class SpvFromBTCWrapper<
                 walletUtxos, bitcoinFeeRate,
                 this.getDummySwapPsbt(includeGas), REQUIRED_SPV_SWAP_LP_ADDRESS_TYPE
             );
-            if(spendableBalance.balance<=0n)
-                throw new UserError("Wallet doesn't have enough BTC balance to cover transaction fees");
             return spendableBalance.balance;
         } catch (e) {
             abortController.abort(e);
@@ -944,6 +942,12 @@ export class SpvFromBTCWrapper<
                         const quote = new SpvFromBTCSwap<T>(this, swapInit);
                         return quote;
                     } catch (e) {
+                        if(e instanceof OutOfBoundsError) {
+                            const amountResult = await amountPromise.catch(() => undefined);
+                            if(_options.sourceWalletUtxos!=null && amountResult!=null && amountResult<=0n) {
+                                e = new UserError("Wallet doesn't have enough BTC balance to cover transaction fees");
+                            }
+                        }
                         abortController.abort(e);
                         throw e;
                     }

--- a/src/utils/BitcoinUtils.ts
+++ b/src/utils/BitcoinUtils.ts
@@ -2,6 +2,7 @@ import {BTC_NETWORK, isBytes, PubT, validatePubkey} from "@scure/btc-signer/util
 import {Buffer} from "buffer";
 import {Address, OutScript, Transaction} from "@scure/btc-signer";
 import {CoinselectAddressTypes} from "../bitcoin/coinselect2";
+import { randomBytes } from "./Utils";
 
 
 export function fromOutputScript(network: BTC_NETWORK, outputScriptHex: string): string {
@@ -61,6 +62,46 @@ export function toCoinselectAddressType(outputScript: Uint8Array): CoinselectAdd
             return "p2tr"
     }
     throw new Error("Unrecognized address type!");
+}
+
+
+function getDummySpec(type: CoinselectAddressTypes) {
+    switch(type) {
+        case "p2pkh":
+            return {
+                type: "pkh",
+                hash: randomBytes(20)
+            } as const;
+        case "p2sh-p2wpkh":
+            return {
+                type: "sh",
+                hash: randomBytes(20)
+            } as const;
+        case "p2wpkh":
+            return {
+                type: "wpkh",
+                hash: randomBytes(20)
+            } as const;
+        case "p2wsh":
+            return {
+                type: "wsh",
+                hash: randomBytes(32)
+            } as const;
+        case "p2tr":
+            return {
+                type: "tr",
+                pubkey: Buffer.from("0101010101010101010101010101010101010101010101010101010101010101", "hex")
+            } as const;
+    }
+    throw new Error("Unrecognized address type!");
+}
+
+export function getDummyOutputScript(type: CoinselectAddressTypes): Uint8Array {
+    return OutScript.encode(getDummySpec(type));
+}
+
+export function getDummyAddress(network: BTC_NETWORK, type: CoinselectAddressTypes): string {
+    return Address(network).encode(getDummySpec(type));
 }
 
 /**

--- a/src/utils/BitcoinWalletUtils.ts
+++ b/src/utils/BitcoinWalletUtils.ts
@@ -1,12 +1,12 @@
 import {IBitcoinWallet, isIBitcoinWallet} from "../bitcoin/wallet/IBitcoinWallet";
 import {BTC_NETWORK} from "@scure/btc-signer/utils";
 import {SingleAddressBitcoinWallet} from "../bitcoin/wallet/SingleAddressBitcoinWallet";
-import {BitcoinRpcWithAddressIndex} from "@atomiqlabs/base";
+import {BitcoinNetwork, BitcoinRpcWithAddressIndex} from "@atomiqlabs/base";
 
 export function toBitcoinWallet(
     _bitcoinWallet: IBitcoinWallet | { address: string, publicKey: string },
     btcRpc: BitcoinRpcWithAddressIndex<any>,
-    bitcoinNetwork: BTC_NETWORK
+    bitcoinNetwork: BTC_NETWORK | BitcoinNetwork
 ): IBitcoinWallet {
     if (isIBitcoinWallet(_bitcoinWallet)) {
         return _bitcoinWallet;


### PR DESCRIPTION
Added the functionality to allow cleanly sweeping whole BTC wallet balances into a single swap, without overestimating the required fee.