### PR TITLE
docs: fix Starknet signer example in README (pass a Provider, not a URL string)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,11 @@ const solanaSigner = new SolanaSigner(new SolanaKeypairWallet(Keypair.fromSecret
 ```
 
 ```typescript
+import {RpcProvider} from "starknet";
 import {StarknetSigner, StarknetKeypairWallet} from "@atomiqlabs/chain-starknet";
 //Creating Starknet signer from private key
-const starknetSigner = new StarknetSigner(new StarknetKeypairWallet(starknetRpc, starknetKey));
+const starknetProvider = new RpcProvider({nodeUrl: starknetRpc});
+const starknetSigner = new StarknetSigner(new StarknetKeypairWallet(starknetProvider, starknetKey));
 ```
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -142,11 +142,12 @@ const wallet = new SolanaSigner(anchorWallet);
 ```
 
 ```typescript
-import {WalletAccount} from "starknet";
+import {RpcProvider, WalletAccount} from "starknet";
 import {StarknetBrowserSigner} from "@atomiqlabs/chain-starknet";
 //Browser, using get-starknet
 const swo = await connect();
-const wallet = new StarknetBrowserSigner(new WalletAccount(starknetRpc, swo.wallet));
+const starknetProvider = new RpcProvider({nodeUrl: starknetRpc});
+const wallet = new StarknetBrowserSigner(await WalletAccount.connect(starknetProvider, swo.wallet));
 ```
 
 or


### PR DESCRIPTION
## Problem

The **Setting up signers** section documents creating a Starknet signer from a private key:

```ts
const starknetSigner = new StarknetSigner(new StarknetKeypairWallet(starknetRpc, starknetKey));
```

`starknetRpc` is a URL string, but `StarknetKeypairWallet`'s first constructor argument is a starknet.js `Provider` (it is forwarded to the underlying `Account`). Running the example verbatim throws:

```
TypeError: Cannot use 'in' operator to search for 'channel' in https://...
```

## Fix

Wrap the URL in an `RpcProvider` (and import it), consistent with how a `Provider` is expected everywhere else:

```ts
import {RpcProvider} from "starknet";
import {StarknetSigner, StarknetKeypairWallet} from "@atomiqlabs/chain-starknet";
const starknetProvider = new RpcProvider({nodeUrl: starknetRpc});
const starknetSigner = new StarknetSigner(new StarknetKeypairWallet(starknetProvider, starknetKey));
```

## Verification

With `@atomiqlabs/chain-starknet@8.4.5` + `starknet@9.4.2`:

- **Before** (URL string): throws `Cannot use 'in' operator to search for 'channel' in <url>`.
- **After** (`RpcProvider`): constructs successfully and `signer.getAddress()` returns a valid address.

Docs-only change.
