### PR TITLE
fix: trusted on-chain gas swap PSBT sends outputAmount (gas units) as BTC sats

### DIFF
--- a/src/swaps/trusted/onchain/OnchainForGasSwap.ts
+++ b/src/swaps/trusted/onchain/OnchainForGasSwap.ts
@@ -472,7 +472,7 @@ export class OnchainForGasSwap<T extends ChainType = ChainType> extends ISwap<T,
             allowLegacyWitnessUtxo: true
         });
         basePsbt.addOutput({
-            amount: this.outputAmount,
+            amount: this.inputAmount,
             script: toOutputScript(this.wrapper._options.bitcoinNetwork, this.address)
         });
         if(additionalOutputs!=null) additionalOutputs.forEach(output => {
@@ -511,8 +511,8 @@ export class OnchainForGasSwap<T extends ChainType = ChainType> extends ISwap<T,
         }
 
         const output0 = psbt.getOutput(0);
-        if(output0.amount!==this.outputAmount)
-            throw new Error("PSBT output amount invalid, expected: "+this.outputAmount+" got: "+output0.amount);
+        if(output0.amount!==this.inputAmount)
+            throw new Error("PSBT output amount invalid, expected: "+this.inputAmount+" got: "+output0.amount);
         const expectedOutputScript = toOutputScript(this.wrapper._options.bitcoinNetwork, this.address);
         if(output0.script==null || !expectedOutputScript.equals(output0.script))
             throw new Error("PSBT output script invalid!");


### PR DESCRIPTION

## Summary

The trusted on-chain gas swap (`SwapType.TRUSTED_FROM_BTC`) builds its Bitcoin funding transaction with the **destination gas-token amount** instead of the **BTC sats amount**. `OnchainForGasSwap.getFundedPsbt()` puts `this.outputAmount` (gas-token base units, e.g. lamports/wei) into the BTC output where `this.inputAmount` (sats) belongs, and `submitPsbt()` then validates the tx against the *same* wrong field — so the malformed PSBT passes its own sanity check and is broadcast.

## Root cause

`src/swaps/trusted/onchain/OnchainForGasSwap.ts`

The two amounts are distinct and not interchangeable (set in `OnchainForGasWrapper.create()`): `inputAmount = resp.amountSats` (BTC sats to send) and `outputAmount = resp.total` (gas token to receive, in base units).

**Build** — `getFundedPsbt()`:
```ts
basePsbt.addOutput({
    amount: this.outputAmount,   // <-- gas-token units used as sats
    script: toOutputScript(this.wrapper._options.bitcoinNetwork, this.address)
});
```

**Validate** — `submitPsbt()`:
```ts
const output0 = psbt.getOutput(0);
if(output0.amount!==this.outputAmount)   // <-- compares against the SAME wrong field
    throw new Error("PSBT output amount invalid, expected: "+this.outputAmount+" got: "+output0.amount);
```

Because the guard checks against `outputAmount` — the same value used to build the output — it is self-consistent and can never catch the mistake. Every other Bitcoin-payment path on this swap already uses `inputAmount` (`getHyperlink()`, `sendBitcoinTransaction()` direct path, `estimateBitcoinFee()`, `txsExecute()` address branch); only the PSBT path diverges.

## Impact

The PSBT path is the primary flow for browser / PSBT-signing wallets.

- **Solana** (9-decimal native, the chain this swap type actually serves): requesting e.g. 0.002 SOL (`outputAmount = 2_000_000` lamports) makes the tx send **2,000,000 sats (~0.02 BTC)** instead of the few hundred sats owed — a large, silent overpayment that is broadcast without any error.
- **18-decimal EVM native tokens**: `outputAmount` is astronomically large, so `fundPsbt()` throws `"Not enough balance"` — the PSBT path is entirely non-functional.

## Fix

Use `inputAmount` (sats) in both the output build and the validation.
